### PR TITLE
fix: Trace node panning now guarantees that the selected node ends in the viewport

### DIFF
--- a/packages/components/src/components/Container.vue
+++ b/packages/components/src/components/Container.vue
@@ -28,6 +28,9 @@ export default {
     };
   },
   methods: {
+    translateTo(x, y) {
+      this.container.translateTo(x, y);
+    },
     panToElement(element) {
       panToNode(this.container, element);
     },

--- a/packages/components/src/components/DiagramTrace.vue
+++ b/packages/components/src/components/DiagramTrace.vue
@@ -23,6 +23,7 @@
 import VTrace from '@/components/trace/Trace.vue';
 import VContainer from '@/components/Container.vue';
 import { VIEW_FLOW, SELECT_OBJECT, CLEAR_OBJECT_STACK } from '@/store/vsCode';
+import { getParentRelativeOffset } from '@appland/diagrams';
 
 export default {
   name: 'v-diagram-trace',
@@ -87,11 +88,19 @@ export default {
       }, 16);
     },
 
-    focusSelector(selector) {
-      const element = this.$el.querySelector(selector);
-      if (element) {
-        this.$refs.container.panToElement(element);
-      }
+    focusFocused() {
+      setTimeout(() => {
+        const { container } = this.$refs;
+        const element = container.$el.querySelector('.trace-node.focused');
+        if (!element) {
+          return;
+        }
+
+        const coords = getParentRelativeOffset(element, this.$refs.trace);
+
+        container.setScaleTarget(element);
+        container.translateTo(coords.left, coords.top);
+      }, 16);
     },
 
     onClickEvent(event) {

--- a/packages/components/src/components/trace/TraceNode.vue
+++ b/packages/components/src/components/trace/TraceNode.vue
@@ -135,7 +135,7 @@ $bg-color: $gray2;
 
   &.focused {
     outline: 4px solid transparent;
-    animation: node-focused 1s ease-out 0.3s;
+    animation: node-focused 2s ease-out 0.3s;
   }
 
   &__header {

--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -230,9 +230,7 @@ export default {
         if (event) {
           this.setView(VIEW_FLOW);
           this.$nextTick(() => {
-            this.$refs.diagramFlow.focusSelector(
-              `[data-event-id="${event.id}"]`
-            );
+            this.$refs.diagramFlow.focusFocused();
           });
         }
       },

--- a/packages/components/tests/e2e/specs/vsCodeExtension.spec.js
+++ b/packages/components/tests/e2e/specs/vsCodeExtension.spec.js
@@ -524,6 +524,24 @@ context('VS Code Extension', () => {
         .invoke('text')
         .should('not.match', /SELECT.*FROM/);
     });
+
+    it('pans to the correct location when previewing events in the trace view', () => {
+      cy.get(
+        '.node.class[data-id="active_support/ActiveSupport::SecurityUtils"]'
+      ).click();
+
+      cy.get('.v-details-panel-list')
+        .contains('Outbound connections')
+        .parent()
+        .within(() => {
+          cy.get('.list-item').contains('Digest::Instance#digest').click();
+        });
+
+      cy.get('.list-item__event-quickview').each((el) => {
+        cy.wrap(el).click();
+        cy.get('.trace-node.focused').should('be.visible');
+      });
+    });
   });
 
   context('Java appmap', () => {

--- a/packages/diagrams/src/util.js
+++ b/packages/diagrams/src/util.js
@@ -47,14 +47,30 @@ function nodeFullyVisible(viewport, node) {
   );
 }
 
-function getParentRelativeOffset(element, parent) {
+export function getParentRelativeOffset(element, parent) {
   const offset = {
     left: 0,
     top: 0,
   };
 
   let child = element;
-  while (child !== parent) {
+  while (child && child !== parent) {
+    offset.left += child.offsetLeft;
+    offset.top += child.offsetTop;
+    child = child.offsetParent;
+  }
+
+  return offset;
+}
+
+function getParentOffset(element, parent) {
+  const offset = {
+    left: 0,
+    top: 0,
+  };
+
+  let child = element;
+  while (child && child !== parent) {
     offset.left += child.offsetLeft;
     offset.top += child.offsetTop;
     child = child.parentNode;
@@ -70,7 +86,7 @@ export function panToNode(viewport, node) {
     return;
   }
 
-  const offset = getParentRelativeOffset(node, viewport.element);
+  const offset = getParentOffset(node, viewport.element);
   const nodeRect = node.getBoundingClientRect();
 
   viewport.translateTo(


### PR DESCRIPTION
Tweening the viewport to focus on nodes was behaving unexpectedly, leaving many nodes clipped or completely outside of the viewport.

https://github.com/applandinc/appmap-js/issues/251