### PR TITLE
Use IntelliJ JDK and build tools

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
@@ -62,7 +62,7 @@ export default class AgentInstallerProcedure extends AgentProcedure {
 
     await this.installer.installAgent();
 
-    this.verifyProject();
+    await this.verifyProject();
 
     const appMapYml = this.configPath;
     if (!useExistingAppMapYml) {

--- a/packages/cli/src/cmds/agentInstaller/javaBuildToolInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/javaBuildToolInstaller.ts
@@ -1,7 +1,30 @@
+import glob from 'glob';
+import os from 'os';
+import path from 'path';
 import chalk from 'chalk';
 import CommandStruct from './commandStruct';
 import { run } from './commandRunner';
 import { getOutput } from './commandUtil';
+import { findIntelliJHome } from './jetBrainsSupport';
+
+export function addJetBrainsEnv() {
+  const jbHome = findIntelliJHome();
+  if (!jbHome) {
+    return;
+  }
+
+  const javaHome = path.join(jbHome, 'jbr');
+  const gradleBin = path.join(jbHome, 'lib');
+  const mvnBin = path.join(jbHome, 'plugins/maven/maven3/bin');
+
+  // Make sure we don't override the user's settings: append to path, use the
+  // existing JAVA_HOME if it's set.
+  if (!process.env['JAVA_HOME']) {
+      process.env['JAVA_HOME'] = javaHome;
+  };
+  process.env['PATH'] = [process.env['PATH'], path.join(javaHome, 'bin'), gradleBin, mvnBin].join(path.delimiter);
+}
+addJetBrainsEnv();
 
 export default abstract class JavaBuildToolInstaller {
   private _agentJar?: string;
@@ -42,7 +65,7 @@ export default abstract class JavaBuildToolInstaller {
         .split('=')[1];
     }
 
-    return this._agentJar!;
+    return this._agentJar!.trim();
   }
 
   async environment(): Promise<Record<string, string>> {
@@ -50,7 +73,7 @@ export default abstract class JavaBuildToolInstaller {
     // javac 1.8.0_212-internal (build 1.8.0_212-internal+11)
     const version = await getOutput('javac', ['-version'], this.path);
     return {
-      JAVA_HOME: process.env.JAVA_HOME || chalk.yellow('Unspecified'),
+      JAVA_HOME: process.env['JAVA_HOME'] || chalk.yellow('Unspecified'),
       'JDK Version': version.ok
         ? version.output.split(/\s/)[1]
         : chalk.red(version.output),

--- a/packages/cli/src/cmds/agentInstaller/jetBrainsSupport.ts
+++ b/packages/cli/src/cmds/agentInstaller/jetBrainsSupport.ts
@@ -1,0 +1,17 @@
+import glob from 'glob';
+import os from 'os';
+import path from 'path';
+
+export function findIntelliJHome(): string | undefined {
+  let defaultDir;
+  if (os.platform() === 'win32') {
+    defaultDir = 'C:/Program Files/JetBrains/IntelliJ*';
+  } else if (os.platform() === 'darwin') {
+    defaultDir = '/Applications/IntelliJ*.app/Contents';
+  } else {
+    return;
+  }
+
+  let jbHome = glob.sync(path.join(defaultDir));
+  return jbHome.length !== 0 ? jbHome[0] : undefined;
+}

--- a/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
@@ -1,5 +1,6 @@
+import {existsSync} from 'fs';
 import os from 'os';
-import { join, sep } from 'path';
+import { join, sep, delimiter as pathDelimiter } from 'path';
 import { JSDOM } from 'jsdom';
 import xmlSerializer from 'w3c-xmlserializer';
 import chalk from 'chalk';
@@ -30,11 +31,11 @@ export default class MavenInstaller
   }
 
   async postInstallMessage(): Promise<string> {
-    let mvnBin = await this.runCommand();
+    const mvn = this.runCommand();
 
     return [
       `The AppMap agent will automatically record your tests when you run ${chalk.blue(
-        `${mvnBin} test`
+        `${mvn} test`
       )}`,
       `By default, AppMap files will be output to ${chalk.blue(
         'target/appmap'
@@ -46,9 +47,9 @@ export default class MavenInstaller
     return await exists(this.buildFilePath);
   }
 
-  async runCommand(): Promise<string> {
+  runCommand(): string {
     const ext = os.platform() === 'win32' ? '.cmd' : '';
-    const wrapperExists = await exists(join(this.path, `mvnw${ext}`));
+    const wrapperExists = existsSync(join(this.path, `mvnw${ext}`));
 
     if (wrapperExists) {
       return `.${sep}mvnw${ext}`;
@@ -65,7 +66,7 @@ export default class MavenInstaller
 
   async verifyCommand(): Promise<CommandStruct> {
     return new CommandStruct(
-      await this.runCommand(),
+      this.runCommand(),
       ['-Dplugin=com.appland:appmap-maven-plugin', 'help:describe'],
       this.path
     );
@@ -73,7 +74,7 @@ export default class MavenInstaller
 
   async printJarPathCommand(): Promise<CommandStruct> {
     return new CommandStruct(
-      await this.runCommand(),
+      this.runCommand(),
       ['appmap:print-jar-path'],
       this.path
     );

--- a/packages/cli/tests/unit/agentInstall/javaBuildToolInstaller.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/javaBuildToolInstaller.spec.ts
@@ -1,0 +1,57 @@
+import * as jbs from '../../../src/cmds/agentInstaller/jetBrainsSupport';
+import { addJetBrainsEnv } from '../../../src/cmds/agentInstaller/javaBuildToolInstaller';
+import sinon from 'sinon';
+
+describe('JavaBuildToolInstaller', () => {
+  let origPath, origJavaHome;
+  beforeEach(() => {
+    origPath = process.env.PATH;
+    origJavaHome = process.env.JAVA_HOME;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    process.env.PATH = origPath;
+    process.env.JAVA_HOME = origJavaHome;
+  });
+
+  describe('when IntelliJ is installed', () => {
+    const intellijHome = '/IntelliJ';
+    beforeEach(() => {
+      sinon.stub(jbs, 'findIntelliJHome').returns(intellijHome);
+    });
+
+    it('appends JetBrains JDK to PATH', () => {
+      addJetBrainsEnv();
+      expect(process.env.PATH).toMatch(/\/IntelliJ\/jbr\/bin/);
+    });
+
+    it('sets JAVA_HOME if unset', () => {
+      delete process.env.JAVA_HOME;
+      addJetBrainsEnv();
+      expect(process.env.JAVA_HOME).toBe(intellijHome + '/jbr');
+    });
+
+    it('uses JAVA_HOME if set', () => {
+      process.env.JAVA_HOME = '/JDK';
+      addJetBrainsEnv();
+      expect(process.env.JAVA_HOME).toBe('/JDK');
+    });
+  });
+
+  describe('when IntelliJ is not installed', () => {
+    beforeEach(() => {
+      sinon.stub(jbs, 'findIntelliJHome').returns(undefined);
+    });
+
+    it("doesn't update PATH", () => {
+      addJetBrainsEnv();
+      expect(process.env.PATH).toBe(origPath);
+    });
+
+    it("doesn't set JAVA_HOME", () => {
+      addJetBrainsEnv();
+      expect(process.env.JAVA_HOME).toBe(origJavaHome);
+    });
+  });
+});


### PR DESCRIPTION
Use the IntelliJ embedded JDK and build tools, if available and not overriden, when installing and validating the Java agent. The user can override the use of the embedded components by setting the `PATH` and `JAVA_HOME` environment variables appropriately.

Fixes #413.