### PR TITLE
feat: show SQL queries as code objects in Details panel

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     parser: 'babel-eslint',
   },
   rules: {
+    'no-param-reassign': ['error', { props: false }],
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'prettier/prettier': ['error'],

--- a/src/components/DetailsPanel.vue
+++ b/src/components/DetailsPanel.vue
@@ -41,6 +41,7 @@ import VDetailsPanelEvent from '@/components/DetailsPanelEvent.vue';
 import VDetailsPanelFunction from '@/components/DetailsPanelFunction.vue';
 import VDetailsPanelHttp from '@/components/DetailsPanelHttp.vue';
 import VDetailsPanelPackage from '@/components/DetailsPanelPackage.vue';
+import VDetailsPanelQuery from '@/components/DetailsPanelQuery.vue';
 import VDetailsPanelRoute from '@/components/DetailsPanelRoute.vue';
 import VDetailsPanelLabels from '@/components/DetailsPanelLabels.vue';
 import VDetailsSearch from '@/components/DetailsSearch.vue';
@@ -58,6 +59,7 @@ export default {
     VDetailsPanelFunction,
     VDetailsPanelHttp,
     VDetailsPanelPackage,
+    VDetailsPanelQuery,
     VDetailsPanelRoute,
     VDetailsPanelLabels,
     VDetailsSearch,
@@ -82,7 +84,6 @@ export default {
       } else if (this.selectedObject instanceof Event) {
         kind = 'event';
       }
-
       return `v-details-panel-${kind}`;
     },
   },

