### PR TITLE
fix: don't expand class with one function by default

### DIFF
--- a/packages/diagrams/src/componentDiagram/index.js
+++ b/packages/diagrams/src/componentDiagram/index.js
@@ -267,7 +267,8 @@ export default class ComponentDiagram extends EventSource {
 
         if (
           children.length === 1 &&
-          children[0].type !== CodeObjectType.QUERY
+          children[0].type !== CodeObjectType.QUERY &&
+          children[0].type !== CodeObjectType.FUNCTION
         ) {
           // Make sure this object isn't empty
           const eventCount = obj.allEvents.length;


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/17301016/116917708-5cf9a780-ac92-11eb-91c4-b78bf4ff1807.png)

after:
![image](https://user-images.githubusercontent.com/17301016/116917734-684cd300-ac92-11eb-9156-ff522363f314.png)
