### PR TITLE
tests: Ignore APPMAP_TELEMETRY_DISABLED

### DIFF
--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -130,9 +130,13 @@ export default class Telemetry {
   private static _session?: Session;
   private static _client?: TelemetryClient;
   private static debug = process.env.APPMAP_TELEMETRY_DEBUG !== undefined;
-  private static enabled = process.env.APPMAP_TELEMETRY_DISABLED === undefined;
+  private static _enabled = process.env.APPMAP_TELEMETRY_DISABLED === undefined;
   public static readonly machineId = getMachineId();
 
+  static get enabled(): boolean {
+    return this._enabled
+  }
+  
   static get session(): Session {
     if (!this._session?.valid) {
       this._session = Session.issue();

--- a/packages/cli/tests/unit/telemetry.spec.ts
+++ b/packages/cli/tests/unit/telemetry.spec.ts
@@ -9,7 +9,7 @@ const invalidExpiration = () => Date.now() - 1000 * 60 * 60;
 
 describe('telemetry', () => {
   beforeAll(() => {
-    // Don't acidentally send data
+    // Don't accidentally send data
     sinon.stub(Telemetry, 'client').value({
       trackEvent: sinon.stub(),
     });
@@ -66,6 +66,10 @@ describe('telemetry', () => {
   });
 
   describe('Telemetry', () => {
+    beforeEach(() => {
+      sandbox.stub(Telemetry, 'enabled').get(() => true);
+    });
+
     it('sends the expected telemetry data', () => {
       const trackEvent = Telemetry.client.trackEvent as sinon.SinonStub;
       Telemetry.sendEvent({


### PR DESCRIPTION
Ignore the value of process.env.APPMAP_TELEMETRY_DISABLED when running
tests.