### PR TITLE
fix: filter out ClassMap nodes without events

### DIFF
--- a/packages/components/tests/e2e/specs/vsCodeExtension.spec.js
+++ b/packages/components/tests/e2e/specs/vsCodeExtension.spec.js
@@ -483,7 +483,7 @@ context('VS Code Extension', () => {
         .contains('Functions')
         .parent()
         .within(() => {
-          cy.get('.list-item').should('have.length', 4);
+          cy.get('.list-item').should('have.length', 5);
         });
     });
 

--- a/packages/components/tests/e2e/specs/vsCodeExtension.spec.js
+++ b/packages/components/tests/e2e/specs/vsCodeExtension.spec.js
@@ -483,7 +483,7 @@ context('VS Code Extension', () => {
         .contains('Functions')
         .parent()
         .within(() => {
-          cy.get('.list-item').should('have.length', 5);
+          cy.get('.list-item').should('have.length', 4);
         });
     });
 

--- a/packages/models/src/classMap.js
+++ b/packages/models/src/classMap.js
@@ -132,10 +132,6 @@ export default class ClassMap {
         ancestors.forEach((obj) => validCodeObjects.add(obj));
       });
 
-    this.codeObjects = this.codeObjects.filter((obj) =>
-      validCodeObjects.has(obj)
-    );
-
     this.roots = this.roots.filter((obj) => validCodeObjects.has(obj));
 
     Object.keys(this.codeObjectsByLocation).forEach((obj) => {

--- a/packages/models/src/classMap.js
+++ b/packages/models/src/classMap.js
@@ -30,6 +30,13 @@ function addCodeObject(codeObjectArray, codeObject, parent = null) {
   }
 }
 
+function filterValidCodeObjects(children, validCodeObjects) {
+  return children.filter((obj) => {
+    obj.children = filterValidCodeObjects(obj.children, validCodeObjects);
+    return validCodeObjects.has(obj);
+  });
+}
+
 export default class ClassMap {
   constructor(classMap) {
     this.codeObjectsByLocation = {};
@@ -132,7 +139,14 @@ export default class ClassMap {
         ancestors.forEach((obj) => validCodeObjects.add(obj));
       });
 
-    this.roots = this.roots.filter((obj) => validCodeObjects.has(obj));
+    this.codeObjects = this.codeObjects.filter((obj) =>
+      validCodeObjects.has(obj)
+    );
+
+    this.roots = this.roots.filter((obj) => {
+      obj.children = filterValidCodeObjects(obj.children, validCodeObjects);
+      return validCodeObjects.has(obj);
+    });
 
     Object.keys(this.codeObjectsByLocation).forEach((obj) => {
       if (!validCodeObjects.has(obj)) {

--- a/packages/models/src/classMap.js
+++ b/packages/models/src/classMap.js
@@ -30,13 +30,6 @@ function addCodeObject(codeObjectArray, codeObject, parent = null) {
   }
 }
 
-function filterValidCodeObjects(children, validCodeObjects) {
-  return children.filter((obj) => {
-    obj.children = filterValidCodeObjects(obj.children, validCodeObjects);
-    return validCodeObjects.has(obj);
-  });
-}
-
 export default class ClassMap {
   constructor(classMap) {
     this.codeObjectsByLocation = {};
@@ -139,14 +132,20 @@ export default class ClassMap {
         ancestors.forEach((obj) => validCodeObjects.add(obj));
       });
 
+    // Remove code objects which have no events
     this.codeObjects = this.codeObjects.filter((obj) =>
       validCodeObjects.has(obj)
     );
 
-    this.roots = this.roots.filter((obj) => {
-      obj.children = filterValidCodeObjects(obj.children, validCodeObjects);
-      return validCodeObjects.has(obj);
+    // Not every child of an object is guaranteed to be valid. Prune the children.
+    this.codeObjects.forEach((obj) => {
+      obj.children = obj.children.filter((child) =>
+        validCodeObjects.has(child)
+      );
     });
+
+    // Similarly, make sure all the root nodes are valid
+    this.roots = this.roots.filter((obj) => validCodeObjects.has(obj));
 
     Object.keys(this.codeObjectsByLocation).forEach((obj) => {
       if (!validCodeObjects.has(obj)) {

--- a/packages/models/tests/unit/classMap.spec.js
+++ b/packages/models/tests/unit/classMap.spec.js
@@ -171,9 +171,8 @@ describe('ClassMap', () => {
       expect(roots[1].id).toEqual(
         'org/springframework/samples/petclinic/owner'
       );
-      expect(roots[2].id).toEqual('org/springframework/mock/web');
-      expect(roots[3].id).toEqual('HTTP server requests');
-      expect(roots).toHaveLength(4);
+      expect(roots[2].id).toEqual('HTTP server requests');
+      expect(roots).toHaveLength(3);
     });
   });
 });


### PR DESCRIPTION
With this change we don't filter out CodeObjects array anymore because it used by Dependency Map where packages/classes without events are still present.

Fixes: #206 