### PR TITLE
fix: prevent word wrapping in tab buttons

### DIFF
--- a/src/components/TabButton.vue
+++ b/src/components/TabButton.vue
@@ -44,6 +44,7 @@ export default {
   margin: 0;
   transition: $transition;
   letter-spacing: 0.5px;
+  white-space: nowrap;
 
   &:hover,
   &:active {

--- a/src/pages/VsCodeExtension.vue
+++ b/src/pages/VsCodeExtension.vue
@@ -450,6 +450,7 @@ code {
   display: grid;
   grid-template-columns: auto 1fr;
   grid-template-rows: 100%;
+  min-width: 800px;
   height: 100vh;
   color: $base11;
   background-color: $vs-code-gray1;
@@ -499,7 +500,7 @@ code {
       grid-column-start: 2;
       grid-column-end: 3;
       width: 100%;
-      min-width: 250px;
+      min-width: 400px;
       word-break: break-all;
       overflow: hidden;
 


### PR DESCRIPTION
- add `white-space: nowrap;` for tab buttons
- set minimum width for diagrams container (right column)

![image](https://user-images.githubusercontent.com/17301016/116725277-0fc4ce00-aa25-11eb-8dde-c48f03cfccea.png)

Fixes: #189 