### PR TITLE
fix: Find all matching events in each AppMap

### DIFF
--- a/packages/cli/src/search/codeObjectMatcher.js
+++ b/packages/cli/src/search/codeObjectMatcher.js
@@ -51,6 +51,7 @@ class CodeObjectMatcher {
           }' and completes the search`
         );
       }
+      this.depth += 1;
       return MATCH_COMPLETE;
     }
     if (verbose()) {

--- a/packages/cli/src/search/findCodeObjects.js
+++ b/packages/cli/src/search/findCodeObjects.js
@@ -235,16 +235,11 @@ class FindCodeObjects {
         console.warn(`Checking AppMap ${appmapName}`);
       }
 
-      let match = null;
       const findMatchingFunction = (
         /** @type {import('./types').CodeObject} */ item,
         /** @type {import('./types').CodeObjectMatcher} */ matcher,
         /** @type {import('./types').CodeObject[]} */ ancestors
       ) => {
-        if (match) {
-          return;
-        }
-
         const buildCodeObject = () => {
           let parent = null;
           ancestors.forEach((ancestor) => {
@@ -253,6 +248,7 @@ class FindCodeObjects {
           return new CodeObjectModel(item, parent);
         };
 
+        let match;
         const matchResult = matcher.match(item);
         switch (matchResult) {
           case MATCH_ABORT:
@@ -263,7 +259,6 @@ class FindCodeObjects {
               console.warn(`Completed match: ${JSON.stringify(match)}`);
             }
             matches.push(match);
-            return;
           case MATCH_CONTINUE:
           default:
         }

--- a/packages/cli/src/search/trigram.js
+++ b/packages/cli/src/search/trigram.js
@@ -51,7 +51,10 @@ class Trigram {
    */
   get codeObjectId() {
     const co = this.codeObjectFn(this.event);
-    return co ? co.id : null;
+    if (co) {
+      return normalizeId(co, this.event);
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
Don't terminate the search once a match is found.
Keep searching for all e.g. matching tables in an AppMap.