### PR TITLE
fix: parse incoming AppMap data as JSON

### DIFF
--- a/src/pages/VsCodeExtension.vue
+++ b/src/pages/VsCodeExtension.vue
@@ -226,13 +226,21 @@ export default {
 
   methods: {
     loadData(data) {
-      const hasEvents = Array.isArray(data.events) && data.events.length;
-      const hasClassMap = Array.isArray(data.classMap) && data.classMap.length;
+      try {
+        const appMapData = typeof data === 'string' ? JSON.parse(data) : data;
+        const hasEvents =
+          Array.isArray(appMapData.events) && appMapData.events.length;
+        const hasClassMap =
+          Array.isArray(appMapData.classMap) && appMapData.classMap.length;
 
-      if (hasEvents && hasClassMap) {
-        this.isEmptyAppMap = false;
-        this.$store.commit(SET_APPMAP_DATA, data);
-      } else {
+        if (hasEvents && hasClassMap) {
+          this.isEmptyAppMap = false;
+          this.$store.commit(SET_APPMAP_DATA, appMapData);
+        } else {
+          this.isEmptyAppMap = true;
+        }
+      } catch (e) {
+        console.error('AppMap JSON parse error!');
         this.isEmptyAppMap = true;
       }
     },


### PR DESCRIPTION
In VSCode extenstion JSON content comes as string and "empty appmap" check is broken, so VSCode extension doesn't work at all with `@appland/appmap` versions `1.8.0`, `1.9.0`, `1.10.0` and `1.10.1`.
This PR add `JSON.parse` when AppMap data is string.