### PR TITLE
fix: Show the correct version with --version

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,8 @@
     "pre-commit": "lint-staged",
     "test": "jest",
     "build": "tsc && webpack --mode=production",
-    "start": "ts-node src/cli.ts"
+    "start": "ts-node src/cli.ts",
+    "prepack": "$npm_execpath run build"
   },
   "lint-staged": {
     "*.{js,md,json}": [


### PR DESCRIPTION
Add a prepack hook to the package.json. This will cause the updates
applied by semantic-release (e.g. the new version) to be included in the
compiled sources that are packaged and published to npm.