### PR TITLE
fix: "HTTP response details" section was already visible in event details

### DIFF
--- a/packages/components/src/components/DetailsPanelEvent.vue
+++ b/packages/components/src/components/DetailsPanelEvent.vue
@@ -52,7 +52,7 @@
       </ul>
     </div>
 
-    <div class="event-params" v-if="httpServerResponse">
+    <div class="event-params" v-if="Object.keys(httpServerResponse).length">
       <h5>HTTP response details</h5>
       <ul class="table-01">
         <li v-for="(v, k) in httpServerResponse" :key="k">


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1647695/137008551-688b8c6f-02ce-4a5d-8127-d72bc80560aa.png)

after:
![image](https://user-images.githubusercontent.com/1647695/137008487-33b6467d-7bac-4899-b381-7c135327c979.png)
