### PR TITLE
feat: display only details panel in mobile views

### DIFF
--- a/packages/components/src/components/DetailsButton.vue
+++ b/packages/components/src/components/DetailsButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <button type="button" class="details-btn">
+  <button type="button" :class="classes">
     <i :class="iconClass" v-if="icon" />
 
     <!-- Wrap the slot in a single object for better alignment -->
@@ -17,11 +17,19 @@ export default {
       type: String,
       required: false,
     },
+    additionalClass: {
+      type: String,
+      required: false,
+      default: '',
+    },
   },
 
   computed: {
     iconClass() {
       return `icon icon--${this.icon}`;
+    },
+    classes() {
+      return `details-btn ${this.additionalClass || ''}`;
     },
   },
 };

--- a/packages/components/src/components/DetailsPanelEvent.vue
+++ b/packages/components/src/components/DetailsPanelEvent.vue
@@ -5,6 +5,7 @@
         <v-details-button
           v-if="shouldDisplayViewEvent"
           @click.native="viewEvent"
+          additionalClass="details-btn--show-in-trace"
         >
           Show in Trace
         </v-details-button>

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -461,6 +461,7 @@ html,
 body {
   width: 100%;
   height: 100%;
+  min-width: 320px;
   margin: 0;
 }
 
@@ -696,5 +697,21 @@ code {
 }
 ::-webkit-scrollbar-corner {
   background: transparent;
+}
+
+@media (max-width: 800px) {
+  #app {
+    grid-template-columns: 100%;
+
+    .main-column--left {
+      width: 100%;
+    }
+    .main-column--drag,
+    .main-column--right,
+    .list-item__event-quickview,
+    .details-btn--show-in-trace {
+      display: none;
+    }
+  }
 }
 </style>


### PR DESCRIPTION
Display only Details panel for screens width less than 800px.

![image](https://user-images.githubusercontent.com/17301016/117472075-dc8dbc00-af9b-11eb-8fdb-347fdec277ac.png)

Fixes: #208 
