### PR TITLE
Update CLI build target to ES6

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -516,12 +516,12 @@ yargs(process.argv.slice(2))
       });
       return args.strict();
     },
-    (argv) => {
+    async (argv) => {
       verbose(argv.verbose);
 
       if (argv.watch) {
         const cmd = new FingerprintWatchCommand(argv.appmapDir);
-        cmd.execute();
+        await cmd.execute();
 
         if (!argv.verbose) {
           process.stdout.write('\x1B[?25l');
@@ -537,7 +537,8 @@ yargs(process.argv.slice(2))
           });
         }
       } else {
-        new FingerprintDirectoryCommand(argv.appmapDir).execute();
+        const cmd = new FingerprintDirectoryCommand(argv.appmapDir);
+        await cmd.execute();
       }
     }
   )

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -10,7 +10,7 @@
     "resolveJsonModule": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "types": ["node", "jest"]
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
This fixes issues with `index` exiting silently. ES5 does not support generators.