### PR TITLE
fix: Use child_process.spawn instead of exec

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/commandRunner.ts
+++ b/packages/cli/src/cmds/agentInstaller/commandRunner.ts
@@ -1,7 +1,7 @@
-import { ChildProcess, exec, execSync } from 'child_process';
+import { ChildProcess, execSync, spawn } from 'child_process';
 import path from 'path';
 import chalk from 'chalk';
-import CommandStruct, { CommandOutput, CommandReturn } from './commandStruct';
+import CommandStruct, { CommandReturn } from './commandStruct';
 import { verbose } from '../../utils';
 
 export class ProcessLog {
@@ -30,8 +30,8 @@ export class ProcessLog {
 
 export async function run(command: CommandStruct): Promise<CommandReturn> {
   return new Promise((resolve, reject) => {
-    const cp = exec(command.toString(), {
-      env: command.environment,
+    const cp = spawn(command.program, command.args, {
+        env: command.environment,
       cwd: command.path as string,
     });
 

--- a/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.ts
@@ -23,7 +23,7 @@ abstract class PythonEnvironment {
     const version = await getOutput('python', ['--version'], this.path);
     const pythonPath = await getOutput(
       'python',
-      ['-c', "'import sys; print(sys.prefix)'"],
+      ['-c', 'import sys; print(sys.prefix)'],
       this.path
     );
 


### PR DESCRIPTION
Avoid quoting issues (especially on Windows) by using
child_process.spawn instead of exec. Take advantage of this change by
removing some quoting in the Python installer.

I don't see any tests for this functionality. I've tested the python installer on macOS and Windows, and it works on both platforms. I've also inspected all places where `CommandStruct`s are created, so finger's crossed....