### PR TITLE
feat: Fingerprint fixes

### DIFF
--- a/packages/cli/src/cli.js
+++ b/packages/cli/src/cli.js
@@ -358,8 +358,20 @@ yargs(process.argv.slice(2))
     async (argv) => {
       verbose(argv.verbose);
 
-      const newProgress = () =>
-        new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
+      const newProgress = () => {
+        if (argv.interactive) {
+          return new cliProgress.SingleBar(
+            {},
+            cliProgress.Presets.shades_classic
+          );
+        }
+
+        return {
+          increment: () => {},
+          start: () => {},
+          stop: () => {},
+        };
+      };
 
       console.warn('Indexing the AppMap database');
       await new FingerprintDirectoryCommand(argv.appmapDir)

--- a/packages/cli/src/cli.js
+++ b/packages/cli/src/cli.js
@@ -361,6 +361,11 @@ yargs(process.argv.slice(2))
       const newProgress = () =>
         new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
 
+      console.warn('Indexing the AppMap database');
+      await new FingerprintDirectoryCommand(argv.appmapDir)
+        .setPrint(argv.print)
+        .execute();
+
       console.warn('Finding matching AppMaps');
       let progress = newProgress();
       const codeObjectId = argv.codeObject;

--- a/packages/cli/src/fingerprint/algorithms.js
+++ b/packages/cli/src/fingerprint/algorithms.js
@@ -3,27 +3,6 @@ function notNull(event) {
   return event !== null && event !== undefined;
 }
 
-function compareEvents(first, second) {
-  const diff = first.kind.localeCompare(second.kind);
-  if (diff !== 0) {
-    return diff;
-  }
-
-  return JSON.stringify(first).localeCompare(JSON.stringify(second));
-}
-
-function uniqueEvents() {
-  const set = new Set();
-  return (event) => {
-    const eventStr = JSON.stringify(event, null, 2);
-    if (!set.has(eventStr)) {
-      set.add(eventStr);
-      return event;
-    }
-    return null;
-  };
-}
-
 function buildTree(events) {
   const eventsById = events
     .filter((event) => event.id)
@@ -74,7 +53,5 @@ function buildTree(events) {
 
 module.exports = {
   notNull,
-  compareEvents,
-  uniqueEvents,
   buildTree,
 };

--- a/packages/cli/src/fingerprint/canonicalize/base.js
+++ b/packages/cli/src/fingerprint/canonicalize/base.js
@@ -1,8 +1,19 @@
 const { buildTree, notNull } = require('../algorithms');
 
+const BLACKLISTED_LABELS = new Set([
+  'format.json.generate',
+  'format.yaml.generate',
+  'http.session.read',
+]);
+
 module.exports = class {
   constructor(appmap) {
     this.appmap = appmap;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  whitelistedLabels(labels) {
+    return [...labels].filter((label) => !BLACKLISTED_LABELS.has(label));
   }
 
   execute() {
@@ -10,17 +21,35 @@ module.exports = class {
       .filter((event) => event.isCall())
       .map(this.transform.bind(this))
       .filter(notNull);
+
     return buildTree(events);
   }
 
   transform(event) {
-    if (event.sql) {
-      return this.sql(event);
-    }
-    if (event.httpServerRequest) {
-      return this.httpServerRequest(event);
+    const buildEvent = () => {
+      if (event.sql) {
+        return this.sql(event);
+      }
+      if (event.httpServerRequest) {
+        return this.httpServerRequest(event);
+      }
+      if (event.httpClientRequest) {
+        return this.httpClientRequest(event);
+      }
+
+      return this.functionCall(event);
+    };
+
+    const result = buildEvent();
+    if (!result) {
+      return null;
     }
 
-    return this.functionCall(event);
+    result.id = event.id;
+    if (event.parent) {
+      result.parent_id = event.parent.id;
+    }
+    result.depth = event.depth;
+    return result;
   }
 };

--- a/packages/cli/src/fingerprint/canonicalize/info_v1.js
+++ b/packages/cli/src/fingerprint/canonicalize/info_v1.js
@@ -9,33 +9,45 @@ const Base = require('./base');
 class Canonicalize extends Base {
   sql(event) {
     return {
-      id: event.id,
-      parent_id: event.parent ? event.parent.id : null,
       kind: 'sql',
-      sql: analyzeQuery(event.sql),
+      sql: {
+        analyzed_query: analyzeQuery(event.sql),
+      },
+    };
+  }
+
+  httpClientRequest(event) {
+    return {
+      kind: 'http_client_request',
+      route: event.route,
+      parameter_names: event.message ? event.message.map((m) => m.name) : null,
+      status_code: event.httpClientResponse
+        ? event.httpClientResponse.status_code
+        : null,
     };
   }
 
   httpServerRequest(event) {
     return {
-      id: event.id,
-      parent_id: event.parent ? event.parent.id : null,
       kind: 'http_server_request',
       route: event.route,
-      status: event.httpServerResponse ? event.httpServerResponse.status : null,
+      parameter_names: event.message ? event.message.map((m) => m.name) : null,
+      status_code: event.httpServerResponse
+        ? event.httpServerResponse.status ||
+          event.httpServerResponse.status_code
+        : null,
     };
   }
 
   functionCall(event) {
-    if (event.codeObject.labels.size === 0) {
+    const labels = this.whitelistedLabels(event.codeObject.labels);
+    if (labels.length === 0) {
       return null;
     }
 
     return {
-      id: event.id,
-      parent_id: event.parent ? event.parent.id : null,
       kind: 'function',
-      labels: [...event.codeObject.labels],
+      labels,
     };
   }
 }

--- a/packages/cli/src/fingerprint/canonicalize/trace_v1.js
+++ b/packages/cli/src/fingerprint/canonicalize/trace_v1.js
@@ -1,41 +1,52 @@
 /* eslint-disable class-methods-use-this */
-const { analyzeQuery } = require('../../database');
+const { obfuscate, analyzeQuery } = require('../../database');
 const Base = require('./base');
 
 /**
- * At DEBUG level, the order of labeled function calls matters, and all function class
- * and method names are retained. SQL queries are also retained in order.
+ * At TRACE level, the order of labeled function calls matters, and all function class
+ * and method names are retained. SQL queries are also retained in order. HTTP
+ * server and client request parameters are retained.
  */
 class Canonicalize extends Base {
   sql(event) {
-    return {
-      id: event.id,
-      parent_id: event.parent ? event.parent.id : null,
+    const analyzedQuery = analyzeQuery(event.sql);
+    const result = {
       kind: 'sql',
-      sql: analyzeQuery(event.sql),
+      sql: {
+        normalized_query: obfuscate(event.sqlQuery, event.sql.database_type),
+      },
+    };
+    if (typeof analyzedQuery === 'object') {
+      result.analyzed_query = analyzedQuery;
+    }
+    return result;
+  }
+
+  httpClientRequest(event) {
+    return {
+      kind: 'http_client_request',
+      route: event.route,
+      parameter_names: event.message ? event.message.map((m) => m.name) : null,
+      status_code: event.httpClientResponse
+        ? event.httpClientResponse.status_code
+        : null,
     };
   }
 
   httpServerRequest(event) {
     return {
-      id: event.id,
-      parent_id: event.parent ? event.parent.id : null,
       kind: 'http_server_request',
-      mime_type: event.httpServerResponse
-        ? event.httpServerResponse.mime_type
-        : null,
-      parameters: event.httpServerRequest
-        ? event.httpServerRequest.message
-        : null,
       route: event.route,
-      status: event.httpServerResponse ? event.httpServerResponse.status : null,
+      parameter_names: event.message ? event.message.map((m) => m.name) : null,
+      status_code: event.httpServerResponse
+        ? event.httpServerResponse.status ||
+          event.httpServerResponse.status_code
+        : null,
     };
   }
 
   functionCall(event) {
     return {
-      id: event.id,
-      parent_id: event.parent ? event.parent.id : null,
       kind: 'function',
       function: event.codeObject.id,
       labels: [...event.codeObject.labels],

--- a/packages/cli/src/fingerprint/canonicalize/update_v1.js
+++ b/packages/cli/src/fingerprint/canonicalize/update_v1.js
@@ -1,10 +1,12 @@
 /* eslint-disable class-methods-use-this */
-const { analyzeQuery } = require('../../database');
+const { analyzeQuery, obfuscate } = require('../../database');
 const Base = require('./base');
 
 /**
- * At ERROR level, the order of events is not important, and the amount of data
- * retained about events is minimal.
+ * At UPDATE level, the order of events is not important, and the amount of data
+ * retained about events is minimal. Function labels are retained. HTTP server
+ * and client request method, route, and status code are retained; but not parameter
+ * names.
  */
 class Canonicalize extends Base {
   /**
@@ -12,59 +14,70 @@ class Canonicalize extends Base {
    * @param {Event} event
    */
   sql(event) {
-    const normalizedSQL = analyzeQuery(event.sql);
-    if (typeof normalizedSQL === 'string') {
+    const analyzedQuery = analyzeQuery(event.sql);
+    if (typeof analyzedQuery === 'string') {
       const sqlLower = event.sqlQuery.toLowerCase();
       if (
         sqlLower.indexOf('insert') !== -1 ||
         sqlLower.indexOf('update') !== -1
       ) {
         return {
-          id: event.id,
-          parent_id: event.parent ? event.parent.id : null,
           kind: 'sql',
-          sql: analyzeQuery(event.sql),
+          sql: {
+            normalized_query: obfuscate(
+              event.sqlQuery,
+              event.sql.database_type
+            ),
+          },
         };
       }
-    } else if (normalizedSQL) {
-      let actions = [];
-      if (normalizedSQL.action) {
-        actions.push(normalizedSQL.action);
-      }
-      if (normalizedSQL.actions) {
-        actions = actions.concat(normalizedSQL.actions);
-      }
+    } else if (analyzedQuery && analyzedQuery.actions) {
       if (
-        ['insert', 'update', 'delete'].filter((x) => actions.includes(x))
-          .length > 0
+        ['insert', 'update', 'delete'].find((x) =>
+          analyzedQuery.actions.includes(x)
+        )
       ) {
-        return normalizedSQL;
+        return {
+          kind: 'sql',
+          sql: {
+            analyzed_query: analyzedQuery,
+          },
+        };
       }
     }
 
     return null;
   }
 
+  httpClientRequest(event) {
+    return {
+      kind: 'http_client_request',
+      route: event.route,
+      status_code: event.httpClientResponse
+        ? event.httpClientResponse.status_code
+        : null,
+    };
+  }
+
   httpServerRequest(event) {
     return {
-      id: event.id,
-      parent_id: event.parent ? event.parent.id : null,
       kind: 'http_server_request',
       route: event.route,
-      status: event.httpServerResponse ? event.httpServerResponse.status : null,
+      status_code: event.httpServerResponse
+        ? event.httpServerResponse.status_code
+        : null,
     };
   }
 
   functionCall(event) {
-    if (event.codeObject.labels.size === 0) {
+    const labels = this.whitelistedLabels(event.codeObject.labels);
+    if (labels.length === 0) {
       return null;
     }
 
     return {
-      id: event.id,
-      parent_id: event.parent ? event.parent.id : null,
       kind: 'function',
-      labels: [...event.codeObject.labels],
+      labels,
     };
   }
 }

--- a/packages/cli/src/fingerprint/fingerprinter.js
+++ b/packages/cli/src/fingerprint/fingerprinter.js
@@ -13,7 +13,16 @@ const {
 } = require('../utils');
 const { algorithms, canonicalize } = require('./canonicalize');
 
-const VERSION = '1.0.0';
+/**
+ * CHANGELOG
+ *
+ * = 1.1.0
+ *
+ * * Add database_type to CodeObjectType.QUERY and store in metadata.json.
+ * * Fix handling of parent assignment in normalization.
+ * * sql can contain the analysis (action, tables, columns), and/or the normalized query string.
+ */
+const VERSION = '1.1.0';
 
 class Fingerprinter {
   /**

--- a/packages/cli/src/functionStats.js
+++ b/packages/cli/src/functionStats.js
@@ -39,7 +39,20 @@ class FunctionStats {
   }
 
   toJSON() {
-    return this.eventMatches;
+    const trigram = (/** @type {Trigram} */ t) =>
+      [t.callerId, t.codeObjectId, t.calleeId].join(' ->\n');
+    return {
+      returnValues: this.returnValues,
+      httpServerRequests: this.httpServerRequests,
+      sqlQueries: this.sqlQueries,
+      sqlTables: this.sqlTables,
+      callers: this.callers,
+      ancestors: this.ancestors,
+      descendants: this.descendants,
+      packageTrigrams: this.packageTrigrams.map(trigram),
+      classTrigrams: this.classTrigrams.map(trigram),
+      functionTrigrams: this.functionTrigrams.map(trigram),
+    };
   }
 
   get appMapNames() {

--- a/packages/cli/src/search/findEvents.js
+++ b/packages/cli/src/search/findEvents.js
@@ -1,6 +1,6 @@
 // @ts-check
-const fsp = require('fs').promises;
 
+const fsp = require('fs').promises;
 const { buildAppMap } = require('./utils');
 const matchFilter = require('./matchFilter');
 const buildTrigrams = require('./trigram');

--- a/packages/cli/src/search/findEvents.js
+++ b/packages/cli/src/search/findEvents.js
@@ -75,7 +75,7 @@ class FindEvents {
         matchObj.caller = caller;
       }
 
-      if (event.children.length === 0) {
+      if (event.children.length === 0 && caller) {
         const trigrams = buildTrigrams(caller, event, null);
 
         matchObj.functionTrigrams.push(trigrams.functionTrigram);

--- a/packages/cli/src/search/matchSpec.js
+++ b/packages/cli/src/search/matchSpec.js
@@ -101,7 +101,10 @@ function matchTable(tableName) {
       return false;
     }
 
-    const queryInfo = /** @type {SQLInfo} */ analyzeQuery(codeObject.name);
+    const queryInfo = /** @type {SQLInfo} */ analyzeQuery({
+      sql: codeObject.name,
+      database_type: codeObject.database_type,
+    });
     if (typeof queryInfo !== 'object') {
       return false;
     }

--- a/packages/cli/src/search/types.d.ts
+++ b/packages/cli/src/search/types.d.ts
@@ -36,6 +36,7 @@ export interface CodeObject {
   id: string;
   name: string;
   type: string;
+  database_type: string;
   children: CodeObject[];
   parent: CodeObject;
   location: string; // Functions only

--- a/packages/cli/tests/unit/fingerprint/canonicalize.spec.js
+++ b/packages/cli/tests/unit/fingerprint/canonicalize.spec.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 const { buildAppMap } = require('@appland/models');
+const { readFileSync } = require('fs-extra');
 const {
   algorithms,
   canonicalize,
@@ -15,16 +16,34 @@ describe('Canonicalize', () => {
 
   test('UPDATE level', async () => {
     const normalForm = await canonicalize('update_v1', apiKeyAppMap);
-    console.log(JSON.stringify(normalForm, null, 2));
+    expect(
+      JSON.parse(
+        readFileSync(
+          `tests/unit/fixtures/canonicalize/revoke_api_key.update.json`
+        )
+      )
+    ).toEqual(normalForm);
   });
 
   test('INFO level', async () => {
     const normalForm = await canonicalize('info_v1', apiKeyAppMap);
-    console.log(JSON.stringify(normalForm, null, 2));
+    expect(
+      JSON.parse(
+        readFileSync(
+          `tests/unit/fixtures/canonicalize/revoke_api_key.info.json`
+        )
+      )
+    ).toEqual(normalForm);
   });
 
   test('TRACE level', async () => {
     const normalForm = await canonicalize('trace_v1', apiKeyAppMap);
-    console.log(JSON.stringify(normalForm, null, 2));
+    expect(
+      JSON.parse(
+        readFileSync(
+          `tests/unit/fixtures/canonicalize/revoke_api_key.trace.json`
+        )
+      )
+    ).toEqual(normalForm);
   });
 });

--- a/packages/cli/tests/unit/fingerprint/sql.spec.js
+++ b/packages/cli/tests/unit/fingerprint/sql.spec.js
@@ -5,7 +5,7 @@ describe('Normalize SQL', () => {
     const sql = 'SELECT * FROM users';
     const result = normalizeSQL(sql);
     expect(result).toEqual({
-      action: 'select',
+      actions: ['select'],
       columns: ['*'],
       tables: ['users'],
     });
@@ -14,7 +14,7 @@ describe('Normalize SQL', () => {
     const sql = `INSERT INTO users (login) VALUES ('fred')`;
     const result = normalizeSQL(sql);
     expect(result).toEqual({
-      action: 'insert',
+      actions: ['insert'],
       columns: ['login'],
       tables: ['users'],
     });
@@ -23,7 +23,7 @@ describe('Normalize SQL', () => {
     const sql = `INSERT INTO users (login) VALUES ('fred') RETURNING *`;
     const result = normalizeSQL(sql);
     expect(result).toEqual({
-      action: 'insert',
+      actions: ['insert'],
       columns: ['login'],
       tables: ['users'],
     });
@@ -32,7 +32,7 @@ describe('Normalize SQL', () => {
     const sql = `UPDATE users SET login = 'fred'`;
     const result = normalizeSQL(sql);
     expect(result).toEqual({
-      action: 'update',
+      actions: ['update'],
       columns: ['login'],
       tables: ['users'],
     });

--- a/packages/cli/tests/unit/fixtures/canonicalize/revoke_api_key.info.json
+++ b/packages/cli/tests/unit/fixtures/canonicalize/revoke_api_key.info.json
@@ -1,0 +1,248 @@
+[
+  {
+    "kind": "http_server_request",
+    "route": "DELETE /api/api_keys",
+    "parameter_names": [
+      "controller",
+      "action"
+    ],
+    "status_code": 200,
+    "children": [
+      {
+        "kind": "function",
+        "labels": [
+          "security",
+          "provider.authenticate"
+        ],
+        "children": [
+          {
+            "kind": "sql",
+            "sql": {
+              "analyzed_query": {
+                "actions": [
+                  "select"
+                ],
+                "tables": [
+                  "api_keys"
+                ],
+                "columns": [
+                  "*",
+                  "login"
+                ]
+              }
+            }
+          },
+          {
+            "kind": "sql",
+            "sql": {
+              "analyzed_query": {
+                "actions": [
+                  "select"
+                ],
+                "tables": [
+                  "users"
+                ],
+                "columns": [
+                  "*",
+                  "users.login"
+                ]
+              }
+            }
+          },
+          {
+            "kind": "sql",
+            "sql": {
+              "analyzed_query": {
+                "actions": [
+                  "select"
+                ],
+                "tables": [
+                  "pg_type"
+                ],
+                "columns": [
+                  "pg_type.oid",
+                  "typarray",
+                  "typname",
+                  "typrelid",
+                  "typtype"
+                ]
+              }
+            }
+          },
+          {
+            "kind": "sql",
+            "sql": {
+              "analyzed_query": {
+                "actions": [
+                  "select"
+                ],
+                "tables": [
+                  "pg_attribute",
+                  "pg_type"
+                ],
+                "columns": [
+                  "attisdropped",
+                  "attname",
+                  "attnum",
+                  "attrelid",
+                  "atttypid",
+                  "pg_attribute.atttypid",
+                  "pg_type.oid",
+                  "pg_type.typbasetype"
+                ]
+              }
+            }
+          },
+          {
+            "kind": "sql",
+            "sql": {
+              "analyzed_query": {
+                "actions": [
+                  "select"
+                ],
+                "tables": [
+                  "pg_type"
+                ],
+                "columns": [
+                  "pg_type.oid",
+                  "typarray",
+                  "typname",
+                  "typrelid",
+                  "typtype"
+                ]
+              }
+            }
+          },
+          {
+            "kind": "sql",
+            "sql": {
+              "analyzed_query": {
+                "actions": [
+                  "select"
+                ],
+                "tables": [
+                  "pg_attribute",
+                  "pg_type"
+                ],
+                "columns": [
+                  "attisdropped",
+                  "attname",
+                  "attnum",
+                  "attrelid",
+                  "atttypid",
+                  "pg_attribute.atttypid",
+                  "pg_type.oid",
+                  "pg_type.typbasetype"
+                ]
+              }
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "http_server_request",
+    "route": "DELETE /api/api_keys",
+    "parameter_names": [
+      "controller",
+      "action"
+    ],
+    "status_code": 401,
+    "children": [
+      {
+        "kind": "function",
+        "labels": [
+          "security",
+          "provider.authenticate"
+        ],
+        "children": [
+          {
+            "kind": "sql",
+            "sql": {
+              "analyzed_query": {
+                "actions": [
+                  "select"
+                ],
+                "tables": [
+                  "api_keys"
+                ],
+                "columns": [
+                  "*",
+                  "login"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      {
+        "kind": "function",
+        "labels": [
+          "serialization",
+          "json"
+        ],
+        "children": [
+          {
+            "kind": "sql",
+            "sql": {
+              "analyzed_query": {
+                "actions": [
+                  "update"
+                ],
+                "tables": [
+                  "api_keys"
+                ],
+                "columns": [
+                  "id",
+                  "last_used"
+                ]
+              }
+            }
+          },
+          {
+            "kind": "function",
+            "labels": [
+              "security"
+            ],
+            "children": [
+              {
+                "kind": "sql",
+                "sql": {
+                  "analyzed_query": {
+                    "actions": [
+                      "select"
+                    ],
+                    "tables": [
+                      "api_keys"
+                    ],
+                    "columns": [
+                      "*",
+                      "login"
+                    ]
+                  }
+                }
+              },
+              {
+                "kind": "sql",
+                "sql": {
+                  "analyzed_query": {
+                    "actions": [
+                      "delete"
+                    ],
+                    "tables": [
+                      "api_keys"
+                    ],
+                    "columns": [
+                      "id"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/cli/tests/unit/fixtures/canonicalize/revoke_api_key.trace.json
+++ b/packages/cli/tests/unit/fixtures/canonicalize/revoke_api_key.trace.json
@@ -1,0 +1,289 @@
+[
+  {
+    "kind": "http_server_request",
+    "route": "DELETE /api/api_keys",
+    "parameter_names": [
+      "controller",
+      "action"
+    ],
+    "status_code": 200,
+    "children": [
+      {
+        "kind": "function",
+        "function": "app/models/ApiKey.authenticate",
+        "labels": [
+          "security",
+          "provider.authenticate"
+        ],
+        "children": [
+          {
+            "kind": "function",
+            "function": "app/models/ApiKey.decode",
+            "labels": []
+          },
+          {
+            "kind": "sql",
+            "sql": {
+              "normalized_query": "SELECT * FROM \"api_keys\" WHERE (\"login\" = ?)"
+            },
+            "analyzed_query": {
+              "actions": [
+                "select"
+              ],
+              "tables": [
+                "api_keys"
+              ],
+              "columns": [
+                "*",
+                "login"
+              ]
+            }
+          },
+          {
+            "kind": "function",
+            "function": "app/models/ApiKey.touch",
+            "labels": [],
+            "children": [
+              {
+                "kind": "sql",
+                "sql": {
+                  "normalized_query": "UPDATE \"api_keys\" SET \"last_used\" = ? WHERE (\"id\" = ?)"
+                },
+                "analyzed_query": {
+                  "actions": [
+                    "update"
+                  ],
+                  "tables": [
+                    "api_keys"
+                  ],
+                  "columns": [
+                    "id",
+                    "last_used"
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "kind": "sql",
+            "sql": {
+              "normalized_query": "SELECT * FROM \"users\" WHERE (\"users\".\"login\" = ?) LIMIT ?"
+            },
+            "analyzed_query": {
+              "actions": [
+                "select"
+              ],
+              "tables": [
+                "users"
+              ],
+              "columns": [
+                "*",
+                "users.login"
+              ]
+            }
+          },
+          {
+            "kind": "sql",
+            "sql": {
+              "normalized_query": "SELECT \"pg_type\".\"oid\", \"typrelid\", \"typarray\" FROM \"pg_type\" WHERE ((\"typtype\" = ?) AND (\"typname\" = ?)) LIMIT ?"
+            },
+            "analyzed_query": {
+              "actions": [
+                "select"
+              ],
+              "tables": [
+                "pg_type"
+              ],
+              "columns": [
+                "pg_type.oid",
+                "typarray",
+                "typname",
+                "typrelid",
+                "typtype"
+              ]
+            }
+          },
+          {
+            "kind": "sql",
+            "sql": {
+              "normalized_query": "SELECT \"attname\", (CASE \"pg_type\".\"typbasetype\" WHEN ? THEN \"atttypid\" ELSE \"pg_type\".\"typbasetype\" END) AS \"atttypid\" FROM \"pg_attribute\" INNER JOIN \"pg_type\" ON (\"pg_type\".\"oid\" = \"pg_attribute\".\"atttypid\") WHERE ((\"attrelid\" = ?) AND (\"attnum\" > ?) AND NOT \"attisdropped\") ORDER BY \"attnum\""
+            },
+            "analyzed_query": {
+              "actions": [
+                "select"
+              ],
+              "tables": [
+                "pg_attribute",
+                "pg_type"
+              ],
+              "columns": [
+                "attisdropped",
+                "attname",
+                "attnum",
+                "attrelid",
+                "atttypid",
+                "pg_attribute.atttypid",
+                "pg_type.oid",
+                "pg_type.typbasetype"
+              ]
+            }
+          },
+          {
+            "kind": "sql",
+            "sql": {
+              "normalized_query": "SELECT \"pg_type\".\"oid\", \"typrelid\", \"typarray\" FROM \"pg_type\" WHERE ((\"typtype\" = ?) AND (\"typname\" = ?)) LIMIT ?"
+            },
+            "analyzed_query": {
+              "actions": [
+                "select"
+              ],
+              "tables": [
+                "pg_type"
+              ],
+              "columns": [
+                "pg_type.oid",
+                "typarray",
+                "typname",
+                "typrelid",
+                "typtype"
+              ]
+            }
+          },
+          {
+            "kind": "sql",
+            "sql": {
+              "normalized_query": "SELECT \"attname\", (CASE \"pg_type\".\"typbasetype\" WHEN ? THEN \"atttypid\" ELSE \"pg_type\".\"typbasetype\" END) AS \"atttypid\" FROM \"pg_attribute\" INNER JOIN \"pg_type\" ON (\"pg_type\".\"oid\" = \"pg_attribute\".\"atttypid\") WHERE ((\"attrelid\" = ?) AND (\"attnum\" > ?) AND NOT \"attisdropped\") ORDER BY \"attnum\""
+            },
+            "analyzed_query": {
+              "actions": [
+                "select"
+              ],
+              "tables": [
+                "pg_attribute",
+                "pg_type"
+              ],
+              "columns": [
+                "attisdropped",
+                "attname",
+                "attnum",
+                "attrelid",
+                "atttypid",
+                "pg_attribute.atttypid",
+                "pg_type.oid",
+                "pg_type.typbasetype"
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "kind": "function",
+        "function": "app/controllers/API::APIKeysController#destroy",
+        "labels": [],
+        "children": [
+          {
+            "kind": "function",
+            "function": "app/models/ApiKey.revoke",
+            "labels": [
+              "security"
+            ],
+            "children": [
+              {
+                "kind": "function",
+                "function": "app/models/ApiKey.decode",
+                "labels": []
+              },
+              {
+                "kind": "sql",
+                "sql": {
+                  "normalized_query": "SELECT * FROM \"api_keys\" WHERE (\"login\" = ?)"
+                },
+                "analyzed_query": {
+                  "actions": [
+                    "select"
+                  ],
+                  "tables": [
+                    "api_keys"
+                  ],
+                  "columns": [
+                    "*",
+                    "login"
+                  ]
+                }
+              },
+              {
+                "kind": "sql",
+                "sql": {
+                  "normalized_query": "DELETE FROM \"api_keys\" WHERE \"id\" = ?"
+                },
+                "analyzed_query": {
+                  "actions": [
+                    "delete"
+                  ],
+                  "tables": [
+                    "api_keys"
+                  ],
+                  "columns": [
+                    "id"
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "http_server_request",
+    "route": "DELETE /api/api_keys",
+    "parameter_names": [
+      "controller",
+      "action"
+    ],
+    "status_code": 401,
+    "children": [
+      {
+        "kind": "function",
+        "function": "app/models/ApiKey.authenticate",
+        "labels": [
+          "security",
+          "provider.authenticate"
+        ],
+        "children": [
+          {
+            "kind": "function",
+            "function": "app/models/ApiKey.decode",
+            "labels": []
+          },
+          {
+            "kind": "sql",
+            "sql": {
+              "normalized_query": "SELECT * FROM \"api_keys\" WHERE (\"login\" = ?)"
+            },
+            "analyzed_query": {
+              "actions": [
+                "select"
+              ],
+              "tables": [
+                "api_keys"
+              ],
+              "columns": [
+                "*",
+                "login"
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "kind": "function",
+        "function": "json/JSON::Ext::Generator::State#generate",
+        "labels": [
+          "serialization",
+          "json"
+        ]
+      }
+    ]
+  }
+]

--- a/packages/cli/tests/unit/fixtures/canonicalize/revoke_api_key.update.json
+++ b/packages/cli/tests/unit/fixtures/canonicalize/revoke_api_key.update.json
@@ -1,0 +1,78 @@
+[
+  {
+    "kind": "http_server_request",
+    "route": "DELETE /api/api_keys",
+    "children": [
+      {
+        "kind": "function",
+        "labels": [
+          "security",
+          "provider.authenticate"
+        ]
+      }
+    ]
+  },
+  {
+    "kind": "http_server_request",
+    "route": "DELETE /api/api_keys",
+    "children": [
+      {
+        "kind": "function",
+        "labels": [
+          "security",
+          "provider.authenticate"
+        ]
+      },
+      {
+        "kind": "function",
+        "labels": [
+          "serialization",
+          "json"
+        ],
+        "children": [
+          {
+            "kind": "sql",
+            "sql": {
+              "analyzed_query": {
+                "actions": [
+                  "update"
+                ],
+                "tables": [
+                  "api_keys"
+                ],
+                "columns": [
+                  "id",
+                  "last_used"
+                ]
+              }
+            }
+          },
+          {
+            "kind": "function",
+            "labels": [
+              "security"
+            ],
+            "children": [
+              {
+                "kind": "sql",
+                "sql": {
+                  "analyzed_query": {
+                    "actions": [
+                      "delete"
+                    ],
+                    "tables": [
+                      "api_keys"
+                    ],
+                    "columns": [
+                      "id"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/packages/models/src/codeObject.js
+++ b/packages/models/src/codeObject.js
@@ -253,6 +253,9 @@ export default class CodeObject {
       obj.static = this.data.static;
       obj.location = this.data.location;
     }
+    if (this.data.type === CodeObjectType.QUERY) {
+      obj.database_type = this.data.database_type;
+    }
 
     if (this.children.length > 0) {
       obj.children = this.children;
@@ -299,6 +302,7 @@ export default class CodeObject {
         {
           type: CodeObjectType.QUERY,
           name: event.sqlQuery,
+          database_type: event.sql.database_type,
         },
       ];
     } else {

--- a/packages/models/src/event.js
+++ b/packages/models/src/event.js
@@ -43,9 +43,23 @@ export default class Event {
     addHiddenProperty(this, 'previous');
     addHiddenProperty(this, 'hash');
     addHiddenProperty(this, 'identityHash');
+    addHiddenProperty(this, 'depth');
 
     // Data must be written last, after our properties are configured.
     Object.assign(this, data);
+  }
+
+  get depth() {
+    if (this.$hidden.depth === undefined) {
+      let result = 0;
+      let { parent } = this;
+      while (parent) {
+        result += 1;
+        parent = parent.parent;
+      }
+      this.$hidden.depth = result;
+    }
+    return this.$hidden.depth;
   }
 
   get methodId() {

--- a/packages/models/src/util.js
+++ b/packages/models/src/util.js
@@ -481,7 +481,14 @@ function parseNormalizeSQL(sql) {
 /* eslint-enable no-inner-declarations */
 
 function dumbNormalizeSQL(sql) {
-  const sqlLower = sql.toLowerCase();
+  const sqlLower = sql.toLowerCase().trim();
+  if (sqlLower.indexOf('pragma') === 0) {
+    return {
+      tables: [],
+      columns: [],
+    };
+  }
+
   const stopWords = ['where', 'limit', 'order by', 'group by', 'values', 'set'];
   const stopWordLocations = stopWords
     .map((word) => sqlLower.indexOf(` ${word}`))


### PR DESCRIPTION
* Assign proper parentage to fingerprint tree nodes
* Silence noisy labels
* Update the AppMap index before `inspect`
* Properly normalize `PRAGMA` queries
* Store the database type on classMap entries of type `query`, so that they can be reliably parsed

