### PR TITLE
test: set Chromatic delay for some components with animation

### DIFF
--- a/src/stories/DiagramComponent.stories.js
+++ b/src/stories/DiagramComponent.stories.js
@@ -10,7 +10,7 @@ export default {
   title: 'AppLand/Diagrams/Component',
   component: VDiagramComponent,
   parameters: {
-    chromatic: { delay: 300 },
+    chromatic: { delay: 1000 },
   },
   argTypes: {
     theme: { control: { type: 'select', options: ['dark', 'light'] } },

--- a/src/stories/DiagramComponent.stories.js
+++ b/src/stories/DiagramComponent.stories.js
@@ -9,6 +9,9 @@ store.commit(SET_APPMAP_DATA, scenario);
 export default {
   title: 'AppLand/Diagrams/Component',
   component: VDiagramComponent,
+  parameters: {
+    chromatic: { delay: 300 },
+  },
   argTypes: {
     theme: { control: { type: 'select', options: ['dark', 'light'] } },
   },

--- a/src/stories/DiagramFlow.stories.js
+++ b/src/stories/DiagramFlow.stories.js
@@ -9,6 +9,9 @@ store.commit(SET_APPMAP_DATA, scenario);
 export default {
   title: 'AppLand/Diagrams/Flow',
   component: VDiagramFlow,
+  parameters: {
+    chromatic: { delay: 1000 },
+  },
   argTypes: {
     theme: { control: { type: 'select', options: ['dark', 'light'] } },
     callTree: { table: { disable: true } },

--- a/src/stories/Trace.stories.js
+++ b/src/stories/Trace.stories.js
@@ -15,6 +15,9 @@ if (events.length === 0) {
 export default {
   title: 'AppLand/Diagrams/Trace',
   component: VDiagramTrace,
+  parameters: {
+    chromatic: { delay: 300 },
+  },
   argTypes: {
     events: { table: { disable: true } },
   },

--- a/src/stories/Trace.stories.js
+++ b/src/stories/Trace.stories.js
@@ -16,7 +16,7 @@ export default {
   title: 'AppLand/Diagrams/Trace',
   component: VDiagramTrace,
   parameters: {
-    chromatic: { delay: 300 },
+    chromatic: { delay: 1000 },
   },
   argTypes: {
     events: { table: { disable: true } },

--- a/src/stories/VsCodeExtension.stories.js
+++ b/src/stories/VsCodeExtension.stories.js
@@ -13,7 +13,7 @@ export default {
   title: 'Pages/VS Code',
   component: VVsCodeExtension,
   parameters: {
-    chromatic: { delay: 300 },
+    chromatic: { delay: 1000 },
   },
   argTypes: {
     scenario: {

--- a/src/stories/VsCodeExtension.stories.js
+++ b/src/stories/VsCodeExtension.stories.js
@@ -12,6 +12,9 @@ const scenarioData = {
 export default {
   title: 'Pages/VS Code',
   component: VVsCodeExtension,
+  parameters: {
+    chromatic: { delay: 300 },
+  },
   argTypes: {
     scenario: {
       control: {

--- a/src/stories/VsCodeExtensionJava.stories.js
+++ b/src/stories/VsCodeExtensionJava.stories.js
@@ -5,7 +5,7 @@ export default {
   title: 'Pages/VS Code',
   component: VExtension,
   parameters: {
-    chromatic: { delay: 300 },
+    chromatic: { delay: 1000 },
   },
 };
 

--- a/src/stories/VsCodeExtensionJava.stories.js
+++ b/src/stories/VsCodeExtensionJava.stories.js
@@ -4,6 +4,9 @@ import petClinicScenario from './data/java_scenario.json';
 export default {
   title: 'Pages/VS Code',
   component: VExtension,
+  parameters: {
+    chromatic: { delay: 300 },
+  },
 };
 
 // Controls cannot be set in the URL params until Storybook 6.2 (next release).


### PR DESCRIPTION
Set delay for Chromatic screenshots for some components with animation (`DiagramComponent`, `DiagramTrace` and `VsCodeExtension`).

Fixes: #179 