### PR TITLE
fix: display HTTP server response status in 'status' property

### DIFF
--- a/src/lib/models/appMapBuilder/index.js
+++ b/src/lib/models/appMapBuilder/index.js
@@ -91,9 +91,20 @@ class AppMapBuilder extends EventSource {
       /* eslint-disable no-param-reassign */
       event.id = eventId;
       eventId += 1;
+
       if (event.isCall() && event.returnEvent) {
         event.returnEvent.parent_id = event.id;
       }
+
+      // Normalize status/status_code properties
+      const { httpServerResponse } = event;
+      if (event.isReturn() && httpServerResponse) {
+        if (httpServerResponse.status_code) {
+          httpServerResponse.status = httpServerResponse.status_code;
+          delete httpServerResponse.status_code;
+        }
+      }
+
       return event;
       /* eslint-enable no-param-reassign */
     });

--- a/src/lib/models/event.js
+++ b/src/lib/models/event.js
@@ -106,12 +106,7 @@ export default class Event {
   }
 
   get httpServerResponse() {
-    const response = { ...this.returnEvent.http_server_response };
-    if (response.status_code) {
-      response.status = response.status_code;
-      delete response.status_code;
-    }
-    return response;
+    return this.returnEvent.http_server_response;
   }
 
   get definedClass() {

--- a/src/lib/models/event.js
+++ b/src/lib/models/event.js
@@ -106,7 +106,12 @@ export default class Event {
   }
 
   get httpServerResponse() {
-    return this.returnEvent.http_server_response;
+    const response = { ...this.returnEvent.http_server_response };
+    if (response.status_code) {
+      response.status = response.status_code;
+      delete response.status_code;
+    }
+    return response;
   }
 
   get definedClass() {


### PR DESCRIPTION
In Details panel HTTP `status` will be displayed with status key, despite [`the official specification`](https://github.com/applandinc/appmap#http-server-request-return-attributes) where HTTP response event must have required `status_code` key.

![image](https://user-images.githubusercontent.com/17301016/116111642-2fdd5000-a6fa-11eb-8db7-b9a0f76173ac.png)

Fixes: #171 