### PR TITLE
fix: Correct search for first gem in a Gemfile

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.ts
@@ -11,7 +11,8 @@ import { getOutput } from './commandUtil';
 import CommandStruct from './commandStruct';
 import EncodedFile from '../../encodedFile';
 
-const REGEX_GEM_DECLARATION = /(?!\s)(?:gem|group|require)\s/m;
+const REGEX_GEM_DECLARATION = /^(?:gem|group|require)\s/m;
+
 const REGEX_GEM_DEPENDENCY = /^\s*gem\s+['|"]appmap['|"].*$/m;
 const GEM_DEPENDENCY = "gem 'appmap', :groups => [:development, :test]";
 
@@ -66,7 +67,7 @@ export class BundleInstaller implements AgentInstaller {
       encodedFile.write(gemfile);
     } else {
       encodedFile.write(
-        `${gemfile}${os.EOL}gem "appmap", :groups => [:development, :test]${os.EOL}`
+        `${gemfile}${os.EOL}${GEM_DEPENDENCY}${os.EOL}`
       );
     }
 

--- a/packages/cli/tests/unit/fixtures/ruby/app/Gemfile.expected
+++ b/packages/cli/tests/unit/fixtures/ruby/app/Gemfile.expected
@@ -6,4 +6,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby '2.6.8'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails', branch: 'main'
+gem 'appmap', :groups => [:development, :test]
+
 gem 'rails', '~> 6.1.4', '>= 6.1.4.1'


### PR DESCRIPTION
Fix the regex the Ruby installers uses to find the first gem, group, or
require in a Gemfile. Now, it only matches those statements if they're
at the beginning of the line.

Also, adds a test to check that the Gemfile is properly updated.