### PR TITLE
feat: Add validate-config subcommand

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,6 +42,8 @@
   },
   "dependencies": {
     "@appland/models": "workspace:*",
+    "@sidvind/better-ajv-errors": "^0.9.1",
+    "ajv": "^8.6.2",
     "async": "^3.2.0",
     "chokidar": "^3.5.1",
     "cli-progress": "^3.9.0",
@@ -52,6 +54,7 @@
     "glob": "^7.1.6",
     "js-yaml": "^3.14.1",
     "jsdom": "^16.6.0",
+    "jsonschema": "^1.4.0",
     "moo": "^0.5.1",
     "semver": "^7.3.5",
     "w3c-xmlserializer": "^2.0.0",

--- a/packages/cli/src/cli.js
+++ b/packages/cli/src/cli.js
@@ -574,6 +574,7 @@ yargs(process.argv.slice(2))
     description: 'Run with verbose logging',
   })
   .command(require('./cmds/agentInstaller/install-agent'))
+  .command(require('./cmds/configValidator/validate-config'))
   .strict()
   .demandCommand()
   .help().argv;

--- a/packages/cli/src/cmds/configValidator/java-config-schema.yml
+++ b/packages/cli/src/cmds/configValidator/java-config-schema.yml
@@ -1,0 +1,23 @@
+type: object
+additionalProperties: false
+required:
+- name
+properties:
+  name:
+    type: string
+  packages:
+    type: array
+    items:
+      type: object
+      additionalProperties: false
+      required:
+      - path
+      properties:
+        path:
+          type: string
+        shallow:
+          type: boolean
+        exclude:
+          type: array
+          items:
+            type: string

--- a/packages/cli/src/cmds/configValidator/validate-config.js
+++ b/packages/cli/src/cmds/configValidator/validate-config.js
@@ -1,0 +1,73 @@
+const fs = require('fs');
+const { join } = require('path');
+const process = require('process');
+
+const yaml = require('js-yaml');
+const Yargs = require('yargs');
+
+const { verbose } = require('../../utils');
+const validator = require('../../service/config/validator');
+
+exports.command = 'validate-config <project type>';
+exports.describe = 'Validate AppMap configuration';
+
+const projectTypes = ['java', 'python', 'ruby'];
+exports.builder = (yargs) => {
+  yargs
+    .positional('project type', {
+      describe: 'the type of project to validate',
+    })
+    .choices('projecttype', projectTypes)
+    .check((argv) => {
+      if (argv.projecttype !== 'java') {
+        return 'Only Java projects can currently be validated.';
+      }
+      return true;
+    })
+    .option('dir', {
+      describe: 'directory in which to perform validation',
+      default: '.',
+      alias: 'd',
+    });
+};
+
+const cmdHandler = async (
+  schema,
+  config,
+  configFile,
+  svc = validator,
+  logger = console
+) => {
+  const result = svc.validateConfig(schema, config);
+  if (result.valid) {
+    logger.log(`\n${configFile} is valid.\n`);
+    return 0;
+  }
+
+  logger.error(`\n${result.errors}\n`);
+  return 1;
+};
+
+exports.handler = async (argv) => {
+  verbose(argv.verbose);
+
+  const schema = yaml.load(
+    fs.readFileSync(join(__dirname, 'java-config-schema.yml'))
+  );
+  const configFile = join(argv.dir, 'appmap.yml');
+  try {
+    const config = yaml.load(fs.readFileSync(configFile, 'utf8'));
+
+    Yargs.exit(await cmdHandler(schema, config, configFile));
+  } catch (e) {
+    if (e instanceof yaml.YAMLException) {
+      console.error();
+      console.error(e.message);
+      console.error();
+      process.exit(1);
+    }
+    throw e;
+  }
+};
+
+exports.cmdHandler = cmdHandler;

--- a/packages/cli/src/service/config/validator.js
+++ b/packages/cli/src/service/config/validator.js
@@ -1,0 +1,16 @@
+const { default: Ajv } = require('ajv');
+const { default: betterAjvErrors } = require('@sidvind/better-ajv-errors');
+
+function validateConfig(schema, config) {
+  const ajv = new Ajv({ allErrors: true });
+  const validate = ajv.compile(schema);
+
+  const valid = validate(config);
+  const result = { valid };
+  if (!valid) {
+    result.errors = betterAjvErrors(schema, config, validate.errors);
+  }
+  return result;
+}
+
+module.exports = { validateConfig };

--- a/packages/cli/tests/unit/service/config/validator.spec.js
+++ b/packages/cli/tests/unit/service/config/validator.spec.js
@@ -1,0 +1,33 @@
+const { validateConfig } = require('../../../../src/service/config/validator');
+
+const schema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['name'],
+  properties: {
+    name: {
+      type: 'string',
+    },
+  },
+};
+
+describe('Config validation service', () => {
+  it('returns no errors for a valid config', () => {
+    const config = {
+      name: 'a-config',
+    };
+
+    const result = validateConfig(schema, config);
+    expect(result.valid).toBeTruthy();
+  });
+
+  it('returns errors for a valid config', () => {
+    const config = {
+      name: 'a-config',
+      extraProp: true,
+    };
+
+    const result = validateConfig(schema, config);
+    expect(result.valid).toBeFalsy();
+  });
+});

