### PR TITLE
fix: "no data" screen is rendered inside it's parent

### DIFF
--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -473,6 +473,7 @@ code {
 }
 
 #app {
+  position: relative;
   display: grid;
   grid-template-columns: auto 1fr;
   grid-template-rows: 100%;


### PR DESCRIPTION
CSS property `position: relative;` was missing on `#app`, that's why "no data" notice was rendered full-screen.

Before:
![image](https://user-images.githubusercontent.com/17301016/120542367-5e9fc200-c42e-11eb-8167-e5b1406070d0.png)

After:
![image](https://user-images.githubusercontent.com/17301016/120542394-66f7fd00-c42e-11eb-85aa-2352f244dce1.png)

Fixes: #240 