### PR TITLE
feature: multi-project installer

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
@@ -4,148 +4,92 @@ import { resolve } from 'path';
 import Yargs from 'yargs';
 
 import AgentInstaller from './agentInstaller';
-import { AbortError, InstallError, ValidationError } from '../errors';
+import { AbortError, ValidationError } from '../errors';
 import { run } from './commandRunner';
 import UI from '../userInteraction';
 import AgentProcedure from './agentProcedure';
 
 export default class AgentInstallerProcedure extends AgentProcedure {
-  async run(userSpecifiedInstaller?: string): Promise<AgentInstaller> {
-    const availableInstallers = await this.getInstallersForProject();
+  async run(): Promise<void> {
+    const { confirm } = await UI.prompt({
+      type: 'confirm',
+      name: 'confirm',
+      message: [
+        `AppMap is about to be installed. Confirm the details below.`,
+        await this.getEnvironmentForDisplay(),
+        '',
+        '  Is this correct?',
+      ]
+        .flat()
+        .join('\n'),
+    });
 
-    let installer: AgentInstaller | undefined;
-    if (userSpecifiedInstaller) {
-      installer = this.installers.find(
-        (i) => i.name.toLowerCase() === userSpecifiedInstaller.toLowerCase()
+    if (!confirm) {
+      UI.status = 'Aborting installation.';
+      UI.error(
+        [
+          'Modify the installation environment as needed, and re-run the command.',
+          `Use ${chalk.blue('--help')} for more information.`,
+        ].join('\n')
       );
-
-      if (!installer) {
-        const { willContinue } = await UI.prompt([
-          {
-            type: 'confirm',
-            name: 'willContinue',
-            prefix: chalk.yellow('!'),
-            message: `${chalk.red(
-              userSpecifiedInstaller
-            )} is not a supported project type. However, installation may continue with: ${availableInstallers
-              .map((i) => chalk.blue(i.name))
-              .join(', ')}. Continue?`,
-          },
-        ]);
-
-        if (!willContinue) {
-          throw new AbortError(
-            [
-              `user attempted to install via \`${userSpecifiedInstaller}\` but aborted.`,
-              `installers available: ${availableInstallers
-                .map((i) => i.name)
-                .join(', ')}`,
-            ].join('\n')
-          );
-        }
-      }
+      throw new AbortError('aborted while confirming installation environment');
     }
 
-    if (!installer) {
-      if (availableInstallers.length === 1) {
-        installer = availableInstallers[0];
-      } else {
-        installer = await this.chooseInstaller(availableInstallers);
-      }
-    }
-    if (!installer) {
-      // This should branch should never occur
-      throw new ValidationError(`Invalid selection`);
-    }
+    let useExistingAppMapYml = false;
+    if (this.configExists) {
+      const USE_EXISTING = 'Use existing';
+      const OVERWRITE = 'Overwrite';
+      const ABORT = 'Abort';
 
-    try {
-
-      const { confirm } = await UI.prompt({
-        type: 'confirm',
-        name: 'confirm',
-        message: [
-          `AppMap is about to be installed. Confirm the details below.`,
-          await this.getEnvironmentForDisplay(installer),
-          '',
-          '  Is this correct?',
-        ]
-          .flat()
-          .join('\n'),
+      const { overwriteAppMapYml } = await UI.prompt({
+        type: 'list',
+        name: 'overwriteAppMapYml',
+        message:
+          'An appmap.yml configuration file already exists. How should the conflict be resolved?',
+        choices: [USE_EXISTING, OVERWRITE, ABORT],
       });
 
-      if (!confirm) {
-        UI.status = 'Aborting installation.';
-        UI.error(
-          [
-            'Modify the installation environment as needed, and re-run the command.',
-            `Use ${chalk.blue('--help')} for more information.`,
-          ].join('\n')
-        );
-        throw new AbortError(
-          'aborted while confirming installation environment'
-        );
+      if (overwriteAppMapYml === ABORT) {
+        Yargs.exit(0, new Error());
       }
 
-      let useExistingAppMapYml = false;
-      if (this.configExists) {
-        const USE_EXISTING = 'Use existing';
-        const OVERWRITE = 'Overwrite';
-        const ABORT = 'Abort';
-
-        const { overwriteAppMapYml } = await UI.prompt({
-          type: 'list',
-          name: 'overwriteAppMapYml',
-          message:
-            'An appmap.yml configuration file already exists. How should the conflict be resolved?',
-          choices: [USE_EXISTING, OVERWRITE, ABORT],
-        });
-
-        if (overwriteAppMapYml === ABORT) {
-          Yargs.exit(0, new Error());
-        }
-
-        if (overwriteAppMapYml === USE_EXISTING) {
-          useExistingAppMapYml = true;
-        }
+      if (overwriteAppMapYml === USE_EXISTING) {
+        useExistingAppMapYml = true;
       }
-
-      UI.status = 'Installing the AppMap agent...';
-
-      await installer.installAgent();
-
-      this.verifyProject(installer);
-
-      const appMapYml = this.configPath;
-      if (!useExistingAppMapYml) {
-        const initCommand = await installer.initCommand();
-        const { stdout } = await run(initCommand);
-        const json = JSON.parse(stdout);
-
-        fs.writeFileSync(appMapYml, json.configuration.contents);
-      }
-
-      await this.validateProject(installer, useExistingAppMapYml);
-
-      const successMessage = [
-        chalk.green('Success! The AppMap agent has been installed.'),
-      ];
-
-      if (installer.postInstallMessage) {
-        successMessage.push('', await installer.postInstallMessage(), '');
-      }
-
-      if (installer.documentation) {
-        successMessage.push(
-          'For more information, visit',
-          chalk.blue(installer.documentation)
-        );
-      }
-
-      UI.success(successMessage.join('\n'));
-
-      return installer;
-    } catch (e) {
-      throw new InstallError(e, installer);
     }
+
+    UI.status = 'Installing the AppMap agent...';
+
+    await this.installer.installAgent();
+
+    this.verifyProject();
+
+    const appMapYml = this.configPath;
+    if (!useExistingAppMapYml) {
+      const initCommand = await this.installer.initCommand();
+      const { stdout } = await run(initCommand);
+      const json = JSON.parse(stdout);
+
+      fs.writeFileSync(appMapYml, json.configuration.contents);
+    }
+
+    await this.validateProject(useExistingAppMapYml);
+
+    const successMessage = [
+      chalk.green('Success! The AppMap agent has been installed.'),
+    ];
+
+    if (this.installer.postInstallMessage) {
+      successMessage.push('', await this.installer.postInstallMessage(), '');
+    }
+
+    if (this.installer.documentation) {
+      successMessage.push(
+        'For more information, visit',
+        chalk.blue(this.installer.documentation)
+      );
+    }
+
+    UI.success(successMessage.join('\n'));
   }
 }

--- a/packages/cli/src/cmds/agentInstaller/agentStatusProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentStatusProcedure.ts
@@ -1,24 +1,14 @@
-import UI from "../userInteraction";
-import AgentProcedure from "./agentProcedure";
-import Yargs from 'yargs';
+import UI from '../userInteraction';
+import AgentProcedure from './agentProcedure';
+
 export default class AgentStatusProcedure extends AgentProcedure {
   async run(): Promise<void> {
-    const installers = await this.getInstallersForProject();
-    let installer;
-    if (installers.length === 1) {
-      installer = installers[0];
-    }
-    else {
-      installer = await this.chooseInstaller(installers);
-    }
-    
     console.log('\nAgent environment:');
-    const env = await this.getEnvironmentForDisplay(installer)
+    const env = await this.getEnvironmentForDisplay();
     console.log(`${env.join('\n')}\n`);
 
-    await this.verifyProject(installer);
-
-    await this.validateProject(installer, true);
+    await this.verifyProject();
+    await this.validateProject(true);
 
     UI.success('Success!');
   }

--- a/packages/cli/src/cmds/agentInstaller/commandRunner.ts
+++ b/packages/cli/src/cmds/agentInstaller/commandRunner.ts
@@ -106,7 +106,7 @@ export async function run(command: CommandStruct): Promise<CommandReturn> {
         reject(
           new ChildProcessError(
             command.toString(),
-            `${command.toString()} was not found. Verify the command can be found in your PATH and try again.`
+            `${command.program} was not found. Verify the command can be found in your PATH and try again.`
           )
         );
       }

--- a/packages/cli/src/cmds/agentInstaller/commandRunner.ts
+++ b/packages/cli/src/cmds/agentInstaller/commandRunner.ts
@@ -27,6 +27,13 @@ export class ProcessLog {
       `\n\n'${program}' exited with code ${code}, signal ${signal}\n\n`
     );
   }
+
+  // Return the current buffer and clear it for future use
+  public static consumeBuffer() {
+    const buffer = this.buffer;
+    this.buffer = '';
+    return buffer;
+  }
 }
 
 interface CommandOutputChunk {

--- a/packages/cli/src/cmds/agentInstaller/installers.ts
+++ b/packages/cli/src/cmds/agentInstaller/installers.ts
@@ -1,0 +1,34 @@
+import AgentInstaller from './agentInstaller';
+import GradleInstaller from './gradleInstaller';
+import MavenInstaller from './mavenInstaller';
+import { PipInstaller, PoetryInstaller } from './pythonAgentInstaller';
+import { BundleInstaller } from './rubyAgentInstaller';
+
+type AgentInstallerConstructor = new (...args: any[]) => AgentInstaller;
+export const INSTALLERS: readonly AgentInstallerConstructor[] = [
+  BundleInstaller,
+  MavenInstaller,
+  GradleInstaller,
+  PipInstaller,
+  PoetryInstaller,
+];
+
+/**
+ * Retrieve the installers available for a given path
+ * @param path The path to check for available installers
+ * @returns An array of installers available for the given path. May be empty.
+ */
+export default async function getAvailableInstallers(
+  path: string
+): Promise<AgentInstaller[]> {
+  const allInstallers = INSTALLERS.map((constructor) => new constructor(path));
+
+  // Results is an array lookup containing a boolean indicating whether the installer is available
+  // e.g. [true, false, true, true]
+  const results = await Promise.all(
+    allInstallers.map(async (installer) => await installer.available())
+  );
+
+  // Index the results array to get the installers that are available
+  return allInstallers.filter((_, i) => results[i]);
+}

--- a/packages/cli/src/cmds/agentInstaller/projectConfiguration.ts
+++ b/packages/cli/src/cmds/agentInstaller/projectConfiguration.ts
@@ -1,0 +1,233 @@
+import chalk from 'chalk';
+import { promises as fs, constants as fsConstants } from 'fs';
+import { basename, join, resolve } from 'path';
+import { AbortError, InvalidPathError } from '../errors';
+import UI from '../userInteraction';
+import AgentInstaller from './agentInstaller';
+import getAvailableInstallers from './installers';
+
+export interface ProjectConfiguration {
+  name: string;
+  path: string;
+  availableInstallers: AgentInstaller[];
+  selectedInstaller?: AgentInstaller;
+  writeAppMapYaml?: boolean;
+}
+
+async function resolveSelectedInstallers(
+  projects: ProjectConfiguration[],
+  userSpecifiedInstaller?: string
+): Promise<void> {
+  // Attempt to resolve selectedInstallers from the user's arg line input.
+  if (userSpecifiedInstaller) {
+    for (const project of projects) {
+      const { availableInstallers } = project;
+      let selectedInstaller: AgentInstaller | undefined;
+
+      selectedInstaller = availableInstallers.find(
+        (i) => i.name.toLowerCase() === userSpecifiedInstaller.toLowerCase()
+      );
+
+      if (!selectedInstaller) {
+        const { willContinue } = await UI.prompt([
+          {
+            type: 'confirm',
+            name: 'willContinue',
+            prefix: chalk.yellow('!'),
+            message: `${chalk.red(
+              userSpecifiedInstaller
+            )} is not a supported project type. However, installation for ${chalk.blue(
+              name
+            )} may continue with: ${availableInstallers
+              .map((i) => chalk.blue(i.name))
+              .join(', ')}. Continue?`,
+          },
+        ]);
+
+        if (!willContinue) {
+          throw new AbortError(
+            [
+              `user attempted to install via \`${userSpecifiedInstaller}\` but aborted.`,
+              `installers available: ${availableInstallers
+                .map((i) => i.name)
+                .join(', ')}`,
+            ].join('\n')
+          );
+        }
+      }
+
+      project.selectedInstaller = selectedInstaller;
+    }
+  }
+
+  // Populate selected installer either by selecting the only one available or prompting the user
+  // to make a selection.
+  for (let i = 0; i < projects.length; ++i) {
+    const project = projects[i];
+    if (!project.selectedInstaller) {
+      if (project.availableInstallers.length === 1) {
+        project.selectedInstaller = project.availableInstallers[0];
+      } else {
+        const key = `installer${i}`;
+        const result = await UI.prompt({
+          type: 'list',
+          name: key,
+          message: `Multiple project types were found in ${chalk.blue(
+            resolve(project.path)
+          )}. Select one to continue.`,
+          choices: project.availableInstallers.map((i) => i.name),
+        });
+        const installerName = result[key];
+        project.selectedInstaller = project.availableInstallers.find(
+          (i) => i.name === installerName
+        );
+      }
+    }
+  }
+
+  // Sanity check. Verify everything resolved properly. This should branch should never occur.
+  if (projects.some(({ selectedInstaller }) => !selectedInstaller)) {
+    throw new Error('Invalid selection');
+  }
+}
+
+/**
+ * Identifies subprojects and returns an array of ProjectConfigurations if the user chooses to
+ * install to them. If the user opts not to install to any subprojects, undefined is returned. This
+ * is different from an empty array, which indicates the user opted to install to subprojects, but
+ * selected nothing.
+ * @param dir
+ * @returns ProjectConfiguration[] if the user chooses to install to subprojects, otherwise
+ *          undefined
+ */
+async function getSubprojects(
+  dir: string
+): Promise<ProjectConfiguration[] | undefined> {
+  const ents = await fs.readdir(dir, { withFileTypes: true });
+  const subprojects = (
+    await Promise.all(
+      ents.map(async (ent): Promise<ProjectConfiguration | null> => {
+        if (!ent.isDirectory()) {
+          return null;
+        }
+
+        const subProjectPath = join(dir, ent.name);
+        try {
+          await fs.access(subProjectPath, fsConstants.R_OK);
+        } catch {
+          // This directory is not readable. Ignore it.
+          return null;
+        }
+
+        const installers = await getAvailableInstallers(subProjectPath);
+        if (!installers.length) {
+          return null;
+        }
+
+        return {
+          name: ent.name,
+          path: subProjectPath,
+          availableInstallers: installers,
+        };
+      })
+    )
+  ).filter(Boolean) as ProjectConfiguration[];
+
+  if (!subprojects.length) {
+    // There's nothing that we can do here.
+    return undefined;
+  }
+
+  const { addSubprojects } = await UI.prompt({
+    type: 'confirm',
+    name: 'addSubprojects',
+    message:
+      'This directory contains sub-projects. Would you like to choose sub-projects for installation?',
+  });
+  if (!addSubprojects) {
+    // The user has opted not to continue by selecting subprojects.
+    return undefined;
+  }
+
+  const subProjectConfigurations: ProjectConfiguration[] = [];
+  const { selectedSubprojects } = await UI.prompt({
+    type: 'checkbox',
+    name: 'selectedSubprojects',
+    message: 'Select the projects to install AppMap to.',
+    choices: subprojects.map(({ name }) => name),
+  });
+
+  if (selectedSubprojects.length > 0) {
+    subProjectConfigurations.push(
+      ...subprojects.filter(({ name }) => selectedSubprojects.includes(name))
+    );
+  }
+
+  return subProjectConfigurations;
+}
+
+export async function getProjects(
+  installers: readonly AgentInstaller[],
+  dir: string,
+  allowMulti?: boolean,
+  userSpecifiedInstaller?: string
+): Promise<ProjectConfiguration[]> {
+  let projectConfigurations: ProjectConfiguration[] = [];
+
+  if (allowMulti) {
+    const subprojects = await getSubprojects(dir);
+    if (subprojects?.length) {
+      projectConfigurations.push(...(subprojects as ProjectConfiguration[]));
+    } else if (subprojects?.length === 0) {
+      throw new InvalidPathError(
+        'No sub-projects were chosen, so there is nothing to do. Exiting.',
+        dir
+      );
+    }
+  }
+
+  // If there are no subprojects, we will continue by installing to the current directory.
+  if (!projectConfigurations.length) {
+    const availableInstallers = await getAvailableInstallers(dir);
+    if (availableInstallers.length) {
+      projectConfigurations = [
+        {
+          name: basename(dir),
+          path: resolve(dir),
+          availableInstallers,
+        },
+      ];
+    } else {
+      const longestInstallerName = Math.max(
+        ...installers.map((i) => i.name.length)
+      );
+
+      throw new InvalidPathError(
+        [
+          `No supported project was found in ${chalk.red(resolve(dir))}.`,
+          '',
+          'The installation requirements for each project type are listed below:',
+          installers
+            .map(
+              (i) =>
+                `${chalk.blue(
+                  i.name.padEnd(longestInstallerName + 2, ' ')
+                )} ${chalk.yellow(`${i.buildFile} not found`)}`
+            )
+            .filter(Boolean)
+            .join('\n'),
+          '',
+          `At least one of the requirements above must be satisfied to continue.`,
+          '',
+          `Change the current directory or specify a different directory as the last argument to this command.`,
+          `Use ${chalk.blue('--help')} for more information.`,
+        ].join('\n'),
+        dir
+      );
+    }
+  }
+
+  resolveSelectedInstallers(projectConfigurations, userSpecifiedInstaller);
+
+  return projectConfigurations;
+}

--- a/packages/cli/src/cmds/agentInstaller/telemetryUtil.ts
+++ b/packages/cli/src/cmds/agentInstaller/telemetryUtil.ts
@@ -1,0 +1,13 @@
+import { promises as fs } from 'fs';
+
+export async function getDirectoryProperty(path: string): Promise<string> {
+  try {
+    return (await fs.readdir(path)).join('\n');
+  } catch (e) {
+    if (e instanceof Error) {
+      return e.stack || e.message;
+    } else {
+      return String(e);
+    }
+  }
+}

--- a/packages/cli/src/cmds/errors.ts
+++ b/packages/cli/src/cmds/errors.ts
@@ -1,9 +1,10 @@
 import chalk from 'chalk';
 import { prefixLines } from '../utils';
-import AgentInstaller from './agentInstaller/agentInstaller';
 
-export class InstallError {
-  constructor(readonly error: unknown, readonly installer?: AgentInstaller) {}
+export class InvalidPathError extends Error {
+  constructor(readonly message: string, readonly path?: string) {
+    super(message);
+  }
 }
 
 export class AbortError extends Error {}

--- a/packages/cli/tests/unit/agentInstall/statusCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/statusCommand.spec.ts
@@ -1,10 +1,11 @@
-import path from "path";
+import path from 'path';
 import tmp from 'tmp';
-import yargs from "yargs";
+import yargs from 'yargs';
 import sinon, { stubInterface } from 'ts-sinon';
 import 'jest-sinon';
 import AgentInstaller from '../../../src/cmds/agentInstaller/agentInstaller';
 import AgentStatusProcedure from '../../../src/cmds/agentInstaller/agentStatusProcedure';
+import * as ProjectConfiguration from '../../../src/cmds/agentInstaller/projectConfiguration';
 
 import UI from '../../../src/cmds/userInteraction';
 
@@ -12,38 +13,51 @@ tmp.setGracefulCleanup();
 
 const invokeCommand = (
   projectDir: string,
-  evalResults: (err: Error | undefined, argv: any, output: string) => void,
-  ) => {
+  evalResults: (err: Error | undefined, argv: any, output: string) => void
+) => {
   sinon.stub(console, 'log');
   sinon.stub(console, 'warn');
   sinon.stub(console, 'error');
   return yargs
     .command(require('../../../src/cmds/agentInstaller/status').default)
-    .parse(
-      `status ${projectDir}`,
-      {},
-      (err, argv, output) => {
-        evalResults(err, argv, output);
-      }
-    );
+    .parse(`status ${projectDir}`, {}, (err, argv, output) => {
+      evalResults(err, argv, output);
+    });
 };
 
 describe('status sub-command', () => {
   let projectDir: string;
-  let getInstallersForProject, chooseInstaller, verifyProject, validateProject, success;
+  let getInstallersForProject,
+    chooseInstaller,
+    verifyProject,
+    validateProject,
+    success;
   beforeEach(() => {
     projectDir = tmp.dirSync({} as any).name;
-    sinon.stub(AgentStatusProcedure.prototype, 'getEnvironmentForDisplay').resolves(['env']);
+    sinon
+      .stub(AgentStatusProcedure.prototype, 'getEnvironmentForDisplay')
+      .resolves(['env']);
 
     const installer = stubInterface<AgentInstaller>();
     installer.verifyCommand = undefined;
 
-    getInstallersForProject = sinon.stub(AgentStatusProcedure.prototype, 'getInstallersForProject').resolves([installer]);
+    getInstallersForProject = sinon
+      .stub(ProjectConfiguration, 'getProjects')
+      .resolves([
+        {
+          path: projectDir,
+          name: 'test',
+          availableInstallers: [installer],
+          selectedInstaller: installer,
+        },
+      ]);
 
-    chooseInstaller = sinon.stub(AgentStatusProcedure.prototype, 'chooseInstaller');
     verifyProject = sinon.stub(AgentStatusProcedure.prototype, 'verifyProject');
-    validateProject = sinon.stub(AgentStatusProcedure.prototype, 'validateProject');
-    success = sinon.stub(UI, 'success')
+    validateProject = sinon.stub(
+      AgentStatusProcedure.prototype,
+      'validateProject'
+    );
+    success = sinon.stub(UI, 'success');
   });
 
   afterEach(() => {
@@ -53,11 +67,10 @@ describe('status sub-command', () => {
   it('works', async () => {
     const evalResults = (err, argv, output) => {
       expect(err).toBeNull;
-    }
+    };
 
     await invokeCommand(projectDir, evalResults);
-    
-    expect(chooseInstaller).not.toBeCalled();
+
     expect(verifyProject).toBeCalledOnce();
     expect(validateProject).toBeCalledOnce();
     expect(success).toBeCalledWithExactly('Success!');
@@ -68,19 +81,25 @@ describe('status sub-command', () => {
     installers[0] = stubInterface<AgentInstaller>();
     installers[1] = stubInterface<AgentInstaller>();
 
-    getInstallersForProject.restore();    
-    getInstallersForProject = sinon.stub(AgentStatusProcedure.prototype, 'getInstallersForProject').resolves(installers);
-
-    chooseInstaller.resolves(installers[0]);
+    getInstallersForProject.restore();
+    getInstallersForProject = sinon
+      .stub(ProjectConfiguration, 'getProjects')
+      .resolves([
+        {
+          path: projectDir,
+          name: 'test',
+          availableInstallers: installers,
+          selectedInstaller: installers[0],
+        },
+      ]);
 
     const evalResults = (err, argv, output) => {
       expect(err).toBeNull;
-    }
+    };
 
     await invokeCommand(projectDir, evalResults);
-    expect(chooseInstaller).toBeCalledOnce();
   });
-  
+
   it('fails when project verification fails', async () => {
     const error = new Error('verification failed');
     verifyProject.throws(error);

--- a/packages/cli/tests/unit/fixtures/java/multi-project/project-a/pom.xml
+++ b/packages/cli/tests/unit/fixtures/java/multi-project/project-a/pom.xml
@@ -1,0 +1,28 @@
+<!-- This is a comment as the first child node. -->
+<!-- There doesn't appear to be a way to control w3c-xmlserializer's
+indentation, so the spacing in expected-pom.xml is a bit wonky -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.springframework.samples</groupId>
+  <artifactId>spring-petclinic</artifactId>
+  <version>2.4.5</version>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.spring.javaformat</groupId>
+        <artifactId>spring-javaformat-maven-plugin</artifactId>
+        <version>${spring-format.version}</version>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/packages/cli/tests/unit/fixtures/java/multi-project/project-b/build.gradle
+++ b/packages/cli/tests/unit/fixtures/java/multi-project/project-b/build.gradle
@@ -1,0 +1,12 @@
+buildscript { }
+
+plugins {
+  id 'java'
+}
+
+repositories {
+  mavenCentral()
+}
+
+group = 'com.example'
+version = '0.0.0-test'


### PR DESCRIPTION
If sub-projects are detected, this change will ask the user if they'd like to select sub-projects. If so, they'll have the ability to select which sub-projects to install to. The installer flow will then be run for each directory selected.

Also, incorrect installer path errors or process abort cases are now reported as `soft_failure`.

See the updated flow here: https://asciinema.org/a/e3sVXMwRHN8Ul1s4YKd10GMeg