### PR TITLE
fix: Improve bind events

### DIFF
--- a/packages/components/src/stories/data/java_scenario.json
+++ b/packages/components/src/stories/data/java_scenario.json
@@ -1,1245 +1,1205 @@
 {
   "events": [
-      {
-          "id": 1,
-          "path": "src/main/java/org/springframework/web/filter/OncePerRequestFilter.java",
-          "event": "call",
-          "lineno": 91,
-          "static": false,
-          "message": [
-              {
-                  "kind": "req",
-                  "name": "date",
-                  "class": "java.lang.String",
-                  "value": "2020-09-12",
-                  "object_id": 1713864906
-              },
-              {
-                  "kind": "req",
-                  "name": "description",
-                  "class": "java.lang.String",
-                  "value": "routine check up",
-                  "object_id": 1522361550
-              },
-              {
-                  "kind": "req",
-                  "name": "petId",
-                  "class": "java.lang.String",
-                  "value": "9",
-                  "object_id": 801870463
-              },
-              {
-                  "kind": "req",
-                  "name": "ownerId",
-                  "class": "java.lang.String",
-                  "value": "7",
-                  "object_id": 709319113
-              },
-              {
-                  "kind": "req",
-                  "name": "petId",
-                  "class": "java.lang.String",
-                  "value": "9",
-                  "object_id": 611526333
-              }
-          ],
-          "method_id": "doFilter",
-          "thread_id": 556,
-          "defined_class": "org.springframework.web.filter.OncePerRequestFilter",
-          "http_server_request": {
-              "protocol": "HTTP/1.1",
-              "path_info": "/owners/7/pets/9/visits/new",
-              "request_method": "POST",
-              "normalized_path_info": "/owners/:ownerId/pets/:petId/visits/new",
-              "client_normalized_path_info": "/owners/:ownerId/pets/:petId/visits/new"
-          }
-      },
-      {
-          "id": 2,
-          "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
-          "event": "call",
-          "lineno": 59,
-          "static": false,
-          "receiver": {
-              "class": "org.springframework.samples.petclinic.owner.VisitController",
-              "value": "org.springframework.samples.petclinic.owner.VisitController@eb0d286",
-              "object_id": 246469254
-          },
-          "method_id": "setAllowedFields",
-          "thread_id": 556,
-          "parameters": [
-              {
-                  "kind": "req",
-                  "name": "dataBinder",
-                  "class": "org.springframework.web.servlet.mvc.method.annotation.ExtendedServletRequestDataBinder",
-                  "value": "org.springframework.web.servlet.mvc.method.annotation.ExtendedServletRequestDataBinder@4f9594d9",
-                  "object_id": 1335203033
-              }
-          ],
-          "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
-      },
-      {
-          "id": 3,
-          "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
-          "event": "return",
-          "lineno": 59,
-          "static": false,
-          "method_id": "setAllowedFields",
-          "parent_id": 2,
-          "thread_id": 556,
-          "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
-      },
-      {
-          "id": 4,
-          "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
-          "event": "call",
-          "lineno": 74,
-          "static": false,
-          "receiver": {
-              "class": "org.springframework.samples.petclinic.owner.VisitController",
-              "value": "org.springframework.samples.petclinic.owner.VisitController@eb0d286",
-              "object_id": 246469254
-          },
-          "method_id": "loadPetWithVisit",
-          "thread_id": 556,
-          "parameters": [
-              {
-                  "kind": "req",
-                  "name": "petId",
-                  "class": "java.lang.Integer",
-                  "value": "9",
-                  "object_id": 1916011657
-              },
-              {
-                  "kind": "req",
-                  "name": "model",
-                  "class": "org.springframework.validation.support.BindingAwareModelMap",
-                  "value": "{}",
-                  "object_id": 1073920961
-              }
-          ],
-          "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
-      },
-      {
-          "id": 5,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
-          "event": "call",
-          "lineno": 140,
-          "static": false,
-          "receiver": {
-              "class": "com.mchange.v2.c3p0.ComboPooledDataSource",
-              "value": "com.mchange.v2.c3p0.ComboPooledDataSource[ identityToken -> 1hge136ac1x0f595mu1co1|68e7e7a0, dataSourceName -> 1hge136ac1x0f595mu1co1|68e7e7a0 ]",
-              "object_id": 1760028576
-          },
-          "method_id": "getConnection",
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
-      },
-      {
-          "id": 6,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "call",
-          "lineno": 208,
-          "static": false,
-          "receiver": {
-              "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@51bc8c24",
-              "object_id": 1371311140
-          },
-          "method_id": "getConnection",
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
-      },
-      {
-          "id": 7,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "return",
-          "lineno": 208,
-          "static": false,
-          "method_id": "getConnection",
-          "parent_id": 6,
-          "thread_id": 556,
-          "return_value": {
-              "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@1c8f9233 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@73b21a5d]",
-              "object_id": 479171123
-          },
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
-      },
-      {
-          "id": 8,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
-          "event": "return",
-          "lineno": 140,
-          "static": false,
-          "method_id": "getConnection",
-          "parent_id": 5,
-          "thread_id": 556,
-          "return_value": {
-              "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@1c8f9233 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@73b21a5d]",
-              "object_id": 479171123
-          },
-          "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
-      },
-      {
-          "id": 9,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
-          "event": "call",
-          "lineno": 536,
-          "static": false,
-          "method_id": "prepareStatement",
-          "sql_query": {
-              "sql": "SELECT `PET`.`ID` AS `ID`, `PET`.`type_id` AS `type_id`, `PET`.`NAME` AS `NAME`, `PET`.`owner_id` AS `owner_id`, `PET`.`BIRTH_DATE` AS `BIRTH_DATE` FROM `PET` WHERE `PET`.`ID` = ?",
-              "normalized": false,
-              "database_type": "MySQL",
-              "normalized_sql": "SELECT `PET`.`ID` AS `ID`, `PET`.`type_id` AS `type_id`, `PET`.`NAME` AS `NAME`, `PET`.`owner_id` AS `owner_id`, `PET`.`BIRTH_DATE` AS `BIRTH_DATE` FROM `PET` WHERE `PET`.`ID` = ?"
-          },
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
-      },
-      {
-          "id": 10,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
-          "event": "return",
-          "lineno": 536,
-          "static": false,
-          "method_id": "prepareStatement",
-          "parent_id": 9,
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
-      },
-      {
-          "id": 11,
-          "path": "src/main/java/org/springframework/samples/petclinic/owner/Pet.java",
-          "event": "call",
-          "lineno": 65,
-          "static": false,
-          "receiver": {
-              "class": "org.springframework.samples.petclinic.owner.Pet",
-              "value": "Pet{id=9, name='Lucky', birthDate=1999-08-06, type=5, owner=7}",
-              "object_id": 2075628489
-          },
-          "method_id": "getOwner",
-          "thread_id": 556,
-          "defined_class": "org.springframework.samples.petclinic.owner.Pet"
-      },
-      {
-          "id": 12,
-          "path": "src/main/java/org/springframework/samples/petclinic/owner/Pet.java",
-          "event": "return",
-          "lineno": 65,
-          "static": false,
-          "method_id": "getOwner",
-          "parent_id": 11,
-          "thread_id": 556,
-          "return_value": {
-              "class": "java.lang.Integer",
-              "value": "7",
-              "object_id": 1929919778
-          },
-          "defined_class": "org.springframework.samples.petclinic.owner.Pet"
-      },
-      {
-          "id": 13,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
-          "event": "call",
-          "lineno": 140,
-          "static": false,
-          "receiver": {
-              "class": "com.mchange.v2.c3p0.ComboPooledDataSource",
-              "value": "com.mchange.v2.c3p0.ComboPooledDataSource[ identityToken -> 1hge136ac1x0f595mu1co1|68e7e7a0, dataSourceName -> 1hge136ac1x0f595mu1co1|68e7e7a0 ]",
-              "object_id": 1760028576
-          },
-          "method_id": "getConnection",
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
-      },
-      {
-          "id": 14,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "call",
-          "lineno": 208,
-          "static": false,
-          "receiver": {
-              "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@5cdab556",
-              "object_id": 1557837142
-          },
-          "method_id": "getConnection",
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
-      },
-      {
-          "id": 15,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "return",
-          "lineno": 208,
-          "static": false,
-          "method_id": "getConnection",
-          "parent_id": 14,
-          "thread_id": 556,
-          "return_value": {
-              "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@1e3beb11 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@5ff6377d]",
-              "object_id": 507243281
-          },
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
-      },
-      {
-          "id": 16,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
-          "event": "return",
-          "lineno": 140,
-          "static": false,
-          "method_id": "getConnection",
-          "parent_id": 13,
-          "thread_id": 556,
-          "return_value": {
-              "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@1e3beb11 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@5ff6377d]",
-              "object_id": 507243281
-          },
-          "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
-      },
-      {
-          "id": 17,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
-          "event": "call",
-          "lineno": 536,
-          "static": false,
-          "method_id": "prepareStatement",
-          "sql_query": {
-              "sql": "SELECT `OWNER`.`ID` AS `ID`, `OWNER`.`CITY` AS `CITY`, `OWNER`.`ADDRESS` AS `ADDRESS`, `OWNER`.`LAST_NAME` AS `LAST_NAME`, `OWNER`.`TELEPHONE` AS `TELEPHONE`, `OWNER`.`FIRST_NAME` AS `FIRST_NAME` FROM `OWNER` WHERE `OWNER`.`ID` = ?",
-              "normalized": false,
-              "database_type": "MySQL",
-              "normalized_sql": "SELECT `OWNER`.`ID` AS `ID`, `OWNER`.`CITY` AS `CITY`, `OWNER`.`ADDRESS` AS `ADDRESS`, `OWNER`.`LAST_NAME` AS `LAST_NAME`, `OWNER`.`TELEPHONE` AS `TELEPHONE`, `OWNER`.`FIRST_NAME` AS `FIRST_NAME` FROM `OWNER` WHERE `OWNER`.`ID` = ?"
-          },
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
-      },
-      {
-          "id": 18,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
-          "event": "return",
-          "lineno": 536,
-          "static": false,
-          "method_id": "prepareStatement",
-          "parent_id": 17,
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
-      },
-      {
-          "id": 19,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
-          "event": "call",
-          "lineno": 140,
-          "static": false,
-          "receiver": {
-              "class": "com.mchange.v2.c3p0.ComboPooledDataSource",
-              "value": "com.mchange.v2.c3p0.ComboPooledDataSource[ identityToken -> 1hge136ac1x0f595mu1co1|68e7e7a0, dataSourceName -> 1hge136ac1x0f595mu1co1|68e7e7a0 ]",
-              "object_id": 1760028576
-          },
-          "method_id": "getConnection",
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
-      },
-      {
-          "id": 20,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "call",
-          "lineno": 208,
-          "static": false,
-          "receiver": {
-              "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@5cdab556",
-              "object_id": 1557837142
-          },
-          "method_id": "getConnection",
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
-      },
-      {
-          "id": 21,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "return",
-          "lineno": 208,
-          "static": false,
-          "method_id": "getConnection",
-          "parent_id": 20,
-          "thread_id": 556,
-          "return_value": {
-              "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@433e2251 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@5ff6377d]",
-              "object_id": 1128145489
-          },
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
-      },
-      {
-          "id": 22,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
-          "event": "return",
-          "lineno": 140,
-          "static": false,
-          "method_id": "getConnection",
-          "parent_id": 19,
-          "thread_id": 556,
-          "return_value": {
-              "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@433e2251 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@5ff6377d]",
-              "object_id": 1128145489
-          },
-          "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
-      },
-      {
-          "id": 23,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
-          "event": "call",
-          "lineno": 536,
-          "static": false,
-          "method_id": "prepareStatement",
-          "sql_query": {
-              "sql": "select * from visit where pet_id = ?",
-              "normalized": true,
-              "database_type": "MySQL",
-              "normalized_sql": "select * from visit where pet_id = ?"
-          },
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
-      },
-      {
-          "id": 24,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
-          "event": "return",
-          "lineno": 536,
-          "static": false,
-          "method_id": "prepareStatement",
-          "parent_id": 23,
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
-      },
-      {
-          "id": 25,
-          "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
-          "event": "return",
-          "lineno": 74,
-          "static": false,
-          "method_id": "loadPetWithVisit",
-          "parent_id": 4,
-          "thread_id": 556,
-          "return_value": {
-              "class": "org.springframework.samples.petclinic.visit.Visit",
-              "value": "Visit{id=null, date=2020-10-05, description='null', petId=null}",
-              "object_id": 483593247
-          },
-          "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
-      },
-      {
-          "id": 26,
-          "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
-          "event": "call",
-          "lineno": 59,
-          "static": false,
-          "receiver": {
-              "class": "org.springframework.samples.petclinic.owner.VisitController",
-              "value": "org.springframework.samples.petclinic.owner.VisitController@eb0d286",
-              "object_id": 246469254
-          },
-          "method_id": "setAllowedFields",
-          "thread_id": 556,
-          "parameters": [
-              {
-                  "kind": "req",
-                  "name": "dataBinder",
-                  "class": "org.springframework.web.servlet.mvc.method.annotation.ExtendedServletRequestDataBinder",
-                  "value": "org.springframework.web.servlet.mvc.method.annotation.ExtendedServletRequestDataBinder@7ff20493",
-                  "object_id": 2146567315
-              }
-          ],
-          "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
-      },
-      {
-          "id": 27,
-          "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
-          "event": "return",
-          "lineno": 59,
-          "static": false,
-          "method_id": "setAllowedFields",
-          "parent_id": 26,
-          "thread_id": 556,
-          "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
-      },
-      {
-          "id": 28,
-          "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
-          "event": "call",
-          "lineno": 53,
-          "static": false,
-          "receiver": {
-              "class": "org.springframework.samples.petclinic.visit.Visit",
-              "value": "Visit{id=null, date=2020-10-05, description='null', petId=null}",
-              "object_id": 483593247
-          },
-          "method_id": "getDate",
-          "thread_id": 556,
-          "defined_class": "org.springframework.samples.petclinic.visit.Visit"
-      },
-      {
-          "id": 29,
-          "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
-          "event": "return",
-          "lineno": 53,
-          "static": false,
-          "method_id": "getDate",
-          "parent_id": 28,
-          "thread_id": 556,
-          "return_value": {
-              "class": "java.time.LocalDate",
-              "value": "2020-10-05",
-              "object_id": 92802791
-          },
-          "defined_class": "org.springframework.samples.petclinic.visit.Visit"
-      },
-      {
-          "id": 30,
-          "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
-          "event": "call",
-          "lineno": 57,
-          "static": false,
-          "receiver": {
-              "class": "org.springframework.samples.petclinic.visit.Visit",
-              "value": "Visit{id=null, date=2020-09-12, description='null', petId=null}",
-              "object_id": 483593247
-          },
-          "method_id": "setDate",
-          "thread_id": 556,
-          "parameters": [
-              {
-                  "kind": "req",
-                  "name": "date",
-                  "class": "java.time.LocalDate",
-                  "value": "2020-09-12",
-                  "object_id": 1540092183
-              }
-          ],
-          "defined_class": "org.springframework.samples.petclinic.visit.Visit"
-      },
-      {
-          "id": 31,
-          "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
-          "event": "return",
-          "lineno": 57,
-          "static": false,
-          "method_id": "setDate",
-          "parent_id": 30,
-          "thread_id": 556,
-          "defined_class": "org.springframework.samples.petclinic.visit.Visit"
-      },
-      {
-          "id": 32,
-          "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
-          "event": "call",
-          "lineno": 61,
-          "static": false,
-          "receiver": {
-              "class": "org.springframework.samples.petclinic.visit.Visit",
-              "value": "Visit{id=null, date=2020-09-12, description='null', petId=null}",
-              "object_id": 483593247
-          },
-          "method_id": "getDescription",
-          "thread_id": 556,
-          "defined_class": "org.springframework.samples.petclinic.visit.Visit"
-      },
-      {
-          "id": 33,
-          "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
-          "event": "return",
-          "lineno": 61,
-          "static": false,
-          "method_id": "getDescription",
-          "parent_id": 32,
-          "thread_id": 556,
-          "defined_class": "org.springframework.samples.petclinic.visit.Visit"
-      },
-      {
-          "id": 34,
-          "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
-          "event": "call",
-          "lineno": 65,
-          "static": false,
-          "receiver": {
-              "class": "org.springframework.samples.petclinic.visit.Visit",
-              "value": "Visit{id=null, date=2020-09-12, description='routine check up', petId=null}",
-              "object_id": 483593247
-          },
-          "method_id": "setDescription",
-          "thread_id": 556,
-          "parameters": [
-              {
-                  "kind": "req",
-                  "name": "description",
-                  "class": "java.lang.String",
-                  "value": "routine check up",
-                  "object_id": 1522361550
-              }
-          ],
-          "defined_class": "org.springframework.samples.petclinic.visit.Visit"
-      },
-      {
-          "id": 35,
-          "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
-          "event": "return",
-          "lineno": 65,
-          "static": false,
-          "method_id": "setDescription",
-          "parent_id": 34,
-          "thread_id": 556,
-          "defined_class": "org.springframework.samples.petclinic.visit.Visit"
-      },
-      {
-          "id": 36,
-          "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
-          "event": "call",
-          "lineno": 69,
-          "static": false,
-          "receiver": {
-              "class": "org.springframework.samples.petclinic.visit.Visit",
-              "value": "Visit{id=null, date=2020-09-12, description='routine check up', petId=null}",
-              "object_id": 483593247
-          },
-          "method_id": "getPetId",
-          "thread_id": 556,
-          "defined_class": "org.springframework.samples.petclinic.visit.Visit"
-      },
-      {
-          "id": 37,
-          "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
-          "event": "return",
-          "lineno": 69,
-          "static": false,
-          "method_id": "getPetId",
-          "parent_id": 36,
-          "thread_id": 556,
-          "defined_class": "org.springframework.samples.petclinic.visit.Visit"
-      },
-      {
-          "id": 38,
-          "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
-          "event": "call",
-          "lineno": 73,
-          "static": false,
-          "receiver": {
-              "class": "org.springframework.samples.petclinic.visit.Visit",
-              "value": "Visit{id=null, date=2020-09-12, description='routine check up', petId=9}",
-              "object_id": 483593247
-          },
-          "method_id": "setPetId",
-          "thread_id": 556,
-          "parameters": [
-              {
-                  "kind": "req",
-                  "name": "petId",
-                  "class": "java.lang.Integer",
-                  "value": "9",
-                  "object_id": 1916011657
-              }
-          ],
-          "defined_class": "org.springframework.samples.petclinic.visit.Visit"
-      },
-      {
-          "id": 39,
-          "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
-          "event": "return",
-          "lineno": 73,
-          "static": false,
-          "method_id": "setPetId",
-          "parent_id": 38,
-          "thread_id": 556,
-          "defined_class": "org.springframework.samples.petclinic.visit.Visit"
-      },
-      {
-          "id": 40,
-          "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
-          "event": "call",
-          "lineno": 92,
-          "static": false,
-          "receiver": {
-              "class": "org.springframework.samples.petclinic.owner.VisitController",
-              "value": "org.springframework.samples.petclinic.owner.VisitController@eb0d286",
-              "object_id": 246469254
-          },
-          "method_id": "processNewVisitForm",
-          "thread_id": 556,
-          "parameters": [
-              {
-                  "kind": "req",
-                  "name": "visit",
-                  "class": "org.springframework.samples.petclinic.visit.Visit",
-                  "value": "Visit{id=null, date=2020-09-12, description='routine check up', petId=9}",
-                  "object_id": 483593247
-              },
-              {
-                  "kind": "req",
-                  "name": "result",
-                  "class": "org.springframework.validation.BeanPropertyBindingResult",
-                  "value": "org.springframework.validation.BeanPropertyBindingResult: 0 errors",
-                  "object_id": 1610399109
-              }
-          ],
-          "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
-      },
-      {
-          "id": 41,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
-          "event": "call",
-          "lineno": 140,
-          "static": false,
-          "receiver": {
-              "class": "com.mchange.v2.c3p0.ComboPooledDataSource",
-              "value": "com.mchange.v2.c3p0.ComboPooledDataSource[ identityToken -> 1hge136ac1x0f595mu1co1|68e7e7a0, dataSourceName -> 1hge136ac1x0f595mu1co1|68e7e7a0 ]",
-              "object_id": 1760028576
-          },
-          "method_id": "getConnection",
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
-      },
-      {
-          "id": 42,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "call",
-          "lineno": 208,
-          "static": false,
-          "receiver": {
-              "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@5cdab556",
-              "object_id": 1557837142
-          },
-          "method_id": "getConnection",
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
-      },
-      {
-          "id": 43,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "return",
-          "lineno": 208,
-          "static": false,
-          "method_id": "getConnection",
-          "parent_id": 42,
-          "thread_id": 556,
-          "return_value": {
-              "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@4f14f593 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@5ff6377d]",
-              "object_id": 1326773651
-          },
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
-      },
-      {
-          "id": 44,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
-          "event": "return",
-          "lineno": 140,
-          "static": false,
-          "method_id": "getConnection",
-          "parent_id": 41,
-          "thread_id": 556,
-          "return_value": {
-              "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@4f14f593 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@5ff6377d]",
-              "object_id": 1326773651
-          },
-          "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
-      },
-      {
-          "id": 45,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
-          "event": "call",
-          "lineno": 230,
-          "static": false,
-          "method_id": "prepareStatement",
-          "sql_query": {
-              "sql": "INSERT INTO `VISIT` (`DATE`, `DESCRIPTION`, `PET_ID`) VALUES (?, ?, ?)",
-              "normalized": false,
-              "database_type": "MySQL",
-              "normalized_sql": "INSERT INTO `VISIT` (`DATE`, `DESCRIPTION`, `PET_ID`) VALUES (?, ?, ?)"
-          },
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
-      },
-      {
-          "id": 46,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
-          "event": "return",
-          "lineno": 230,
-          "static": false,
-          "method_id": "prepareStatement",
-          "parent_id": 45,
-          "thread_id": 556,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
-      },
-      {
-          "id": 47,
-          "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
-          "event": "return",
-          "lineno": 92,
-          "static": false,
-          "method_id": "processNewVisitForm",
-          "parent_id": 40,
-          "thread_id": 556,
-          "return_value": {
-              "class": "java.lang.String",
-              "value": "redirect:/owners/{ownerId}",
-              "object_id": 1188712385
-          },
-          "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
-      },
-      {
-          "id": 48,
-          "path": "src/main/java/org/springframework/web/filter/OncePerRequestFilter.java",
-          "event": "return",
-          "lineno": 91,
-          "static": false,
-          "method_id": "doFilter",
-          "parent_id": 1,
-          "thread_id": 556,
-          "defined_class": "org.springframework.web.filter.OncePerRequestFilter",
-          "http_server_response": {
-              "status": 302
-          }
-      },
-      {
-          "id": 49,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "call",
-          "lineno": 208,
-          "static": false,
-          "receiver": {
-              "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@51bc8c24",
-              "object_id": 1371311140
-          },
-          "method_id": "getConnection",
-          "thread_id": 353,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
-      },
-      {
-          "id": 50,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "return",
-          "lineno": 208,
-          "static": false,
-          "method_id": "getConnection",
-          "parent_id": 49,
-          "thread_id": 353,
-          "return_value": {
-              "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@5aaea47c [wrapping: null]",
-              "object_id": 1521394812
-          },
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
-      },
-      {
-          "id": 51,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "call",
-          "lineno": 208,
-          "static": false,
-          "receiver": {
-              "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@5cdab556",
-              "object_id": 1557837142
-          },
-          "method_id": "getConnection",
-          "thread_id": 352,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
-      },
-      {
-          "id": 52,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "return",
-          "lineno": 208,
-          "static": false,
-          "method_id": "getConnection",
-          "parent_id": 51,
-          "thread_id": 352,
-          "return_value": {
-              "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@579eed0f [wrapping: null]",
-              "object_id": 1470033167
-          },
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
-      },
-      {
-          "id": 53,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "call",
-          "lineno": 208,
-          "static": false,
-          "receiver": {
-              "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@5cdab556",
-              "object_id": 1557837142
-          },
-          "method_id": "getConnection",
-          "thread_id": 353,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
-      },
-      {
-          "id": 54,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "return",
-          "lineno": 208,
-          "static": false,
-          "method_id": "getConnection",
-          "parent_id": 53,
-          "thread_id": 353,
-          "return_value": {
-              "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@47a0683c [wrapping: null]",
-              "object_id": 1201694780
-          },
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
-      },
-      {
-          "id": 55,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "call",
-          "lineno": 208,
-          "static": false,
-          "receiver": {
-              "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@5cdab556",
-              "object_id": 1557837142
-          },
-          "method_id": "getConnection",
-          "thread_id": 352,
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
-      },
-      {
-          "id": 56,
-          "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
-          "event": "return",
-          "lineno": 208,
-          "static": false,
-          "method_id": "getConnection",
-          "parent_id": 55,
-          "thread_id": 352,
-          "return_value": {
-              "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
-              "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@346f3e4c [wrapping: null]",
-              "object_id": 879705676
-          },
-          "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    {
+      "id": 1,
+      "event": "call",
+      "message": [
+        {
+          "kind": "req",
+          "name": "date",
+          "class": "java.lang.String",
+          "value": "2020-09-12",
+          "object_id": 1713864906
+        },
+        {
+          "kind": "req",
+          "name": "description",
+          "class": "java.lang.String",
+          "value": "routine check up",
+          "object_id": 1522361550
+        },
+        {
+          "kind": "req",
+          "name": "petId",
+          "class": "java.lang.String",
+          "value": "9",
+          "object_id": 801870463
+        },
+        {
+          "kind": "req",
+          "name": "ownerId",
+          "class": "java.lang.String",
+          "value": "7",
+          "object_id": 709319113
+        },
+        {
+          "kind": "req",
+          "name": "petId",
+          "class": "java.lang.String",
+          "value": "9",
+          "object_id": 611526333
+        }
+      ],
+      "thread_id": 556,
+      "http_server_request": {
+        "protocol": "HTTP/1.1",
+        "path_info": "/owners/7/pets/9/visits/new",
+        "request_method": "POST",
+        "normalized_path_info": "/owners/:ownerId/pets/:petId/visits/new",
+        "client_normalized_path_info": "/owners/:ownerId/pets/:petId/visits/new"
       }
+    },
+    {
+      "id": 2,
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
+      "event": "call",
+      "lineno": 59,
+      "static": false,
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.VisitController",
+        "value": "org.springframework.samples.petclinic.owner.VisitController@eb0d286",
+        "object_id": 246469254
+      },
+      "method_id": "setAllowedFields",
+      "thread_id": 556,
+      "parameters": [
+        {
+          "kind": "req",
+          "name": "dataBinder",
+          "class": "org.springframework.web.servlet.mvc.method.annotation.ExtendedServletRequestDataBinder",
+          "value": "org.springframework.web.servlet.mvc.method.annotation.ExtendedServletRequestDataBinder@4f9594d9",
+          "object_id": 1335203033
+        }
+      ],
+      "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
+    },
+    {
+      "id": 3,
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
+      "event": "return",
+      "lineno": 59,
+      "static": false,
+      "method_id": "setAllowedFields",
+      "parent_id": 2,
+      "thread_id": 556,
+      "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
+    },
+    {
+      "id": 4,
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
+      "event": "call",
+      "lineno": 74,
+      "static": false,
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.VisitController",
+        "value": "org.springframework.samples.petclinic.owner.VisitController@eb0d286",
+        "object_id": 246469254
+      },
+      "method_id": "loadPetWithVisit",
+      "thread_id": 556,
+      "parameters": [
+        {
+          "kind": "req",
+          "name": "petId",
+          "class": "java.lang.Integer",
+          "value": "9",
+          "object_id": 1916011657
+        },
+        {
+          "kind": "req",
+          "name": "model",
+          "class": "org.springframework.validation.support.BindingAwareModelMap",
+          "value": "{}",
+          "object_id": 1073920961
+        }
+      ],
+      "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
+    },
+    {
+      "id": 5,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
+      "event": "call",
+      "lineno": 140,
+      "static": false,
+      "receiver": {
+        "class": "com.mchange.v2.c3p0.ComboPooledDataSource",
+        "value": "com.mchange.v2.c3p0.ComboPooledDataSource[ identityToken -> 1hge136ac1x0f595mu1co1|68e7e7a0, dataSourceName -> 1hge136ac1x0f595mu1co1|68e7e7a0 ]",
+        "object_id": 1760028576
+      },
+      "method_id": "getConnection",
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
+    },
+    {
+      "id": 6,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "call",
+      "lineno": 208,
+      "static": false,
+      "receiver": {
+        "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@51bc8c24",
+        "object_id": 1371311140
+      },
+      "method_id": "getConnection",
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    },
+    {
+      "id": 7,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "return",
+      "lineno": 208,
+      "static": false,
+      "method_id": "getConnection",
+      "parent_id": 6,
+      "thread_id": 556,
+      "return_value": {
+        "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@1c8f9233 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@73b21a5d]",
+        "object_id": 479171123
+      },
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    },
+    {
+      "id": 8,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
+      "event": "return",
+      "lineno": 140,
+      "static": false,
+      "method_id": "getConnection",
+      "parent_id": 5,
+      "thread_id": 556,
+      "return_value": {
+        "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@1c8f9233 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@73b21a5d]",
+        "object_id": 479171123
+      },
+      "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
+    },
+    {
+      "id": 9,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
+      "event": "call",
+      "lineno": 536,
+      "static": false,
+      "method_id": "prepareStatement",
+      "sql_query": {
+        "sql": "SELECT `PET`.`ID` AS `ID`, `PET`.`type_id` AS `type_id`, `PET`.`NAME` AS `NAME`, `PET`.`owner_id` AS `owner_id`, `PET`.`BIRTH_DATE` AS `BIRTH_DATE` FROM `PET` WHERE `PET`.`ID` = ?",
+        "normalized": false,
+        "database_type": "MySQL",
+        "normalized_sql": "SELECT `PET`.`ID` AS `ID`, `PET`.`type_id` AS `type_id`, `PET`.`NAME` AS `NAME`, `PET`.`owner_id` AS `owner_id`, `PET`.`BIRTH_DATE` AS `BIRTH_DATE` FROM `PET` WHERE `PET`.`ID` = ?"
+      },
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
+    },
+    {
+      "id": 10,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
+      "event": "return",
+      "lineno": 536,
+      "static": false,
+      "method_id": "prepareStatement",
+      "parent_id": 9,
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
+    },
+    {
+      "id": 11,
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Pet.java",
+      "event": "call",
+      "lineno": 65,
+      "static": false,
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Pet",
+        "value": "Pet{id=9, name='Lucky', birthDate=1999-08-06, type=5, owner=7}",
+        "object_id": 2075628489
+      },
+      "method_id": "getOwner",
+      "thread_id": 556,
+      "defined_class": "org.springframework.samples.petclinic.owner.Pet"
+    },
+    {
+      "id": 12,
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Pet.java",
+      "event": "return",
+      "lineno": 65,
+      "static": false,
+      "method_id": "getOwner",
+      "parent_id": 11,
+      "thread_id": 556,
+      "return_value": {
+        "class": "java.lang.Integer",
+        "value": "7",
+        "object_id": 1929919778
+      },
+      "defined_class": "org.springframework.samples.petclinic.owner.Pet"
+    },
+    {
+      "id": 13,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
+      "event": "call",
+      "lineno": 140,
+      "static": false,
+      "receiver": {
+        "class": "com.mchange.v2.c3p0.ComboPooledDataSource",
+        "value": "com.mchange.v2.c3p0.ComboPooledDataSource[ identityToken -> 1hge136ac1x0f595mu1co1|68e7e7a0, dataSourceName -> 1hge136ac1x0f595mu1co1|68e7e7a0 ]",
+        "object_id": 1760028576
+      },
+      "method_id": "getConnection",
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
+    },
+    {
+      "id": 14,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "call",
+      "lineno": 208,
+      "static": false,
+      "receiver": {
+        "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@5cdab556",
+        "object_id": 1557837142
+      },
+      "method_id": "getConnection",
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    },
+    {
+      "id": 15,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "return",
+      "lineno": 208,
+      "static": false,
+      "method_id": "getConnection",
+      "parent_id": 14,
+      "thread_id": 556,
+      "return_value": {
+        "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@1e3beb11 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@5ff6377d]",
+        "object_id": 507243281
+      },
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    },
+    {
+      "id": 16,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
+      "event": "return",
+      "lineno": 140,
+      "static": false,
+      "method_id": "getConnection",
+      "parent_id": 13,
+      "thread_id": 556,
+      "return_value": {
+        "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@1e3beb11 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@5ff6377d]",
+        "object_id": 507243281
+      },
+      "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
+    },
+    {
+      "id": 17,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
+      "event": "call",
+      "lineno": 536,
+      "static": false,
+      "method_id": "prepareStatement",
+      "sql_query": {
+        "sql": "SELECT `OWNER`.`ID` AS `ID`, `OWNER`.`CITY` AS `CITY`, `OWNER`.`ADDRESS` AS `ADDRESS`, `OWNER`.`LAST_NAME` AS `LAST_NAME`, `OWNER`.`TELEPHONE` AS `TELEPHONE`, `OWNER`.`FIRST_NAME` AS `FIRST_NAME` FROM `OWNER` WHERE `OWNER`.`ID` = ?",
+        "normalized": false,
+        "database_type": "MySQL",
+        "normalized_sql": "SELECT `OWNER`.`ID` AS `ID`, `OWNER`.`CITY` AS `CITY`, `OWNER`.`ADDRESS` AS `ADDRESS`, `OWNER`.`LAST_NAME` AS `LAST_NAME`, `OWNER`.`TELEPHONE` AS `TELEPHONE`, `OWNER`.`FIRST_NAME` AS `FIRST_NAME` FROM `OWNER` WHERE `OWNER`.`ID` = ?"
+      },
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
+    },
+    {
+      "id": 18,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
+      "event": "return",
+      "lineno": 536,
+      "static": false,
+      "method_id": "prepareStatement",
+      "parent_id": 17,
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
+    },
+    {
+      "id": 19,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
+      "event": "call",
+      "lineno": 140,
+      "static": false,
+      "receiver": {
+        "class": "com.mchange.v2.c3p0.ComboPooledDataSource",
+        "value": "com.mchange.v2.c3p0.ComboPooledDataSource[ identityToken -> 1hge136ac1x0f595mu1co1|68e7e7a0, dataSourceName -> 1hge136ac1x0f595mu1co1|68e7e7a0 ]",
+        "object_id": 1760028576
+      },
+      "method_id": "getConnection",
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
+    },
+    {
+      "id": 20,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "call",
+      "lineno": 208,
+      "static": false,
+      "receiver": {
+        "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@5cdab556",
+        "object_id": 1557837142
+      },
+      "method_id": "getConnection",
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    },
+    {
+      "id": 21,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "return",
+      "lineno": 208,
+      "static": false,
+      "method_id": "getConnection",
+      "parent_id": 20,
+      "thread_id": 556,
+      "return_value": {
+        "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@433e2251 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@5ff6377d]",
+        "object_id": 1128145489
+      },
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    },
+    {
+      "id": 22,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
+      "event": "return",
+      "lineno": 140,
+      "static": false,
+      "method_id": "getConnection",
+      "parent_id": 19,
+      "thread_id": 556,
+      "return_value": {
+        "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@433e2251 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@5ff6377d]",
+        "object_id": 1128145489
+      },
+      "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
+    },
+    {
+      "id": 23,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
+      "event": "call",
+      "lineno": 536,
+      "static": false,
+      "method_id": "prepareStatement",
+      "sql_query": {
+        "sql": "select * from visit where pet_id = ?",
+        "normalized": true,
+        "database_type": "MySQL",
+        "normalized_sql": "select * from visit where pet_id = ?"
+      },
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
+    },
+    {
+      "id": 24,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
+      "event": "return",
+      "lineno": 536,
+      "static": false,
+      "method_id": "prepareStatement",
+      "parent_id": 23,
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
+    },
+    {
+      "id": 25,
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
+      "event": "return",
+      "lineno": 74,
+      "static": false,
+      "method_id": "loadPetWithVisit",
+      "parent_id": 4,
+      "thread_id": 556,
+      "return_value": {
+        "class": "org.springframework.samples.petclinic.visit.Visit",
+        "value": "Visit{id=null, date=2020-10-05, description='null', petId=null}",
+        "object_id": 483593247
+      },
+      "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
+    },
+    {
+      "id": 26,
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
+      "event": "call",
+      "lineno": 59,
+      "static": false,
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.VisitController",
+        "value": "org.springframework.samples.petclinic.owner.VisitController@eb0d286",
+        "object_id": 246469254
+      },
+      "method_id": "setAllowedFields",
+      "thread_id": 556,
+      "parameters": [
+        {
+          "kind": "req",
+          "name": "dataBinder",
+          "class": "org.springframework.web.servlet.mvc.method.annotation.ExtendedServletRequestDataBinder",
+          "value": "org.springframework.web.servlet.mvc.method.annotation.ExtendedServletRequestDataBinder@7ff20493",
+          "object_id": 2146567315
+        }
+      ],
+      "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
+    },
+    {
+      "id": 27,
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
+      "event": "return",
+      "lineno": 59,
+      "static": false,
+      "method_id": "setAllowedFields",
+      "parent_id": 26,
+      "thread_id": 556,
+      "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
+    },
+    {
+      "id": 28,
+      "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
+      "event": "call",
+      "lineno": 53,
+      "static": false,
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.visit.Visit",
+        "value": "Visit{id=null, date=2020-10-05, description='null', petId=null}",
+        "object_id": 483593247
+      },
+      "method_id": "getDate",
+      "thread_id": 556,
+      "defined_class": "org.springframework.samples.petclinic.visit.Visit"
+    },
+    {
+      "id": 29,
+      "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
+      "event": "return",
+      "lineno": 53,
+      "static": false,
+      "method_id": "getDate",
+      "parent_id": 28,
+      "thread_id": 556,
+      "return_value": {
+        "class": "java.time.LocalDate",
+        "value": "2020-10-05",
+        "object_id": 92802791
+      },
+      "defined_class": "org.springframework.samples.petclinic.visit.Visit"
+    },
+    {
+      "id": 30,
+      "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
+      "event": "call",
+      "lineno": 57,
+      "static": false,
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.visit.Visit",
+        "value": "Visit{id=null, date=2020-09-12, description='null', petId=null}",
+        "object_id": 483593247
+      },
+      "method_id": "setDate",
+      "thread_id": 556,
+      "parameters": [
+        {
+          "kind": "req",
+          "name": "date",
+          "class": "java.time.LocalDate",
+          "value": "2020-09-12",
+          "object_id": 1540092183
+        }
+      ],
+      "defined_class": "org.springframework.samples.petclinic.visit.Visit"
+    },
+    {
+      "id": 31,
+      "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
+      "event": "return",
+      "lineno": 57,
+      "static": false,
+      "method_id": "setDate",
+      "parent_id": 30,
+      "thread_id": 556,
+      "defined_class": "org.springframework.samples.petclinic.visit.Visit"
+    },
+    {
+      "id": 32,
+      "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
+      "event": "call",
+      "lineno": 61,
+      "static": false,
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.visit.Visit",
+        "value": "Visit{id=null, date=2020-09-12, description='null', petId=null}",
+        "object_id": 483593247
+      },
+      "method_id": "getDescription",
+      "thread_id": 556,
+      "defined_class": "org.springframework.samples.petclinic.visit.Visit"
+    },
+    {
+      "id": 33,
+      "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
+      "event": "return",
+      "lineno": 61,
+      "static": false,
+      "method_id": "getDescription",
+      "parent_id": 32,
+      "thread_id": 556,
+      "defined_class": "org.springframework.samples.petclinic.visit.Visit"
+    },
+    {
+      "id": 34,
+      "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
+      "event": "call",
+      "lineno": 65,
+      "static": false,
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.visit.Visit",
+        "value": "Visit{id=null, date=2020-09-12, description='routine check up', petId=null}",
+        "object_id": 483593247
+      },
+      "method_id": "setDescription",
+      "thread_id": 556,
+      "parameters": [
+        {
+          "kind": "req",
+          "name": "description",
+          "class": "java.lang.String",
+          "value": "routine check up",
+          "object_id": 1522361550
+        }
+      ],
+      "defined_class": "org.springframework.samples.petclinic.visit.Visit"
+    },
+    {
+      "id": 35,
+      "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
+      "event": "return",
+      "lineno": 65,
+      "static": false,
+      "method_id": "setDescription",
+      "parent_id": 34,
+      "thread_id": 556,
+      "defined_class": "org.springframework.samples.petclinic.visit.Visit"
+    },
+    {
+      "id": 36,
+      "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
+      "event": "call",
+      "lineno": 69,
+      "static": false,
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.visit.Visit",
+        "value": "Visit{id=null, date=2020-09-12, description='routine check up', petId=null}",
+        "object_id": 483593247
+      },
+      "method_id": "getPetId",
+      "thread_id": 556,
+      "defined_class": "org.springframework.samples.petclinic.visit.Visit"
+    },
+    {
+      "id": 37,
+      "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
+      "event": "return",
+      "lineno": 69,
+      "static": false,
+      "method_id": "getPetId",
+      "parent_id": 36,
+      "thread_id": 556,
+      "defined_class": "org.springframework.samples.petclinic.visit.Visit"
+    },
+    {
+      "id": 38,
+      "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
+      "event": "call",
+      "lineno": 73,
+      "static": false,
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.visit.Visit",
+        "value": "Visit{id=null, date=2020-09-12, description='routine check up', petId=9}",
+        "object_id": 483593247
+      },
+      "method_id": "setPetId",
+      "thread_id": 556,
+      "parameters": [
+        {
+          "kind": "req",
+          "name": "petId",
+          "class": "java.lang.Integer",
+          "value": "9",
+          "object_id": 1916011657
+        }
+      ],
+      "defined_class": "org.springframework.samples.petclinic.visit.Visit"
+    },
+    {
+      "id": 39,
+      "path": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java",
+      "event": "return",
+      "lineno": 73,
+      "static": false,
+      "method_id": "setPetId",
+      "parent_id": 38,
+      "thread_id": 556,
+      "defined_class": "org.springframework.samples.petclinic.visit.Visit"
+    },
+    {
+      "id": 40,
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
+      "event": "call",
+      "lineno": 92,
+      "static": false,
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.VisitController",
+        "value": "org.springframework.samples.petclinic.owner.VisitController@eb0d286",
+        "object_id": 246469254
+      },
+      "method_id": "processNewVisitForm",
+      "thread_id": 556,
+      "parameters": [
+        {
+          "kind": "req",
+          "name": "visit",
+          "class": "org.springframework.samples.petclinic.visit.Visit",
+          "value": "Visit{id=null, date=2020-09-12, description='routine check up', petId=9}",
+          "object_id": 483593247
+        },
+        {
+          "kind": "req",
+          "name": "result",
+          "class": "org.springframework.validation.BeanPropertyBindingResult",
+          "value": "org.springframework.validation.BeanPropertyBindingResult: 0 errors",
+          "object_id": 1610399109
+        }
+      ],
+      "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
+    },
+    {
+      "id": 41,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
+      "event": "call",
+      "lineno": 140,
+      "static": false,
+      "receiver": {
+        "class": "com.mchange.v2.c3p0.ComboPooledDataSource",
+        "value": "com.mchange.v2.c3p0.ComboPooledDataSource[ identityToken -> 1hge136ac1x0f595mu1co1|68e7e7a0, dataSourceName -> 1hge136ac1x0f595mu1co1|68e7e7a0 ]",
+        "object_id": 1760028576
+      },
+      "method_id": "getConnection",
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
+    },
+    {
+      "id": 42,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "call",
+      "lineno": 208,
+      "static": false,
+      "receiver": {
+        "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@5cdab556",
+        "object_id": 1557837142
+      },
+      "method_id": "getConnection",
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    },
+    {
+      "id": 43,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "return",
+      "lineno": 208,
+      "static": false,
+      "method_id": "getConnection",
+      "parent_id": 42,
+      "thread_id": 556,
+      "return_value": {
+        "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@4f14f593 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@5ff6377d]",
+        "object_id": 1326773651
+      },
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    },
+    {
+      "id": 44,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java",
+      "event": "return",
+      "lineno": 140,
+      "static": false,
+      "method_id": "getConnection",
+      "parent_id": 41,
+      "thread_id": 556,
+      "return_value": {
+        "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@4f14f593 [wrapping: com.mysql.cj.jdbc.ConnectionImpl@5ff6377d]",
+        "object_id": 1326773651
+      },
+      "defined_class": "com.mchange.v2.c3p0.impl.AbstractPoolBackedDataSource"
+    },
+    {
+      "id": 45,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
+      "event": "call",
+      "lineno": 230,
+      "static": false,
+      "method_id": "prepareStatement",
+      "sql_query": {
+        "sql": "INSERT INTO `VISIT` (`DATE`, `DESCRIPTION`, `PET_ID`) VALUES (?, ?, ?)",
+        "normalized": false,
+        "database_type": "MySQL",
+        "normalized_sql": "INSERT INTO `VISIT` (`DATE`, `DESCRIPTION`, `PET_ID`) VALUES (?, ?, ?)"
+      },
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
+    },
+    {
+      "id": 46,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java",
+      "event": "return",
+      "lineno": 230,
+      "static": false,
+      "method_id": "prepareStatement",
+      "parent_id": 45,
+      "thread_id": 556,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewProxyConnection"
+    },
+    {
+      "id": 47,
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java",
+      "event": "return",
+      "lineno": 92,
+      "static": false,
+      "method_id": "processNewVisitForm",
+      "parent_id": 40,
+      "thread_id": 556,
+      "return_value": {
+        "class": "java.lang.String",
+        "value": "redirect:/owners/{ownerId}",
+        "object_id": 1188712385
+      },
+      "defined_class": "org.springframework.samples.petclinic.owner.VisitController"
+    },
+    {
+      "id": 48,
+      "event": "return",
+      "parent_id": 1,
+      "thread_id": 556,
+      "http_server_response": {
+        "status": 302
+      }
+    },
+    {
+      "id": 49,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "call",
+      "lineno": 208,
+      "static": false,
+      "receiver": {
+        "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@51bc8c24",
+        "object_id": 1371311140
+      },
+      "method_id": "getConnection",
+      "thread_id": 353,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    },
+    {
+      "id": 50,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "return",
+      "lineno": 208,
+      "static": false,
+      "method_id": "getConnection",
+      "parent_id": 49,
+      "thread_id": 353,
+      "return_value": {
+        "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@5aaea47c [wrapping: null]",
+        "object_id": 1521394812
+      },
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    },
+    {
+      "id": 51,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "call",
+      "lineno": 208,
+      "static": false,
+      "receiver": {
+        "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@5cdab556",
+        "object_id": 1557837142
+      },
+      "method_id": "getConnection",
+      "thread_id": 352,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    },
+    {
+      "id": 52,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "return",
+      "lineno": 208,
+      "static": false,
+      "method_id": "getConnection",
+      "parent_id": 51,
+      "thread_id": 352,
+      "return_value": {
+        "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@579eed0f [wrapping: null]",
+        "object_id": 1470033167
+      },
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    },
+    {
+      "id": 53,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "call",
+      "lineno": 208,
+      "static": false,
+      "receiver": {
+        "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@5cdab556",
+        "object_id": 1557837142
+      },
+      "method_id": "getConnection",
+      "thread_id": 353,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    },
+    {
+      "id": 54,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "return",
+      "lineno": 208,
+      "static": false,
+      "method_id": "getConnection",
+      "parent_id": 53,
+      "thread_id": 353,
+      "return_value": {
+        "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@47a0683c [wrapping: null]",
+        "object_id": 1201694780
+      },
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    },
+    {
+      "id": 55,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "call",
+      "lineno": 208,
+      "static": false,
+      "receiver": {
+        "class": "com.mchange.v2.c3p0.impl.NewPooledConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewPooledConnection@5cdab556",
+        "object_id": 1557837142
+      },
+      "method_id": "getConnection",
+      "thread_id": 352,
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    },
+    {
+      "id": 56,
+      "path": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java",
+      "event": "return",
+      "lineno": 208,
+      "static": false,
+      "method_id": "getConnection",
+      "parent_id": 55,
+      "thread_id": 352,
+      "return_value": {
+        "class": "com.mchange.v2.c3p0.impl.NewProxyConnection",
+        "value": "com.mchange.v2.c3p0.impl.NewProxyConnection@346f3e4c [wrapping: null]",
+        "object_id": 879705676
+      },
+      "defined_class": "com.mchange.v2.c3p0.impl.NewPooledConnection"
+    }
   ],
   "version": "1.2",
   "classMap": [
-      {
-          "name": "org",
+    {
+      "name": "org",
+      "type": "package",
+      "children": [
+        {
+          "name": "springframework",
           "type": "package",
           "children": [
-              {
-                  "name": "springframework",
+            {
+              "name": "samples",
+              "type": "package",
+              "children": [
+                {
+                  "name": "petclinic",
                   "type": "package",
                   "children": [
-                      {
-                          "name": "samples",
-                          "type": "package",
+                    {
+                      "name": "owner",
+                      "type": "package",
+                      "children": [
+                        {
+                          "name": "Pet",
+                          "type": "class",
+                          "static": false,
                           "children": [
-                              {
-                                  "name": "petclinic",
-                                  "type": "package",
-                                  "children": [
-                                      {
-                                          "name": "owner",
-                                          "type": "package",
-                                          "children": [
-                                              {
-                                                  "name": "Pet",
-                                                  "type": "class",
-                                                  "static": false,
-                                                  "children": [
-                                                      {
-                                                          "name": "getOwner",
-                                                          "type": "function",
-                                                          "static": false,
-                                                          "location": "src/main/java/org/springframework/samples/petclinic/owner/Pet.java:65",
-                                                          "display_name": "Get Owner",
-                                                          "labels": [
-                                                              "getter"
-                                                          ]
-                                                      }
-                                                  ],
-                                                  "location": "src/main/java/org/springframework/samples/petclinic/owner/Pet.java"
-                                              },
-                                              {
-                                                  "name": "VisitController",
-                                                  "type": "class",
-                                                  "static": false,
-                                                  "children": [
-                                                      {
-                                                          "name": "loadPetWithVisit",
-                                                          "type": "function",
-                                                          "static": false,
-                                                          "location": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java:74",
-                                                          "display_name": "Load Pet With Visit",
-                                                          "labels": [
-                                                              "action"
-                                                          ]
-                                                      },
-                                                      {
-                                                          "name": "setAllowedFields",
-                                                          "type": "function",
-                                                          "static": false,
-                                                          "location": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java:59",
-                                                          "display_name": "Set Allowed Fields For Visit",
-                                                          "labels": [
-                                                              "action"
-                                                          ]
-                                                      },
-                                                      {
-                                                          "name": "processNewVisitForm",
-                                                          "type": "function",
-                                                          "static": false,
-                                                          "location": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java:92",
-                                                          "display_name": "Process New Visit Form",
-                                                          "labels": [
-                                                              "action"
-                                                          ]
-                                                      }
-                                                  ],
-                                                  "location": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java"
-                                              }
-                                          ]
-                                      },
-                                      {
-                                          "name": "visit",
-                                          "type": "package",
-                                          "children": [
-                                              {
-                                                  "name": "Visit",
-                                                  "type": "class",
-                                                  "static": false,
-                                                  "children": [
-                                                      {
-                                                          "name": "setDate",
-                                                          "type": "function",
-                                                          "static": false,
-                                                          "location": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java:57",
-                                                          "display_name": "Set Date",
-                                                          "labels": [
-                                                              "setter"
-                                                          ]
-                                                      },
-                                                      {
-                                                          "name": "getPetId",
-                                                          "type": "function",
-                                                          "static": false,
-                                                          "location": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java:69",
-                                                          "display_name": "Get Pet Id",
-                                                          "labels": [
-                                                              "getter"
-                                                          ]
-                                                      },
-                                                      {
-                                                          "name": "setPetId",
-                                                          "type": "function",
-                                                          "static": false,
-                                                          "location": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java:73",
-                                                          "display_name": "Set Pet Id For Visit",
-                                                          "labels": [
-                                                              "action"
-                                                          ]
-                                                      },
-                                                      {
-                                                          "name": "getDescription",
-                                                          "type": "function",
-                                                          "static": false,
-                                                          "location": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java:61",
-                                                          "display_name": "Get Description",
-                                                          "labels": [
-                                                              "getter"
-                                                          ]
-                                                      },
-                                                      {
-                                                          "name": "setDescription",
-                                                          "type": "function",
-                                                          "static": false,
-                                                          "location": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java:65",
-                                                          "display_name": "Set Description",
-                                                          "labels": [
-                                                              "setter"
-                                                          ]
-                                                      },
-                                                      {
-                                                          "name": "getDate",
-                                                          "type": "function",
-                                                          "static": false,
-                                                          "location": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java:53",
-                                                          "display_name": "Get Date",
-                                                          "labels": [
-                                                              "getter"
-                                                          ]
-                                                      }
-                                                  ],
-                                                  "location": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java"
-                                              }
-                                          ]
-                                      }
-                                  ]
-                              }
-                          ]
-                      },
-                      {
-                          "name": "web",
-                          "type": "package",
+                            {
+                              "name": "getOwner",
+                              "type": "function",
+                              "static": false,
+                              "location": "src/main/java/org/springframework/samples/petclinic/owner/Pet.java:65",
+                              "display_name": "Get Owner",
+                              "labels": ["getter"]
+                            }
+                          ],
+                          "location": "src/main/java/org/springframework/samples/petclinic/owner/Pet.java"
+                        },
+                        {
+                          "name": "VisitController",
+                          "type": "class",
+                          "static": false,
                           "children": [
-                              {
-                                  "name": "filter",
-                                  "type": "package",
-                                  "children": [
-                                      {
-                                          "name": "OncePerRequestFilter",
-                                          "type": "class",
-                                          "static": false,
-                                          "children": [
-                                              {
-                                                  "name": "doFilter",
-                                                  "type": "function",
-                                                  "static": false,
-                                                  "location": "src/main/java/org/springframework/web/filter/OncePerRequestFilter.java:91",
-                                                  "display_name": "Do Filter",
-                                                  "labels": [
-                                                      "action"
-                                                  ]
-                                              }
-                                          ],
-                                          "location": "src/main/java/org/springframework/web/filter/OncePerRequestFilter.java"
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
+                            {
+                              "name": "loadPetWithVisit",
+                              "type": "function",
+                              "static": false,
+                              "location": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java:74",
+                              "display_name": "Load Pet With Visit",
+                              "labels": ["action"]
+                            },
+                            {
+                              "name": "setAllowedFields",
+                              "type": "function",
+                              "static": false,
+                              "location": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java:59",
+                              "display_name": "Set Allowed Fields For Visit",
+                              "labels": ["action"]
+                            },
+                            {
+                              "name": "processNewVisitForm",
+                              "type": "function",
+                              "static": false,
+                              "location": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java:92",
+                              "display_name": "Process New Visit Form",
+                              "labels": ["action"]
+                            }
+                          ],
+                          "location": "src/main/java/org/springframework/samples/petclinic/owner/VisitController.java"
+                        }
+                      ]
+                    },
+                    {
+                      "name": "visit",
+                      "type": "package",
+                      "children": [
+                        {
+                          "name": "Visit",
+                          "type": "class",
+                          "static": false,
+                          "children": [
+                            {
+                              "name": "setDate",
+                              "type": "function",
+                              "static": false,
+                              "location": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java:57",
+                              "display_name": "Set Date",
+                              "labels": ["setter"]
+                            },
+                            {
+                              "name": "getPetId",
+                              "type": "function",
+                              "static": false,
+                              "location": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java:69",
+                              "display_name": "Get Pet Id",
+                              "labels": ["getter"]
+                            },
+                            {
+                              "name": "setPetId",
+                              "type": "function",
+                              "static": false,
+                              "location": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java:73",
+                              "display_name": "Set Pet Id For Visit",
+                              "labels": ["action"]
+                            },
+                            {
+                              "name": "getDescription",
+                              "type": "function",
+                              "static": false,
+                              "location": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java:61",
+                              "display_name": "Get Description",
+                              "labels": ["getter"]
+                            },
+                            {
+                              "name": "setDescription",
+                              "type": "function",
+                              "static": false,
+                              "location": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java:65",
+                              "display_name": "Set Description",
+                              "labels": ["setter"]
+                            },
+                            {
+                              "name": "getDate",
+                              "type": "function",
+                              "static": false,
+                              "location": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java:53",
+                              "display_name": "Get Date",
+                              "labels": ["getter"]
+                            }
+                          ],
+                          "location": "src/main/java/org/springframework/samples/petclinic/visit/Visit.java"
+                        }
+                      ]
+                    }
                   ]
-              }
+                }
+              ]
+            },
+            {
+              "name": "web",
+              "type": "package",
+              "children": [
+                {
+                  "name": "filter",
+                  "type": "package",
+                  "children": [
+                    {
+                      "name": "OncePerRequestFilter",
+                      "type": "class",
+                      "static": false,
+                      "children": [
+                        {
+                          "name": "doFilter",
+                          "type": "function",
+                          "static": false,
+                          "location": "src/main/java/org/springframework/web/filter/OncePerRequestFilter.java:91",
+                          "display_name": "Do Filter",
+                          "labels": ["action"]
+                        }
+                      ],
+                      "location": "src/main/java/org/springframework/web/filter/OncePerRequestFilter.java"
+                    }
+                  ]
+                }
+              ]
+            }
           ]
-      },
-      {
-          "name": "com",
+        }
+      ]
+    },
+    {
+      "name": "com",
+      "type": "package",
+      "children": [
+        {
+          "name": "mchange",
           "type": "package",
           "children": [
-              {
-                  "name": "mchange",
+            {
+              "name": "v2",
+              "type": "package",
+              "children": [
+                {
+                  "name": "c3p0",
                   "type": "package",
                   "children": [
-                      {
-                          "name": "v2",
-                          "type": "package",
+                    {
+                      "name": "impl",
+                      "type": "package",
+                      "children": [
+                        {
+                          "name": "AbstractPoolBackedDataSource",
+                          "type": "class",
+                          "static": false,
                           "children": [
-                              {
-                                  "name": "c3p0",
-                                  "type": "package",
-                                  "children": [
-                                      {
-                                          "name": "impl",
-                                          "type": "package",
-                                          "children": [
-                                              {
-                                                  "name": "AbstractPoolBackedDataSource",
-                                                  "type": "class",
-                                                  "static": false,
-                                                  "children": [
-                                                      {
-                                                          "name": "getConnection",
-                                                          "type": "function",
-                                                          "static": false,
-                                                          "location": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java:140",
-                                                          "display_name": "Get Connection",
-                                                          "labels": [
-                                                              "getter"
-                                                          ]
-                                                      }
-                                                  ],
-                                                  "location": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java"
-                                              },
-                                              {
-                                                  "name": "NewPooledConnection",
-                                                  "type": "class",
-                                                  "static": false,
-                                                  "children": [
-                                                      {
-                                                          "name": "getConnection",
-                                                          "type": "function",
-                                                          "static": false,
-                                                          "location": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java:208",
-                                                          "display_name": "Get Connection",
-                                                          "labels": [
-                                                              "getter"
-                                                          ]
-                                                      }
-                                                  ],
-                                                  "location": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java"
-                                              },
-                                              {
-                                                  "name": "NewProxyConnection",
-                                                  "type": "class",
-                                                  "static": false,
-                                                  "children": [
-                                                      {
-                                                          "name": "prepareStatement",
-                                                          "type": "function",
-                                                          "static": false,
-                                                          "location": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java:536",
-                                                          "display_name": "Get New Proxy Connection Prepare Statement",
-                                                          "labels": [
-                                                              "getter"
-                                                          ]
-                                                      },
-                                                      {
-                                                          "name": "prepareStatement",
-                                                          "type": "function",
-                                                          "static": false,
-                                                          "location": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java:230",
-                                                          "display_name": "Get New Proxy Connection Prepare Statement",
-                                                          "labels": [
-                                                              "getter"
-                                                          ]
-                                                      }
-                                                  ],
-                                                  "location": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java"
-                                              }
-                                          ]
-                                      }
-                                  ]
-                              }
-                          ]
-                      }
+                            {
+                              "name": "getConnection",
+                              "type": "function",
+                              "static": false,
+                              "location": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java:140",
+                              "display_name": "Get Connection",
+                              "labels": ["getter"]
+                            }
+                          ],
+                          "location": "src/main/java/com/mchange/v2/c3p0/impl/AbstractPoolBackedDataSource.java"
+                        },
+                        {
+                          "name": "NewPooledConnection",
+                          "type": "class",
+                          "static": false,
+                          "children": [
+                            {
+                              "name": "getConnection",
+                              "type": "function",
+                              "static": false,
+                              "location": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java:208",
+                              "display_name": "Get Connection",
+                              "labels": ["getter"]
+                            }
+                          ],
+                          "location": "src/main/java/com/mchange/v2/c3p0/impl/NewPooledConnection.java"
+                        },
+                        {
+                          "name": "NewProxyConnection",
+                          "type": "class",
+                          "static": false,
+                          "children": [
+                            {
+                              "name": "prepareStatement",
+                              "type": "function",
+                              "static": false,
+                              "location": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java:536",
+                              "display_name": "Get New Proxy Connection Prepare Statement",
+                              "labels": ["getter"]
+                            },
+                            {
+                              "name": "prepareStatement",
+                              "type": "function",
+                              "static": false,
+                              "location": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java:230",
+                              "display_name": "Get New Proxy Connection Prepare Statement",
+                              "labels": ["getter"]
+                            }
+                          ],
+                          "location": "src/main/java/com/mchange/v2/c3p0/impl/NewProxyConnection.java"
+                        }
+                      ]
+                    }
                   ]
-              }
+                }
+              ]
+            }
           ]
-      }
+        }
+      ]
+    }
   ],
   "metadata": {
-      "app": "spring-petclinic",
-      "git": {
-          "branch": "master",
-          "commit": "0f5992e7392405700473699cac3543a862d6e1fd",
-          "repository": "https://github.com/spring-petclinic/spring-petclinic-data-jdbc.git"
-      },
-      "name": "Create Visit For Pet",
-      "client": {
-          "url": "https://github.com/appland/appmap-java",
-          "name": "appmap-java"
-      },
-      "language": {
-          "name": "java",
-          "engine": "OpenJDK 64-Bit Server VM",
-          "version": "11.0.8+11"
-      },
-      "recorder": {
-          "name": "remote_recording"
-      },
-      "framework": {},
-      "recording": {}
+    "app": "spring-petclinic",
+    "git": {
+      "branch": "master",
+      "commit": "0f5992e7392405700473699cac3543a862d6e1fd",
+      "repository": "https://github.com/spring-petclinic/spring-petclinic-data-jdbc.git"
+    },
+    "name": "Create Visit For Pet",
+    "client": {
+      "url": "https://github.com/appland/appmap-java",
+      "name": "appmap-java"
+    },
+    "language": {
+      "name": "java",
+      "engine": "OpenJDK 64-Bit Server VM",
+      "version": "11.0.8+11"
+    },
+    "recorder": {
+      "name": "remote_recording"
+    },
+    "framework": {},
+    "recording": {}
   }
 }

--- a/packages/models/src/codeObject.js
+++ b/packages/models/src/codeObject.js
@@ -260,48 +260,47 @@ export default class CodeObject {
     return obj;
   }
 
-  static constructDataFromEvent(event) {
-    const data = {};
-
+  static constructDataChainFromEvent(event) {
+    let elements;
     if (event.httpServerRequest) {
-      Object.assign(data, {
-        type: CodeObjectType.HTTP,
-        name: 'HTTP server requests',
-        children: [
-          {
-            type: CodeObjectType.ROUTE,
-            name: event.route,
-          },
-        ],
-      });
+      elements = [
+        {
+          type: CodeObjectType.HTTP,
+          name: 'HTTP server requests',
+        },
+        {
+          type: CodeObjectType.ROUTE,
+          name: event.route,
+        },
+      ];
     } else if (event.sqlQuery) {
-      Object.assign(data, {
-        type: CodeObjectType.DATABASE,
-        name: 'Database',
-        children: [
-          {
-            type: CodeObjectType.QUERY,
-            name: event.sqlQuery,
-          },
-        ],
-      });
+      elements = [
+        {
+          type: CodeObjectType.DATABASE,
+          name: 'Database',
+        },
+        {
+          type: CodeObjectType.QUERY,
+          name: event.sqlQuery,
+        },
+      ];
     } else {
-      Object.assign(data, {
-        type: CodeObjectType.CLASS,
-        name: event.definedClass,
-        children: [
-          {
-            type: CodeObjectType.FUNCTION,
-            name: event.methodId,
-            static: event.isStatic,
-            location: '',
-          },
-        ],
-      });
+      elements = [
+        {
+          type: CodeObjectType.CLASS,
+          name: event.definedClass,
+        },
+        {
+          type: CodeObjectType.FUNCTION,
+          name: event.methodId,
+          static: event.isStatic,
+          location: '',
+        },
+      ];
     }
 
     // Flag this object as having been created dynamically
-    const queue = [data];
+    const queue = [...elements];
     while (queue.length) {
       const obj = queue.pop();
       obj.dynamic = true;
@@ -310,7 +309,7 @@ export default class CodeObject {
       }
     }
 
-    return data;
+    return elements;
   }
 
   get inboundConnections() {

--- a/packages/models/tests/unit/fixtures/spring_petclinic.json
+++ b/packages/models/tests/unit/fixtures/spring_petclinic.json
@@ -1,973 +1,963 @@
 {
-    "version": "1.2",
-    "metadata": {
-        "name": "Owner controllers test init creation form",
-        "app": "land-of-apps/pet-clinic",
-        "feature": "Test init creation form",
-        "feature_group": "Owner controllers",
-        "language": {
-            "name": "java",
-            "version": "25.242-b08",
-            "engine": "OpenJDK 64-Bit Server VM"
-        },
-        "client": {
-            "name": "appmap-java",
-            "url": "https://github.com/appland/appmap-java"
-        },
-        "recorder": {
-            "name": "toggle_record_receiver"
-        },
-        "recording": {
-            "defined_class": "org.springframework.samples.petclinic.owner.OwnerControllerTests",
-            "method_id": "testInitCreationForm"
-        },
-        "framework": {
-            "name": "junit"
-        }
+  "version": "1.2",
+  "metadata": {
+    "name": "Owner controllers test init creation form",
+    "app": "land-of-apps/pet-clinic",
+    "feature": "Test init creation form",
+    "feature_group": "Owner controllers",
+    "language": {
+      "name": "java",
+      "version": "25.242-b08",
+      "engine": "OpenJDK 64-Bit Server VM"
     },
-    "events": [
+    "client": {
+      "name": "appmap-java",
+      "url": "https://github.com/appland/appmap-java"
+    },
+    "recorder": {
+      "name": "toggle_record_receiver"
+    },
+    "recording": {
+      "defined_class": "org.springframework.samples.petclinic.owner.OwnerControllerTests",
+      "method_id": "testInitCreationForm"
+    },
+    "framework": {
+      "name": "junit"
+    }
+  },
+  "events": [
+    {
+      "event": "call",
+      "http_server_request": {
+        "normalized_path_info": "/owners/new",
+        "path_info": "/owners/new",
+        "protocol": "HTTP/1.1",
+        "request_method": "GET"
+      },
+      "id": 600,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.OwnerController",
+      "event": "call",
+      "id": 607,
+      "lineno": 60,
+      "method_id": "initCreationForm",
+      "parameters": [
         {
-            "defined_class": "org.springframework.mock.web.MockFilterChain$ServletFilterProxy",
-            "event": "call",
-            "http_server_request": {
-                "normalized_path_info": "/owners/new",
-                "path_info": "/owners/new",
-                "protocol": "HTTP/1.1",
-                "request_method": "GET"
-            },
-            "id": 600,
-            "lineno": 167,
-            "method_id": "doFilter",
-            "path": "src/main/java/org/springframework/mock/web/MockFilterChain.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.OwnerController",
-            "event": "call",
-            "id": 607,
-            "lineno": 60,
-            "method_id": "initCreationForm",
-            "parameters": [
-                {
-                    "class": "org.springframework.validation.support.BindingAwareModelMap",
-                    "kind": "req",
-                    "name": "model",
-                    "object_id": 640093047,
-                    "value": "{owner=[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]}"
-                }
-            ],
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.OwnerController",
-                "object_id": 1144567906,
-                "value": "org.springframework.samples.petclinic.owner.OwnerController@4438b862"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.OwnerController",
-            "event": "return",
-            "id": 608,
-            "lineno": 60,
-            "method_id": "initCreationForm",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java",
-            "return_value": {
-                "class": "java.lang.String",
-                "object_id": 1576422186,
-                "value": "owners/createOrUpdateOwnerForm"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.OwnerController",
-            "event": "call",
-            "id": 609,
-            "lineno": 55,
-            "method_id": "setAllowedFields",
-            "parameters": [
-                {
-                    "class": "org.springframework.web.servlet.mvc.method.annotation.ExtendedServletRequestDataBinder",
-                    "kind": "req",
-                    "name": "dataBinder",
-                    "object_id": 414205222,
-                    "value": "org.springframework.web.servlet.mvc.method.annotation.ExtendedServletRequestDataBinder@18b04526"
-                }
-            ],
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.OwnerController",
-                "object_id": 1144567906,
-                "value": "org.springframework.samples.petclinic.owner.OwnerController@4438b862"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.OwnerController",
-            "event": "return",
-            "id": 610,
-            "lineno": 55,
-            "method_id": "setAllowedFields",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "call",
-            "id": 611,
-            "lineno": 39,
-            "method_id": "getFirstName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "return",
-            "id": 612,
-            "lineno": 39,
-            "method_id": "getFirstName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "call",
-            "id": 613,
-            "lineno": 39,
-            "method_id": "getFirstName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "return",
-            "id": 614,
-            "lineno": 39,
-            "method_id": "getFirstName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "call",
-            "id": 615,
-            "lineno": 39,
-            "method_id": "getFirstName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "return",
-            "id": 616,
-            "lineno": 39,
-            "method_id": "getFirstName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "call",
-            "id": 617,
-            "lineno": 39,
-            "method_id": "getFirstName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "return",
-            "id": 618,
-            "lineno": 39,
-            "method_id": "getFirstName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "call",
-            "id": 619,
-            "lineno": 47,
-            "method_id": "getLastName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "return",
-            "id": 620,
-            "lineno": 47,
-            "method_id": "getLastName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "call",
-            "id": 621,
-            "lineno": 47,
-            "method_id": "getLastName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "return",
-            "id": 622,
-            "lineno": 47,
-            "method_id": "getLastName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "call",
-            "id": 623,
-            "lineno": 47,
-            "method_id": "getLastName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "return",
-            "id": 624,
-            "lineno": 47,
-            "method_id": "getLastName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "call",
-            "id": 625,
-            "lineno": 47,
-            "method_id": "getLastName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "return",
-            "id": 626,
-            "lineno": 47,
-            "method_id": "getLastName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "call",
-            "id": 627,
-            "lineno": 66,
-            "method_id": "getAddress",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "return",
-            "id": 628,
-            "lineno": 66,
-            "method_id": "getAddress",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "call",
-            "id": 629,
-            "lineno": 66,
-            "method_id": "getAddress",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "return",
-            "id": 630,
-            "lineno": 66,
-            "method_id": "getAddress",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "call",
-            "id": 631,
-            "lineno": 66,
-            "method_id": "getAddress",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "return",
-            "id": 632,
-            "lineno": 66,
-            "method_id": "getAddress",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "call",
-            "id": 633,
-            "lineno": 66,
-            "method_id": "getAddress",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "return",
-            "id": 634,
-            "lineno": 66,
-            "method_id": "getAddress",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "call",
-            "id": 635,
-            "lineno": 74,
-            "method_id": "getCity",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "return",
-            "id": 636,
-            "lineno": 74,
-            "method_id": "getCity",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "call",
-            "id": 637,
-            "lineno": 74,
-            "method_id": "getCity",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "return",
-            "id": 638,
-            "lineno": 74,
-            "method_id": "getCity",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "call",
-            "id": 639,
-            "lineno": 74,
-            "method_id": "getCity",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "return",
-            "id": 640,
-            "lineno": 74,
-            "method_id": "getCity",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "call",
-            "id": 641,
-            "lineno": 74,
-            "method_id": "getCity",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "return",
-            "id": 642,
-            "lineno": 74,
-            "method_id": "getCity",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "call",
-            "id": 643,
-            "lineno": 82,
-            "method_id": "getTelephone",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "return",
-            "id": 644,
-            "lineno": 82,
-            "method_id": "getTelephone",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "call",
-            "id": 645,
-            "lineno": 82,
-            "method_id": "getTelephone",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "return",
-            "id": 646,
-            "lineno": 82,
-            "method_id": "getTelephone",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "call",
-            "id": 647,
-            "lineno": 82,
-            "method_id": "getTelephone",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "return",
-            "id": 648,
-            "lineno": 82,
-            "method_id": "getTelephone",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "call",
-            "id": 649,
-            "lineno": 82,
-            "method_id": "getTelephone",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "return",
-            "id": 650,
-            "lineno": 82,
-            "method_id": "getTelephone",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.BaseEntity",
-            "event": "call",
-            "id": 651,
-            "lineno": 48,
-            "method_id": "isNew",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.BaseEntity",
-            "event": "return",
-            "id": 652,
-            "lineno": 48,
-            "method_id": "isNew",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java",
-            "return_value": {
-                "class": "java.lang.Boolean",
-                "object_id": 1358150250,
-                "value": "true"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.mock.web.MockFilterChain$ServletFilterProxy",
-            "event": "return",
-            "http_server_response": {
-                "mime_type": "text/html;charset=UTF-8",
-                "status": 200
-            },
-            "id": 653,
-            "lineno": 167,
-            "method_id": "doFilter",
-            "path": "src/main/java/org/springframework/mock/web/MockFilterChain.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "call",
-            "id": 654,
-            "lineno": 143,
-            "method_id": "toString",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.BaseEntity",
-            "event": "call",
-            "id": 655,
-            "lineno": 40,
-            "method_id": "getId",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.BaseEntity",
-            "event": "return",
-            "id": 656,
-            "lineno": 40,
-            "method_id": "getId",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.BaseEntity",
-            "event": "call",
-            "id": 657,
-            "lineno": 48,
-            "method_id": "isNew",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.BaseEntity",
-            "event": "return",
-            "id": 658,
-            "lineno": 48,
-            "method_id": "isNew",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java",
-            "return_value": {
-                "class": "java.lang.Boolean",
-                "object_id": 832219630,
-                "value": "true"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "call",
-            "id": 659,
-            "lineno": 47,
-            "method_id": "getLastName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "return",
-            "id": 660,
-            "lineno": 47,
-            "method_id": "getLastName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "call",
-            "id": 661,
-            "lineno": 39,
-            "method_id": "getFirstName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "receiver": {
-                "class": "org.springframework.samples.petclinic.owner.Owner",
-                "object_id": 192973557,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.model.Person",
-            "event": "return",
-            "id": 662,
-            "lineno": 39,
-            "method_id": "getFirstName",
-            "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-            "static": false,
-            "thread_id": 1
-        },
-        {
-            "defined_class": "org.springframework.samples.petclinic.owner.Owner",
-            "event": "return",
-            "id": 663,
-            "lineno": 143,
-            "method_id": "toString",
-            "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-            "return_value": {
-                "class": "java.lang.String",
-                "object_id": 494956006,
-                "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
-            },
-            "static": false,
-            "thread_id": 1
+          "class": "org.springframework.validation.support.BindingAwareModelMap",
+          "kind": "req",
+          "name": "model",
+          "object_id": 640093047,
+          "value": "{owner=[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]}"
         }
-    ],
-    "classMap": [
+      ],
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.OwnerController",
+        "object_id": 1144567906,
+        "value": "org.springframework.samples.petclinic.owner.OwnerController@4438b862"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.OwnerController",
+      "event": "return",
+      "id": 608,
+      "lineno": 60,
+      "method_id": "initCreationForm",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java",
+      "return_value": {
+        "class": "java.lang.String",
+        "object_id": 1576422186,
+        "value": "owners/createOrUpdateOwnerForm"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.OwnerController",
+      "event": "call",
+      "id": 609,
+      "lineno": 55,
+      "method_id": "setAllowedFields",
+      "parameters": [
         {
-            "children": [
+          "class": "org.springframework.web.servlet.mvc.method.annotation.ExtendedServletRequestDataBinder",
+          "kind": "req",
+          "name": "dataBinder",
+          "object_id": 414205222,
+          "value": "org.springframework.web.servlet.mvc.method.annotation.ExtendedServletRequestDataBinder@18b04526"
+        }
+      ],
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.OwnerController",
+        "object_id": 1144567906,
+        "value": "org.springframework.samples.petclinic.owner.OwnerController@4438b862"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.OwnerController",
+      "event": "return",
+      "id": 610,
+      "lineno": 55,
+      "method_id": "setAllowedFields",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "call",
+      "id": 611,
+      "lineno": 39,
+      "method_id": "getFirstName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "return",
+      "id": 612,
+      "lineno": 39,
+      "method_id": "getFirstName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "call",
+      "id": 613,
+      "lineno": 39,
+      "method_id": "getFirstName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "return",
+      "id": 614,
+      "lineno": 39,
+      "method_id": "getFirstName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "call",
+      "id": 615,
+      "lineno": 39,
+      "method_id": "getFirstName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "return",
+      "id": 616,
+      "lineno": 39,
+      "method_id": "getFirstName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "call",
+      "id": 617,
+      "lineno": 39,
+      "method_id": "getFirstName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "return",
+      "id": 618,
+      "lineno": 39,
+      "method_id": "getFirstName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "call",
+      "id": 619,
+      "lineno": 47,
+      "method_id": "getLastName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "return",
+      "id": 620,
+      "lineno": 47,
+      "method_id": "getLastName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "call",
+      "id": 621,
+      "lineno": 47,
+      "method_id": "getLastName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "return",
+      "id": 622,
+      "lineno": 47,
+      "method_id": "getLastName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "call",
+      "id": 623,
+      "lineno": 47,
+      "method_id": "getLastName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "return",
+      "id": 624,
+      "lineno": 47,
+      "method_id": "getLastName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "call",
+      "id": 625,
+      "lineno": 47,
+      "method_id": "getLastName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "return",
+      "id": 626,
+      "lineno": 47,
+      "method_id": "getLastName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "call",
+      "id": 627,
+      "lineno": 66,
+      "method_id": "getAddress",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "return",
+      "id": 628,
+      "lineno": 66,
+      "method_id": "getAddress",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "call",
+      "id": 629,
+      "lineno": 66,
+      "method_id": "getAddress",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "return",
+      "id": 630,
+      "lineno": 66,
+      "method_id": "getAddress",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "call",
+      "id": 631,
+      "lineno": 66,
+      "method_id": "getAddress",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "return",
+      "id": 632,
+      "lineno": 66,
+      "method_id": "getAddress",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "call",
+      "id": 633,
+      "lineno": 66,
+      "method_id": "getAddress",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "return",
+      "id": 634,
+      "lineno": 66,
+      "method_id": "getAddress",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "call",
+      "id": 635,
+      "lineno": 74,
+      "method_id": "getCity",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "return",
+      "id": 636,
+      "lineno": 74,
+      "method_id": "getCity",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "call",
+      "id": 637,
+      "lineno": 74,
+      "method_id": "getCity",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "return",
+      "id": 638,
+      "lineno": 74,
+      "method_id": "getCity",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "call",
+      "id": 639,
+      "lineno": 74,
+      "method_id": "getCity",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "return",
+      "id": 640,
+      "lineno": 74,
+      "method_id": "getCity",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "call",
+      "id": 641,
+      "lineno": 74,
+      "method_id": "getCity",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "return",
+      "id": 642,
+      "lineno": 74,
+      "method_id": "getCity",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "call",
+      "id": 643,
+      "lineno": 82,
+      "method_id": "getTelephone",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "return",
+      "id": 644,
+      "lineno": 82,
+      "method_id": "getTelephone",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "call",
+      "id": 645,
+      "lineno": 82,
+      "method_id": "getTelephone",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "return",
+      "id": 646,
+      "lineno": 82,
+      "method_id": "getTelephone",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "call",
+      "id": 647,
+      "lineno": 82,
+      "method_id": "getTelephone",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "return",
+      "id": 648,
+      "lineno": 82,
+      "method_id": "getTelephone",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "call",
+      "id": 649,
+      "lineno": 82,
+      "method_id": "getTelephone",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "return",
+      "id": 650,
+      "lineno": 82,
+      "method_id": "getTelephone",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.BaseEntity",
+      "event": "call",
+      "id": 651,
+      "lineno": 48,
+      "method_id": "isNew",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.BaseEntity",
+      "event": "return",
+      "id": 652,
+      "lineno": 48,
+      "method_id": "isNew",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1358150250,
+        "value": "true"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "event": "return",
+      "http_server_response": {
+        "mime_type": "text/html;charset=UTF-8",
+        "status": 200
+      },
+      "id": 653,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "call",
+      "id": 654,
+      "lineno": 143,
+      "method_id": "toString",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.BaseEntity",
+      "event": "call",
+      "id": 655,
+      "lineno": 40,
+      "method_id": "getId",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.BaseEntity",
+      "event": "return",
+      "id": 656,
+      "lineno": 40,
+      "method_id": "getId",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.BaseEntity",
+      "event": "call",
+      "id": 657,
+      "lineno": 48,
+      "method_id": "isNew",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.BaseEntity",
+      "event": "return",
+      "id": 658,
+      "lineno": 48,
+      "method_id": "isNew",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 832219630,
+        "value": "true"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "call",
+      "id": 659,
+      "lineno": 47,
+      "method_id": "getLastName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "return",
+      "id": 660,
+      "lineno": 47,
+      "method_id": "getLastName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "call",
+      "id": 661,
+      "lineno": 39,
+      "method_id": "getFirstName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "receiver": {
+        "class": "org.springframework.samples.petclinic.owner.Owner",
+        "object_id": 192973557,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.model.Person",
+      "event": "return",
+      "id": 662,
+      "lineno": 39,
+      "method_id": "getFirstName",
+      "path": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+      "static": false,
+      "thread_id": 1
+    },
+    {
+      "defined_class": "org.springframework.samples.petclinic.owner.Owner",
+      "event": "return",
+      "id": 663,
+      "lineno": 143,
+      "method_id": "toString",
+      "path": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+      "return_value": {
+        "class": "java.lang.String",
+        "object_id": 494956006,
+        "value": "[Owner@b808af5 id = [null], new = true, lastName = [null], firstName = [null], address = [null], city = [null], telephone = [null]]"
+      },
+      "static": false,
+      "thread_id": 1
+    }
+  ],
+  "classMap": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
                 {
-                    "children": [
+                  "children": [
+                    {
+                      "children": [
                         {
-                            "children": [
-                                {
-                                    "children": [
-                                        {
-                                            "children": [
-                                                {
-                                                    "children": [],
-                                                    "location": "src/main/java/org/springframework/mock/web/MockFilterChain.java:167",
-                                                    "name": "doFilter",
-                                                    "static": false,
-                                                    "type": "function"
-                                                }
-                                            ],
-                                            "location": "src/main/java/org/springframework/mock/web/MockFilterChain.java",
-                                            "name": "MockFilterChain$ServletFilterProxy",
-                                            "static": true,
-                                            "type": "class"
-                                        }
-                                    ],
-                                    "location": "",
-                                    "name": "web",
-                                    "type": "package"
-                                }
-                            ],
-                            "location": "",
-                            "name": "mock",
-                            "type": "package"
+                          "children": [],
+                          "location": "src/main/java/org/springframework/mock/web/MockFilterChain.java:167",
+                          "name": "doFilter",
+                          "static": false,
+                          "type": "function"
+                        }
+                      ],
+                      "location": "src/main/java/org/springframework/mock/web/MockFilterChain.java",
+                      "name": "MockFilterChain$ServletFilterProxy",
+                      "static": true,
+                      "type": "class"
+                    }
+                  ],
+                  "location": "",
+                  "name": "web",
+                  "type": "package"
+                }
+              ],
+              "location": "",
+              "name": "mock",
+              "type": "package"
+            },
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java:60",
+                              "name": "initCreationForm",
+                              "static": false,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java:55",
+                              "name": "setAllowedFields",
+                              "static": false,
+                              "type": "function"
+                            }
+                          ],
+                          "location": "src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java",
+                          "name": "OwnerController",
+                          "static": false,
+                          "type": "class"
                         },
                         {
-                            "children": [
-                                {
-                                    "children": [
-                                        {
-                                            "children": [
-                                                {
-                                                    "children": [
-                                                        {
-                                                            "children": [],
-                                                            "location": "src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java:60",
-                                                            "name": "initCreationForm",
-                                                            "static": false,
-                                                            "type": "function"
-                                                        },
-                                                        {
-                                                            "children": [],
-                                                            "location": "src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java:55",
-                                                            "name": "setAllowedFields",
-                                                            "static": false,
-                                                            "type": "function"
-                                                        }
-                                                    ],
-                                                    "location": "src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java",
-                                                    "name": "OwnerController",
-                                                    "static": false,
-                                                    "type": "class"
-                                                },
-                                                {
-                                                    "children": [
-                                                        {
-                                                            "children": [],
-                                                            "location": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java:66",
-                                                            "name": "getAddress",
-                                                            "static": false,
-                                                            "type": "function"
-                                                        },
-                                                        {
-                                                            "children": [],
-                                                            "location": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java:74",
-                                                            "name": "getCity",
-                                                            "static": false,
-                                                            "type": "function"
-                                                        },
-                                                        {
-                                                            "children": [],
-                                                            "location": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java:82",
-                                                            "name": "getTelephone",
-                                                            "static": false,
-                                                            "type": "function"
-                                                        },
-                                                        {
-                                                            "children": [],
-                                                            "location": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java:143",
-                                                            "name": "toString",
-                                                            "static": false,
-                                                            "type": "function"
-                                                        }
-                                                    ],
-                                                    "location": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
-                                                    "name": "Owner",
-                                                    "static": false,
-                                                    "type": "class"
-                                                }
-                                            ],
-                                            "location": "",
-                                            "name": "owner",
-                                            "type": "package"
-                                        },
-                                        {
-                                            "children": [
-                                                {
-                                                    "children": [
-                                                        {
-                                                            "children": [],
-                                                            "location": "src/main/java/org/springframework/samples/petclinic/model/Person.java:39",
-                                                            "name": "getFirstName",
-                                                            "static": false,
-                                                            "type": "function"
-                                                        },
-                                                        {
-                                                            "children": [],
-                                                            "location": "src/main/java/org/springframework/samples/petclinic/model/Person.java:47",
-                                                            "name": "getLastName",
-                                                            "static": false,
-                                                            "type": "function"
-                                                        }
-                                                    ],
-                                                    "location": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
-                                                    "name": "Person",
-                                                    "static": false,
-                                                    "type": "class"
-                                                },
-                                                {
-                                                    "children": [
-                                                        {
-                                                            "children": [],
-                                                            "location": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java:48",
-                                                            "name": "isNew",
-                                                            "static": false,
-                                                            "type": "function"
-                                                        },
-                                                        {
-                                                            "children": [],
-                                                            "location": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java:40",
-                                                            "name": "getId",
-                                                            "static": false,
-                                                            "type": "function"
-                                                        }
-                                                    ],
-                                                    "location": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java",
-                                                    "name": "BaseEntity",
-                                                    "static": false,
-                                                    "type": "class"
-                                                }
-                                            ],
-                                            "location": "",
-                                            "name": "model",
-                                            "type": "package"
-                                        }
-                                    ],
-                                    "location": "",
-                                    "name": "petclinic",
-                                    "type": "package"
-                                }
-                            ],
-                            "location": "",
-                            "name": "samples",
-                            "type": "package"
+                          "children": [
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java:66",
+                              "name": "getAddress",
+                              "static": false,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java:74",
+                              "name": "getCity",
+                              "static": false,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java:82",
+                              "name": "getTelephone",
+                              "static": false,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java:143",
+                              "name": "toString",
+                              "static": false,
+                              "type": "function"
+                            }
+                          ],
+                          "location": "src/main/java/org/springframework/samples/petclinic/owner/Owner.java",
+                          "name": "Owner",
+                          "static": false,
+                          "type": "class"
                         }
-                    ],
-                    "location": "",
-                    "name": "springframework",
-                    "type": "package"
+                      ],
+                      "location": "",
+                      "name": "owner",
+                      "type": "package"
+                    },
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/springframework/samples/petclinic/model/Person.java:39",
+                              "name": "getFirstName",
+                              "static": false,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/springframework/samples/petclinic/model/Person.java:47",
+                              "name": "getLastName",
+                              "static": false,
+                              "type": "function"
+                            }
+                          ],
+                          "location": "src/main/java/org/springframework/samples/petclinic/model/Person.java",
+                          "name": "Person",
+                          "static": false,
+                          "type": "class"
+                        },
+                        {
+                          "children": [
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java:48",
+                              "name": "isNew",
+                              "static": false,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java:40",
+                              "name": "getId",
+                              "static": false,
+                              "type": "function"
+                            }
+                          ],
+                          "location": "src/main/java/org/springframework/samples/petclinic/model/BaseEntity.java",
+                          "name": "BaseEntity",
+                          "static": false,
+                          "type": "class"
+                        }
+                      ],
+                      "location": "",
+                      "name": "model",
+                      "type": "package"
+                    }
+                  ],
+                  "location": "",
+                  "name": "petclinic",
+                  "type": "package"
                 }
-            ],
-            "location": "",
-            "name": "org",
-            "type": "package"
+              ],
+              "location": "",
+              "name": "samples",
+              "type": "package"
+            }
+          ],
+          "location": "",
+          "name": "springframework",
+          "type": "package"
         }
-    ]
+      ],
+      "location": "",
+      "name": "org",
+      "type": "package"
+    }
+  ]
 }


### PR DESCRIPTION
Improve the performance and correctness of the code which binds events to code objects.

When loading many AppMaps, the `O(N*M)` nature of event registration was a problem. 

Scanning all code objects (M) for every event (N) is the issue: https://github.com/applandinc/appmap-js/pull/239/files#diff-2208f30747bef29ba042cc56931d47112b3bf25d8b47d9760ad31178e249a5e8L84
