### PR TITLE
feat: Add validation step to agent install

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/agentInstallerBase.js
+++ b/packages/cli/src/cmds/agentInstaller/agentInstallerBase.js
@@ -16,6 +16,10 @@ class AgentInstallerBase {
     return new Workflow(btInstaller, btInstaller.configureSteps, this.path);
   }
 
+  get validateAgentFlow() {
+    const btInstaller = this.buildToolInstaller;
+    return new Workflow(btInstaller, btInstaller.validateSteps, this.path);
+  }
   /*
   runTests( {
     // TODO

--- a/packages/cli/src/cmds/agentInstaller/commandRunner.js
+++ b/packages/cli/src/cmds/agentInstaller/commandRunner.js
@@ -31,4 +31,6 @@ function runSync(command) {
   }).toString();
 }
 
-module.exports = { run, runSync };
+const logger = console;
+
+module.exports = { run, runSync, logger };

--- a/packages/cli/src/cmds/agentInstaller/install-agent.js
+++ b/packages/cli/src/cmds/agentInstaller/install-agent.js
@@ -1,7 +1,7 @@
 const process = require('process');
 const { verbose } = require('../../utils');
 const { JavaAgentInstaller } = require('./javaAgentInstaller');
-const RubyAgentInstaller = require('./rubyAgentInstaller');
+const { RubyAgentInstaller } = require('./rubyAgentInstaller');
 const { PythonAgentInstaller } = require('./pythonAgentInstaller');
 const ValidationError = require('./validationError');
 const AbortError = require('./abortError');
@@ -42,7 +42,8 @@ exports.handler = async (argv) => {
     const installer = new InstallerClass(dir);
 
     await installer.installAgentFlow.run();
-    return installer.configureAgentFlow.run();
+    await installer.configureAgentFlow.run();
+    return installer.validateAgentFlow.run();
   };
 
   return commandFn().catch((err) => {

--- a/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.js
+++ b/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.js
@@ -34,6 +34,10 @@ class PoetryInstaller extends BuildToolInstaller {
     return ret;
   }
 
+  get validateSteps() {
+    return [];
+  }
+
   /**
    * @returns {string}
    */
