### PR TITLE
feat: App.Land client

### DIFF
--- a/packages/cli/src/appland/getAppMap.js
+++ b/packages/cli/src/appland/getAppMap.js
@@ -1,0 +1,55 @@
+// @ts-check
+
+const { request: httpRequest } = require('http');
+const { request: httpsRequest } = require('https');
+const { baseURL, apiKey, exists } = require('./settings');
+
+/**
+ * Loads AppMap data from UUID.
+ *
+ * @param {string} uuid
+ * @returns {Promise<AppMapData>}
+ */
+const getAppMap = async (uuid) => {
+  if (!exists) {
+    throw new Error(`AppMap client is not configured`);
+  }
+
+  return new Promise((resolve, reject) => {
+    const getScenarioURL = new URL([baseURL, 'api/appmaps', uuid].join('/'));
+    const requestFunction =
+      getScenarioURL.protocol === 'https:' ? httpsRequest : httpRequest;
+    const req = requestFunction(
+      getScenarioURL,
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          Accept: 'application/json',
+        },
+      },
+      // eslint-disable-next-line consistent-return
+      (res) => {
+        if (res.statusCode >= 300) {
+          return reject(res.statusCode);
+        }
+        let data = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          resolve(JSON.parse(data));
+        });
+      }
+    );
+
+    req.on('error', (e) => {
+      reject(e);
+    });
+
+    // Write data to request body
+    req.end();
+  });
+};
+
+module.exports = getAppMap;

--- a/packages/cli/src/appland/listAppMaps.js
+++ b/packages/cli/src/appland/listAppMaps.js
@@ -1,0 +1,58 @@
+// @ts-check
+
+const { request: httpRequest } = require('http');
+const { request: httpsRequest } = require('https');
+const { baseURL, apiKey, exists } = require('./settings');
+
+/** @typedef {import('../diff/types').AppMapListItem} AppMapListItem */
+
+/**
+ * Lists AppMaps in a mapset.
+ *
+ * @param {number} mapset
+ * @returns {Promise<AppMapListItem[]>}
+ */
+const listAppMaps = async (mapset) => {
+  if (!exists) {
+    throw new Error(`AppMap client is not configured`);
+  }
+
+  return new Promise((resolve, reject) => {
+    const listAppMapsURL = new URL([baseURL, 'api/appmaps'].join('/'));
+    listAppMapsURL.searchParams.append('mapsets[]', mapset.toString());
+    const requestFunction =
+      listAppMapsURL.protocol === 'https:' ? httpsRequest : httpRequest;
+    const req = requestFunction(
+      listAppMapsURL,
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          Accept: 'application/json',
+        },
+      },
+      // eslint-disable-next-line consistent-return
+      (res) => {
+        if (res.statusCode >= 300) {
+          return reject(res.statusCode);
+        }
+        let data = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          resolve(JSON.parse(data));
+        });
+      }
+    );
+
+    req.on('error', (e) => {
+      reject(e);
+    });
+
+    // Write data to request body
+    req.end();
+  });
+};
+
+module.exports = listAppMaps;

--- a/packages/cli/src/appland/settings.js
+++ b/packages/cli/src/appland/settings.js
@@ -1,0 +1,62 @@
+// @ts-check
+
+const { join } = require('path');
+const { homedir } = require('os');
+const { statSync, readFileSync } = require('fs');
+const yaml = require('js-yaml');
+
+/**
+ * @param {string} msg
+ * @returns {{baseURL: string, apiKey: string, exists: boolean}}
+ */
+const failUsage = (msg) => {
+  console.warn(msg);
+  return { baseURL: null, apiKey: null, exists: false };
+};
+
+const { baseURL, apiKey, exists } =
+  /**
+   * @returns {{baseURL, apiKey}}
+   */
+  (() => {
+    const applandConfigFilePath = join(homedir(), '.appland');
+    const applandConfigStat = statSync(applandConfigFilePath);
+    if (!applandConfigStat.isFile()) {
+      return failUsage(
+        `AppMap Cloud config file ${applandConfigFilePath} does not exist`
+      );
+    }
+    const applandConfig = /** @type {object} */ (
+      yaml.load(readFileSync(applandConfigFilePath).toString())
+    );
+    const currentContext =
+      /** @type {string} */ applandConfig.current_context || 'default';
+    const contextConfig =
+      /** @type {import('./types').Context} */ applandConfig.contexts[
+        currentContext
+      ];
+    if (!contextConfig) {
+      return failUsage(
+        `No context configuration '${currentContext}' in AppMap Cloud config file ${applandConfigFilePath}`
+      );
+    }
+    const { url: configURL, api_key: configApiKey } = contextConfig;
+    if (!configURL) {
+      return failUsage(
+        `No 'url' in context configuration '${currentContext}' in AppMap Cloud config file ${applandConfigFilePath}`
+      );
+    }
+    if (!configApiKey) {
+      return failUsage(
+        `No 'api_key' in context configuration '${currentContext}' in AppMap Cloud config file ${applandConfigFilePath}`
+      );
+    }
+
+    return { baseURL: configURL, apiKey: configApiKey, exists: true };
+  })();
+
+module.exports = {
+  baseURL,
+  apiKey,
+  exists,
+};

--- a/packages/cli/src/appland/types.d.ts
+++ b/packages/cli/src/appland/types.d.ts
@@ -1,0 +1,16 @@
+interface AppMapMetadata {
+  name: string;
+  fingerprints: Fingerprint[];
+}
+
+interface AppMapListItem {
+  scenario_uuid: string;
+  metadata: AppMapMetadata;
+}
+
+interface AppMapData {
+  version: string;
+  metadata: object;
+  classMap: object[];
+  events: object[];
+}


### PR DESCRIPTION
Adds a basic App.Land client to read auth settings, search for AppMaps, and fetch AppMaps.