--- a/src/components/DetailsPanelList.vue
+++ b/src/components/DetailsPanelList.vue
@@ -110,7 +110,7 @@ export default {
       .list-item {
         display: inline-flex;
         width: 100%;
-        justify-content: flex-start;
+        justify-content: space-between;
         align-items: center;
         padding: 0.5rem 2rem;
         color: $blue;
@@ -126,7 +126,7 @@ export default {
         }
 
         &__count {
-          margin-left: auto;
+          margin-left: 1rem;
           border-radius: 0.5rem;
           display: inline-block;
           padding: 0.25rem 0.5rem;

--- a/src/components/DetailsPanelQuery.vue
+++ b/src/components/DetailsPanelQuery.vue
@@ -1,0 +1,47 @@
+<template>
+  <div>
+    <v-details-panel-header object-type="SQL query" :title="title" />
+    <v-details-panel-list title="Events" :items="object.events" />
+  </div>
+</template>
+
+<script>
+import VDetailsPanelHeader from '@/components/DetailsPanelHeader.vue';
+import VDetailsPanelList from '@/components/DetailsPanelList.vue';
+import { getSqlLabelFromString } from '@/lib/util';
+import { SELECT_OBJECT, POP_OBJECT_STACK } from '../store/vsCode';
+
+export default {
+  name: 'v-details-panel-query',
+  components: {
+    VDetailsPanelList,
+    VDetailsPanelHeader,
+  },
+  props: {
+    object: {
+      type: Object,
+      required: true,
+    },
+  },
+  computed: {
+    title() {
+      return getSqlLabelFromString(this.object.name);
+    },
+
+    events() {
+      return this.$store.state.appMap.events.filter(
+        (e) => e.isCall() && e.codeObject && e.codeObject.id === this.object.id
+      );
+    },
+  },
+
+  created() {
+    if (this.object.events.length === 1) {
+      this.$store.commit(POP_OBJECT_STACK);
+      this.$store.commit(SELECT_OBJECT, this.object.events[0]);
+    }
+  },
+};
+</script>
+
+<style scoped lang="scss"></style>

--- a/src/components/DetailsSearch.vue
+++ b/src/components/DetailsSearch.vue
@@ -31,7 +31,7 @@
           @click="selectObject(type, item.object)"
         >
           {{
-            type !== 'sql' && item.object.prettyName
+            type !== 'query' && item.object.prettyName
               ? item.object.prettyName
               : item.object.name || item.object
           }}
@@ -73,7 +73,7 @@ export default {
   computed: {
     listItems() {
       const items = {
-        http: {
+        route: {
           title: 'HTTP routes',
           data: [],
         },
@@ -81,11 +81,19 @@ export default {
           title: 'Labels',
           data: [],
         },
-        code: {
-          title: 'Code',
+        package: {
+          title: 'Packages',
           data: [],
         },
-        sql: {
+        class: {
+          title: 'Classes',
+          data: [],
+        },
+        function: {
+          title: 'Functions',
+          data: [],
+        },
+        query: {
           title: 'SQL queries',
           data: [],
         },
@@ -103,23 +111,19 @@ export default {
 
         switch (codeObject.type) {
           case 'package':
-            if (codeObject.children.length > 1) {
-              items.code.data.push(item);
+            if (codeObject.childLeafs().length > 1) {
+              items[codeObject.type].data.push(item);
             }
-            break;
-          case 'function':
-            items.code.data.push(item);
             break;
           case 'class':
             if (codeObject.functions.length) {
-              items.code.data.push(item);
+              items[codeObject.type].data.push(item);
             }
             break;
+          case 'function':
           case 'route':
-            items.http.data.push(item);
-            break;
           case 'query':
-            items.sql.data.push(item);
+            items[codeObject.type].data.push(item);
             break;
           default:
             break;
@@ -133,6 +137,20 @@ export default {
             childrenCount: labelData.function.length + labelData.event.length,
           });
         }
+      });
+
+      Object.values(items).forEach((item) => {
+        item.data = item.data.sort((a, b) => {
+          const aStr =
+            a.object instanceof CodeObject
+              ? a.object.prettyName
+              : String(a.object);
+          const bStr =
+            b.object instanceof CodeObject
+              ? b.object.prettyName
+              : String(b.object);
+          return aStr.localeCompare(bStr);
+        });
       });
 
       return items;
@@ -171,7 +189,7 @@ export default {
           obj.type === CodeObjectType.QUERY ? obj.name : obj.prettyName;
       }
 
-      if (typeof obj !== 'string') {
+      if (typeof filterString !== 'string') {
         return false;
       }
 
@@ -287,7 +305,7 @@ export default {
         transform: translateX(-50%);
       }
 
-      .details-search__block--http &::before {
+      .details-search__block--route &::before {
         background: linear-gradient(
           to right,
           #c61c38 0%,
@@ -309,7 +327,9 @@ export default {
         }
       }
 
-      .details-search__block--code &::before {
+      .details-search__block--package &::before,
+      .details-search__block--class &::before,
+      .details-search__block--function &::before {
         background: linear-gradient(
           to right,
           #4362b1 0%,
@@ -318,7 +338,7 @@ export default {
         );
       }
 
-      .details-search__block--sql &::before {
+      .details-search__block--query &::before {
         background: linear-gradient(
           to right,
           #9c2fba 0%,

--- a/src/pages/VsCodeExtension.vue
+++ b/src/pages/VsCodeExtension.vue
@@ -17,7 +17,11 @@
           <v-details-button icon="back" v-if="canGoBack" @click.native="goBack">
             Back to
             <b v-if="prevSelectedObject && prevSelectedObject.name">
-              {{ prevSelectedObject.name }}
+              {{
+                prevSelectedObject.type === 'query'
+                  ? prevSelectedObject.prettyName
+                  : prevSelectedObject.name
+              }}
             </b>
             <span v-else>previous</span>
           </v-details-button>

--- a/tests/e2e/specs/vsCodeExtension.spec.js
+++ b/tests/e2e/specs/vsCodeExtension.spec.js
@@ -499,6 +499,18 @@ context('VS Code Extension', () => {
 
       cy.get('.details-panel-header__parent').should('have.length', 3);
     });
+
+    it('does not back link to a large query when clicking a query from the search panel', () => {
+      cy.get(
+        '.details-search__block--query > .details-search__block-list > :nth-child(1)'
+      ).click();
+
+      cy.get(':nth-child(1) > .list-item').click();
+
+      cy.get('.details-panel__buttons')
+        .invoke('text')
+        .should('not.match', /SELECT.*FROM/);
+    });
   });
 
   context('Java appmap', () => {

--- a/tests/e2e/specs/vsCodeExtension.spec.js
+++ b/tests/e2e/specs/vsCodeExtension.spec.js
@@ -186,6 +186,19 @@ context('VS Code Extension', () => {
       );
     });
 
+    it('show child route events count', () => {
+      cy.get('.details-search').should('be.visible');
+
+      cy.get('.details-search__block-item')
+        .contains('GET /admin/orders')
+        .within(() => {
+          cy.get('.details-search__block-item-count').should(
+            'contain.text',
+            '2'
+          );
+        });
+    });
+
     it('the current event is highlighted upon opening the flow view', () => {
       cy.get('.details-search').should('be.visible');
 


### PR DESCRIPTION
Display code object with type `query` in Details panel.

![image](https://user-images.githubusercontent.com/17301016/112055199-4431a880-8ba2-11eb-951f-40c8546247b5.png)

Fixes: #129 