### PR TITLE
fix: empty lists are not visible in search panel results

### DIFF
--- a/packages/components/src/components/DetailsSearch.vue
+++ b/packages/components/src/components/DetailsSearch.vue
@@ -138,7 +138,11 @@ export default {
         }
       });
 
-      Object.values(items).forEach((item) => {
+      Object.entries(items).forEach(([key, item]) => {
+        if (!item.data.length) {
+          delete items[key];
+          return;
+        }
         item.data = item.data.sort((a, b) => {
           const aStr =
             a.object instanceof CodeObject


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/17301016/117042372-3b122a80-ad4f-11eb-8101-2850c9730ee3.png)

after:
![image](https://user-images.githubusercontent.com/17301016/117042329-2cc40e80-ad4f-11eb-9827-be0b3b030a98.png)

Fixes: #199 