### PR TITLE
fix: Move install docs command and copied text to props

### DIFF
--- a/packages/components/src/pages/quickstart-docs/InstallAgent.vue
+++ b/packages/components/src/pages/quickstart-docs/InstallAgent.vue
@@ -41,12 +41,13 @@ export default {
     VCodeSnippet,
   },
 
-  data() {
-    return {
-      codeSnippet: 'npx @appland/appmap install-agent',
-      messageSuccess:
+  props: {
+    codeSnippet: String,
+    messageSuccess: {
+      type: String,
+      default:
         '<b>Copied!</b><br>Paste into your terminal<br>to run the installer',
-    };
+    },
   },
 
   methods: {

--- a/packages/components/src/stories/QuickstartDocsInstallAgent.stories.js
+++ b/packages/components/src/stories/QuickstartDocsInstallAgent.stories.js
@@ -4,7 +4,7 @@ export default {
   title: 'Pages/VS Code/Quickstart Docs/Install Agent',
   component: InstallAgent,
   args: {
-    clipboardText: 'npx @appland/appmap install-agent',
+    codeSnippet: 'npx @appland/appmap install-agent',
   },
 };
 


### PR DESCRIPTION
I found that the command was hardcoded after attempting to change it downstream. This fixes that.