### PR TITLE
Manage app state with getState/setState API

### DIFF
--- a/src/pages/VsCodeExtension.vue
+++ b/src/pages/VsCodeExtension.vue
@@ -172,7 +172,7 @@ export default {
       handler(view) {
         this.onChangeTab(this.$refs[view]);
         this.$refs.tabs.activateTab(this.$refs[view]);
-        this.$root.$emit('stateChanged');
+        this.$root.$emit('stateChanged', 'currentView');
       },
     },
     '$store.getters.selectedObject': {
@@ -181,12 +181,12 @@ export default {
           this.setView(VIEW_COMPONENT);
         }
 
-        this.$root.$emit('stateChanged');
+        this.$root.$emit('stateChanged', 'selectedObject');
       },
     },
     '$store.getters.selectedLabel': {
       handler() {
-        this.$root.$emit('stateChanged');
+        this.$root.$emit('stateChanged', 'selectedObject');
       },
     },
   },

--- a/src/pages/VsCodeExtension.vue
+++ b/src/pages/VsCodeExtension.vue
@@ -172,6 +172,7 @@ export default {
       handler(view) {
         this.onChangeTab(this.$refs[view]);
         this.$refs.tabs.activateTab(this.$refs[view]);
+        this.$root.$emit('stateChanged');
       },
     },
     '$store.getters.selectedObject': {
@@ -180,18 +181,12 @@ export default {
           this.setView(VIEW_COMPONENT);
         }
 
-        if (selectedObject && selectedObject.fqid) {
-          this.emitSelectedObject(selectedObject.fqid);
-        } else {
-          this.emitSelectedObject(null);
-        }
+        this.$root.$emit('stateChanged');
       },
     },
     '$store.getters.selectedLabel': {
-      handler(selectedLabel) {
-        this.emitSelectedObject(
-          selectedLabel ? `label:${selectedLabel}` : null
-        );
+      handler() {
+        this.$root.$emit('stateChanged');
       },
     },
   },
@@ -287,41 +282,6 @@ export default {
       }
     },
 
-    emitSelectedObject(fqid) {
-      this.$root.$emit('selectedObject', fqid);
-    },
-
-    setSelectedObject(fqid) {
-      const [match, type, object] = fqid.match(/^([a-z]+):(.+)/);
-      if (!match) {
-        return;
-      }
-
-      if (type === 'label') {
-        this.$store.commit(SELECT_LABEL, object);
-        return;
-      }
-
-      const { classMap, events } = this.$store.state.appMap;
-      let selectedObject = null;
-
-      if (type === 'event') {
-        const eventId = parseInt(object, 10);
-
-        if (Number.isNaN(eventId)) {
-          return;
-        }
-
-        selectedObject = events.find((e) => e.id === eventId);
-      } else {
-        selectedObject = classMap.codeObjects.find((obj) => obj.fqid === fqid);
-      }
-
-      if (selectedObject) {
-        this.$store.commit(SELECT_OBJECT, selectedObject);
-      }
-    },
-
     getState() {
       const state = {
         currentView: this.currentView,
@@ -342,7 +302,38 @@ export default {
         this.setView(state.currentView);
       }
       if (state.selectedObject) {
-        this.setSelectedObject(state.selectedObject);
+        const fqid = state.selectedObject;
+        const [match, type, object] = fqid.match(/^([a-z]+):(.+)/);
+
+        if (!match) {
+          return;
+        }
+
+        if (type === 'label') {
+          this.$store.commit(SELECT_LABEL, object);
+          return;
+        }
+
+        const { classMap, events } = this.$store.state.appMap;
+        let selectedObject = null;
+
+        if (type === 'event') {
+          const eventId = parseInt(object, 10);
+
+          if (Number.isNaN(eventId)) {
+            return;
+          }
+
+          selectedObject = events.find((e) => e.id === eventId);
+        } else {
+          selectedObject = classMap.codeObjects.find(
+            (obj) => obj.fqid === fqid
+          );
+        }
+
+        if (selectedObject) {
+          this.$store.commit(SELECT_OBJECT, selectedObject);
+        }
       }
     },
 

--- a/tests/unit/components/VsCodeExtension.spec.js
+++ b/tests/unit/components/VsCodeExtension.spec.js
@@ -19,13 +19,13 @@ describe('VsCodeExtension.vue', () => {
   });
 
   it('sets the selected object by FQID', () => {
-    wrapper.vm.setSelectedObject('label:json');
+    wrapper.vm.setState('{"selectedObject":"label:json"}');
     expect(wrapper.vm.selectedLabel).toMatch('json');
 
-    wrapper.vm.setSelectedObject('event:44');
+    wrapper.vm.setState('{"selectedObject":"event:44"}');
     expect(wrapper.vm.selectedObject.toString()).toMatch('User.find_by_id!');
 
-    wrapper.vm.setSelectedObject('class:app/models/User');
+    wrapper.vm.setState('{"selectedObject":"class:app/models/User"}');
     expect(wrapper.vm.selectedObject.id).toMatch('app/models/User');
   });
 
@@ -33,7 +33,7 @@ describe('VsCodeExtension.vue', () => {
     // Sanity checks
     expect(rootWrapper.emitted().showInstructions).toBeUndefined();
     expect(rootWrapper.emitted().changeTab).toBeArrayOfSize(1);
-    expect(rootWrapper.emitted().selectedObject).toBeArrayOfSize(1);
+    expect(rootWrapper.emitted().selectedObject).toBeUndefined();
     expect(rootWrapper.emitted().clearSelection).toBeUndefined();
 
     wrapper.vm.showInstructions();
@@ -41,9 +41,6 @@ describe('VsCodeExtension.vue', () => {
 
     wrapper.vm.onChangeTab(wrapper.vm.$refs[VIEW_FLOW]);
     expect(rootWrapper.emitted().changeTab[1]).toContain(VIEW_FLOW);
-
-    wrapper.vm.emitSelectedObject('example');
-    expect(rootWrapper.emitted().selectedObject[1]).toContain('example');
 
     wrapper.vm.clearSelection();
     expect(rootWrapper.emitted().clearSelection).toBeArrayOfSize(1);


### PR DESCRIPTION
**NB!** There is a breaking change, because `setSelectedObject` method and `selectedObject` event were removed from `VsCodeExtension` component.

With this PR we must read/write app state only with:

- `getState/setState` methods
- `stateChanged` event