@@ -79,6 +83,10 @@ class PipInstaller extends BuildToolInstaller {
    */
   constructor(path) {
     super(REQUIREMENTS_FILE, path);
+  }
+
+  get validateSteps() {
+    return [];
   }
 
   /**

--- a/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.js
+++ b/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.js
@@ -21,8 +21,8 @@ class BundleInstaller extends BuildToolInstaller {
   /**
    * @param {string} path
    */
-  constructor(path) {
-    super('Gemfile', path);
+  constructor(path, commandRunner = null) {
+    super('Gemfile', path, commandRunner);
   }
 
   /**
@@ -86,14 +86,18 @@ in your terminal:`;
   get agentInitCommand() {
     return new CommandStruct('bundle', ['exec', 'appmap-agent-init'], {});
   }
+
+  get agentValidateCommand() {
+    return new CommandStruct('bundle', ['exec', 'appmap-agent-validate'], {});
+  }
 }
 
 class RubyAgentInstaller extends AgentInstaller {
   /**
    * @param {string} path
    */
-  constructor(path) {
-    const installers = [new BundleInstaller(path)].filter(
+  constructor(path, commandRunner = null) {
+    const installers = [new BundleInstaller(path, commandRunner)].filter(
       (installer) => installer.available
     );
     if (installers.length === 0) {

--- a/packages/cli/tests/unit/agentInstall/java.spec.js
+++ b/packages/cli/tests/unit/agentInstall/java.spec.js
@@ -53,6 +53,9 @@ function testAgentInit(installerFixture) {
   it('provides the correct agent init command', () => {
     const cmdRunner = {
       runSync: () => 'com.appland:appmap-agent.jar.path=appmap.jar',
+      logger: {
+        log: () => {},
+      },
     };
 
     const btInstaller = buildToolInstaller(
@@ -60,7 +63,7 @@ function testAgentInit(installerFixture) {
     );
     const cmdStruct = btInstaller.agentInitCommand;
     expect(cmdStruct.program).toBe('java');
-    expect(cmdStruct.args).toEqual([
+    expect(cmdStruct.args).toStrictEqual([
       '-jar',
       'appmap.jar',
       '-d',
@@ -76,6 +79,15 @@ describe('Java Agent Installation', () => {
       const installer = installerForProject('gradle/no-plugins');
       const btInstaller = buildToolInstaller(installer);
       expect(btInstaller).toBeInstanceOf(GradleInstaller);
+    });
+
+    it('uses the correct command to print the jar path', async () => {
+      const btInstaller = buildToolInstaller(
+        installerForProject('gradle/no-plugins')
+      );
+      const printCmd = btInstaller.printJarPathCommand;
+      expect(printCmd.program).toBe('gradle');
+      expect(printCmd.args).toStrictEqual(['appmap-print-jar-path']);
     });
 
     describe(
@@ -97,6 +109,15 @@ describe('Java Agent Installation', () => {
       const installer = installerForProject('maven-no-project');
       const btInstaller = buildToolInstaller(installer);
       expect(btInstaller.install()).rejects.toThrow(/No project section found/);
+    });
+
+    it('uses the correct command to print the jar path', async () => {
+      const btInstaller = buildToolInstaller(
+        installerForProject('maven/no-plugins')
+      );
+      const printCmd = btInstaller.printJarPathCommand;
+      expect(printCmd.program).toBe('mvn');
+      expect(printCmd.args).toStrictEqual(['appmap:print-jar-path']);
     });
 
     describe('updates', testUpdates.bind(null, 'maven', 'expected-pom.xml'));

--- a/packages/cli/tests/unit/agentInstall/ruby.spec.js
+++ b/packages/cli/tests/unit/agentInstall/ruby.spec.js
@@ -12,13 +12,13 @@ tmp.setGracefulCleanup();
 
 const fixtureDir = join(__dirname, '..', 'fixtures', 'ruby');
 
-const installerForProject = (projectType) => {
+const installerForProject = (projectType, cmdRunner = null) => {
   const projectFixtures = join(fixtureDir, projectType);
   const projectDir = tmp.dirSync().name;
 
   fs.copySync(projectFixtures, projectDir);
 
-  const agentInstaller = new RubyAgentInstaller(projectDir);
+  const agentInstaller = new RubyAgentInstaller(projectDir, cmdRunner);
   return agentInstaller;
 };
 
@@ -45,6 +45,52 @@ describe('Ruby Agent Installation', () => {
       const cmdStruct = btInstaller.agentInitCommand;
       expect(cmdStruct.program).toBe('bundle');
       expect(cmdStruct.args).toEqual(['exec', 'appmap-agent-init']);
+    });
+
+    describe('when validating', () => {
+      it('uses the correct command', async () => {
+        const btInstaller = buildToolInstaller(installerForProject('app'));
+        const cmdStruct = btInstaller.agentValidateCommand;
+        expect(cmdStruct.program).toBe('bundle');
+        expect(cmdStruct.args).toEqual(['exec', 'appmap-agent-validate']);
+      });
+
+      it('has one step in the validating flow', async () => {
+        const installer = installerForProject('app');
+        expect(installer.validateAgentFlow.steps.length).toEqual(1);
+      });
+
+      it('succeeds when the agent validates the project', async () => {
+        const runner = {
+          runSync: () => '[]',
+          logger: {
+            log: () => {},
+          },
+        };
+        const prompter = () => Promise.resolve('');
+
+        const installer = installerForProject('app', runner);
+        await expect(
+          installer.validateAgentFlow.steps[0].run(prompter)
+        ).resolves.toBe(0);
+      });
+
+      it('fails when the the agent detects a problem', async () => {
+        const runner = {
+          runSync: () =>
+            '[{ "level": "error", "message": "validation failed" }]',
+          logger: {
+            log: () => {},
+            error: () => {},
+          },
+        };
+        const prompter = () => Promise.resolve('');
+        const installer = installerForProject('app', runner);
+
+        await expect(
+          installer.validateAgentFlow.steps[0].run(prompter)
+        ).rejects.toThrow(/Validation failed/);
+      });
     });
   });
 });


### PR DESCRIPTION
After installing and configuring the agent, validate that the project is
ready for mapping. Currently, only Ruby projects can be validated, so
this step isn't implemented for Python or Java installations.

Happy path: [![asciicast](https://asciinema.org/a/1ypNrQeqwfOOEU1Azc7mUW9Ub.svg)](https://asciinema.org/a/1ypNrQeqwfOOEU1Azc7mUW9Ub)

Failure: [![asciicast](https://asciinema.org/a/1lYcEQAMovfQqEYK6NnYCUWzX.svg)](https://asciinema.org/a/1lYcEQAMovfQqEYK6NnYCUWzX)
