### PR TITLE
fix: Map language types to OpenAPI types

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -569,6 +569,22 @@ yargs(process.argv.slice(2))
     type: 'boolean',
     description: 'Run with verbose logging',
   })
+  .fail((msg, err, yargs) => {
+    if (msg) {
+      console.log(yargs.help());
+      console.log(msg);
+    }
+    else if (err) {
+      if (err.cause) {
+        console.error(err.message);
+        console.error(err.cause);
+      }
+      else {
+        console.error(err);
+      }
+    }
+    process.exit(1);
+  })
   .command(OpenAPICommand)
   .command(InstallCommand)
   .command(OpenCommand)

--- a/packages/cli/src/cmds/agentInstaller/install-agent.ts
+++ b/packages/cli/src/cmds/agentInstaller/install-agent.ts
@@ -234,7 +234,9 @@ export default {
     await Telemetry.flush();
 
     if (errors.length) {
-      Yargs.exit(1, new Error(errors.map((e) => e.message).join('\n')));
+      const reason = new Error(errors.map((e) => e.message).join('\n'));
+      console.log(reason.message);
+      Yargs.exit(1, reason);
     }
   },
 };

--- a/packages/cli/tests/unit/openapi.spec.ts
+++ b/packages/cli/tests/unit/openapi.spec.ts
@@ -1,0 +1,65 @@
+import { messageToOpenAPISchema } from '../../src/openapi/util';
+
+const message = (c) => ({message: {class: c}});
+const expected = (t, i?) => { 
+  const r = {expected: {type: t}}; 
+  if (i) {
+    r.expected['items'] = {type: i};
+  }
+  return r;
+};
+
+const mapping = (c, t, i?) => ({
+  ...message(c),
+  ...expected(t, i)
+});
+
+const multi = (classes, t) => {
+  return classes.map((c) => ({...message(c), ...expected(t)}));
+};
+
+const mappingExamples = (mappings) => {
+  mappings.forEach((m) => {
+    it(`maps from ${m.message.class} to ${m.expected.type}`, () => {
+      const actual = messageToOpenAPISchema(m.message);
+      expect(actual).toStrictEqual(m.expected);
+    });
+  });
+};
+
+describe('messageToOpenAPISchema', () => {
+  describe('for Ruby types', () => {
+    const rubyMappings = [
+      mapping('Array', 'array', 'string'),
+      mapping('NilClass', 'string'),
+      mapping('MyClass', 'MyClass'),
+      ...multi(['Hash', 'ActiveSupport::HashWithIndifferentAccess'], 'object'),
+      ...multi(['TrueClass', 'FalseClass'], 'boolean'),
+    ];
+
+    mappingExamples(rubyMappings);
+  });
+  
+  describe('for Python type', () => {
+    const pythonMappings = [
+      mapping('builtins.bool', 'boolean'),
+      mapping('builtins.dict', 'object'),
+      mapping('builtins.int', 'integer'),
+      mapping('builtins.list', 'array', 'string'),
+      mapping('builtins.str', 'string'),
+      mapping('MyPythonClass', 'MyPythonClass'),
+    ];
+
+    mappingExamples(pythonMappings);
+  });
+
+  describe('for Java Types', () => {
+    const javaMappings = [
+      mapping('java.lang.String', 'string'),
+      mapping('com.example.MyClass', 'com.example.MyClass'),
+    ];
+
+    mappingExamples(javaMappings);
+  });    
+
+});


### PR DESCRIPTION
Add type mappings for Python and Java. This ensures that all types that
can appear in AppMaps will get mapped to the corresponding OpenAPI type.

Fixes #445.