--- a/packages/cli/tests/unit/validate-config.spec.js
+++ b/packages/cli/tests/unit/validate-config.spec.js
@@ -1,0 +1,50 @@
+const yargs = require('yargs');
+
+const {
+  cmdHandler,
+} = require('../../src/cmds/configValidator/validate-config');
+
+const logger = {
+  log: () => {},
+  error: () => {},
+};
+
+describe('validate-config command', () => {
+  it('returns 0 when validation succeeds', async () => {
+    const svc = {
+      validateConfig: () => ({ valid: true }),
+    };
+
+    const ret = await cmdHandler(null, null, null, svc, logger);
+    expect(ret).toEqual(0);
+  });
+
+  it('returns non-zero when validation fails', async () => {
+    const svc = {
+      validateConfig: () => ({ valid: false }),
+    };
+
+    const ret = await cmdHandler(null, null, null, svc, logger);
+    expect(ret).not.toEqual(0);
+  });
+
+  const parser = (newYargs) =>
+    newYargs
+      // eslint-disable-next-line global-require
+      .command(require('../../src/cmds/configValidator/validate-config'))
+      .demandOption('projecttype')
+      .exitProcess(false);
+
+  ['python', 'ruby'].forEach((p) => {
+    const projectType = p;
+    it(`fails to validate ${projectType} projects`, () => {
+      const newYargs = yargs();
+      expect(() => {
+        parser(newYargs).parse(`validate-config ${projectType}`);
+      }).toThrow(/Only Java projects can currently be validated./);
+    });
+  });
+  it('will validate Java projects', () => {
+    expect(() => parser(yargs()).parse('validate-config java')).not.toThrow();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,7 +55,9 @@ __metadata:
   resolution: "@appland/appmap@workspace:packages/cli"
   dependencies:
     "@appland/models": "workspace:*"
+    "@sidvind/better-ajv-errors": ^0.9.1
     "@types/node": ^16.6.2
+    ajv: ^8.6.2
     async: ^3.2.0
     chokidar: ^3.5.1
     cli-progress: ^3.9.0
@@ -72,6 +74,7 @@ __metadata:
     jest: ^26.6.3
     js-yaml: ^3.14.1
     jsdom: ^16.6.0
+    jsonschema: ^1.4.0
     lint-staged: ^10.5.4
     moo: ^0.5.1
     prettier: ^2.2.1
@@ -3234,6 +3237,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sidvind/better-ajv-errors@npm:^0.9.1":
+  version: 0.9.1
+  resolution: "@sidvind/better-ajv-errors@npm:0.9.1"
+  dependencies:
+    "@babel/code-frame": ^7.0.0
+    chalk: ^4.0.0
+    json-to-ast: ^2.0.3
+    jsonpointer: ^4.1.0
+    leven: ^3.1.0
+  peerDependencies:
+    ajv: 4.11.8 - 8
+  checksum: 3addacff0bd10190cc6e5938d359720be662740b77070d9a741049d2ec68575f44214024c6a54e65963feb25e59e9cc13cd09c3b61059fd64cccd3a0bb6871ab
+  languageName: node
+  linkType: hard
+
 "@sinonjs/commons@npm:^1.7.0":
   version: 1.8.3
   resolution: "@sinonjs/commons@npm:1.8.3"
@@ -4520,9 +4538,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:^16.6.2":
-  version: 16.6.2
-  resolution: "@types/node@npm:16.6.2"
-  checksum: 2245e50058ac49ab3d76af5ded7fc655d783a88a800139dad6caaf962f15c909287853012c9461b49600741bcc2b09042f94ce734f0440b6ad444d838e62904a
+  version: 16.7.8
+  resolution: "@types/node@npm:16.7.8"
+  checksum: 060ea222ce8f3eb05bd86a7785ca5807503a50602dd805c5be997a5ae684fa6224c9ad8890bcc5551c05d14a8bcd735f94567691342d197f5f7f7f893ed0d46b
   languageName: node
   linkType: hard
 
@@ -5794,6 +5812,18 @@ __metadata:
     require-from-string: ^2.0.2
     uri-js: ^4.2.2
   checksum: 4cc0ca6c60d6a279aa7ade99515868a3d0485b2b920ddbbc6ee6c7100197dedeff61314a577c3258b1abbbbb084a846825ece7504c848ffbe513c9c54e5fc08b
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.6.2":
+  version: 8.6.2
+  resolution: "ajv@npm:8.6.2"
+  dependencies:
+    fast-deep-equal: ^3.1.1
+    json-schema-traverse: ^1.0.0
+    require-from-string: ^2.0.2
+    uri-js: ^4.2.2
+  checksum: b86d6cb86c69abbd8ce71ab7d4ff272660bf6d34fa9fbe770f73e54da59d531b2546692e36e2b35bbcfb11d20db774b4c09189671335185b8c799d65194e5169
   languageName: node
   linkType: hard
 
@@ -8267,6 +8297,13 @@ __metadata:
     chalk: ^2.4.1
     q: ^1.1.2
   checksum: 44736914aac2160d3d840ed64432a90a3bb72285a0cd6a688eb5cabdf15d15a85eee0915b3f6f2a4659d5075817b1cb577340d3c9cbb47d636d59ab69f819552
+  languageName: node
+  linkType: hard
+
+"code-error-fragment@npm:0.0.230":
+  version: 0.0.230
+  resolution: "code-error-fragment@npm:0.0.230"
+  checksum: 6c5e800d6d70b30938cc85a2fc2c6069f028eadb58bceb65716b995ce6228c99906302f2c438ba50115fd81a1ee15dd95dc7d317b16a6c590e311ac7e50613f3
   languageName: node
   linkType: hard
 
@@ -12776,6 +12813,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"grapheme-splitter@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "grapheme-splitter@npm:1.0.4"
+  checksum: 0c22ec54dee1b05cd480f78cf14f732cb5b108edc073572c4ec205df4cd63f30f8db8025afc5debc8835a8ddeacf648a1c7992fe3dcd6ad38f9a476d84906620
+  languageName: node
+  linkType: hard
+
 "graphlib@npm:^2.1.8":
   version: 2.1.8
   resolution: "graphlib@npm:2.1.8"
@@ -16205,6 +16249,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-to-ast@npm:^2.0.3":
+  version: 2.1.0
+  resolution: "json-to-ast@npm:2.1.0"
+  dependencies:
+    code-error-fragment: 0.0.230
+    grapheme-splitter: ^1.0.4
+  checksum: 1e9b051505b218573b39f3fec9054d75772413aefc2fee3e763d9033276664faa7eec26b945a71f70b9ce29685b2f13259df7dd3243e15eacf4672c62d5ba7ce
+  languageName: node
+  linkType: hard
+
 "json3@npm:^3.3.3":
   version: 3.3.3
   resolution: "json3@npm:3.3.3"
@@ -16284,6 +16338,20 @@ __metadata:
   version: 1.3.1
   resolution: "jsonparse@npm:1.3.1"
   checksum: 6514a7be4674ebf407afca0eda3ba284b69b07f9958a8d3113ef1005f7ec610860c312be067e450c569aab8b89635e332cee3696789c750692bb60daba627f4d
+  languageName: node
+  linkType: hard
+
+"jsonpointer@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "jsonpointer@npm:4.1.0"
+  checksum: ffc3e8937380989934676b339718d3213ecf5f6b7ce637b1ce5669a22f45dc61a86463e28abbe8c743d62f87ae790253c50cce0f586cb8e7623a21a7f811a444
+  languageName: node
+  linkType: hard
+
+"jsonschema@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "jsonschema@npm:1.4.0"
+  checksum: a2f96b5154658f5567b064d6f25fa4cb7e38b923d5dce9dad8d2566a07dd94abc4acedf234333a91f31bc9934e9dd57c270dcc51e5656b4c104408196c768580
   languageName: node
   linkType: hard
 
@@ -24835,22 +24903,22 @@ resolve@1.1.7:
   linkType: hard
 
 typescript@^4.3.5:
-  version: 4.3.5
-  resolution: "typescript@npm:4.3.5"
+  version: 4.4.2
+  resolution: "typescript@npm:4.4.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bab033b5e2b0790dd35b77fd005df976ef80b8d84fd2c6e63cc31808151875beae9216e5a315fe7068e8499905c3c354248fe83272cdfc13b7705635f0c66c97
+  checksum: 194e08e9d1971d667d6fd1a0554616b7022312a2319d70e81a64e502a265992061ee7817ed9a69b52bbabe7a9b85e7938cb8c11c433e40a516b277f8c4dacd51
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@^4.3.5#~builtin<compat/typescript>":
-  version: 4.3.5
-  resolution: "typescript@patch:typescript@npm%3A4.3.5#~builtin<compat/typescript>::version=4.3.5&hash=d8b4e7"
+  version: 4.4.2
+  resolution: "typescript@patch:typescript@npm%3A4.4.2#~builtin<compat/typescript>::version=4.4.2&hash=d8b4e7"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: bc2c4fdf0f1557fdafe4ef74848c72ebd9c8c60829568248f869121aea2bb20e16649a252431d0acb185ec118143be22bed73d08f64379557810d82756afedde
+  checksum: 11d6ab6e868117908c388401e2ac06d503c5c8709115ab80ee69a1a6352c1f98471d1e595636bfe6a2d6b20b03a44df6bb2d3d198cea97c0c328968cd18d2b70
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add the validate-config subcommand to the CLI. Currently, only supports
Java projects, and uses a hard-coded JSON schema for the config.

Here's what it looks like: https://asciinema.org/a/gVYKc91UGuM1Yb6W8z1uhgo7C