### PR TITLE
fix: Wait for debugging information on exit

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/install-agent.ts
+++ b/packages/cli/src/cmds/agentInstaller/install-agent.ts
@@ -57,7 +57,7 @@ class InstallerError {
       .join(', ');
 
     if (this.error instanceof AbortError) {
-      await Telemetry.sendEvent({
+      Telemetry.sendEvent({
         name: 'install-agent:abort',
         properties: {
           installer: this.project?.selectedInstaller?.name,
@@ -104,7 +104,7 @@ class InstallerError {
         }
       }
 
-      await Telemetry.sendEvent({
+      Telemetry.sendEvent({
         name: 'install-agent:failure',
         properties: {
           installer: this.project?.selectedInstaller?.name,
@@ -229,6 +229,9 @@ export default {
 
       errors.push(installerError);
     }
+
+    // Make sure there's nothing left in the queue before we exit.
+    await Telemetry.flush();
 
     if (errors.length) {
       Yargs.exit(1, new Error(errors.map((e) => e.message).join('\n')));


### PR DESCRIPTION
`Yargs.exit` results in a call to `process.exit`, immediately exiting the process without waiting for promises to resolve. This was resulting in us losing some data. As a result, all telemetry events are now sent without `await`, and if the queue is not clear by the time the command is finishing, we'll wait for the queue to flush. This won't capture exit via `SIGINT` or similar, but that's a more complicated effort.