### PR TITLE
fix: Rebuild packages before publish

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -10,10 +10,10 @@ module.exports = {
         releaseRules: [
           {
             type: 'feature',
-            release: 'minor'
-          }
-        ]
-      }
+            release: 'minor',
+          },
+        ],
+      },
     ],
     '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
@@ -36,6 +36,12 @@ module.exports = {
             ],
           },
         ],
+      },
+    ],
+    [
+      '@semantic-release/exec',
+      {
+        publishCmd: 'yarn build',
       },
     ],
     '@semantic-release/git',

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "packages/*"
   ],
   "scripts": {
-    "prepack": "$npm_execpath run build",
     "lint": "yarn workspaces foreach --exclude root -v run lint",
     "test": "yarn workspaces foreach --exclude root -v run test",
     "build": "yarn workspaces foreach -t --exclude root -v run build",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,8 +15,7 @@
     "pre-commit": "lint-staged",
     "test": "jest",
     "build": "tsc && webpack --mode=production",
-    "start": "ts-node src/cli.ts",
-    "prepack": "$npm_execpath run build"
+    "start": "ts-node src/cli.ts"
   },
   "lint-staged": {
     "*.{js,md,json}": [


### PR DESCRIPTION
In case the published package copies package.json, rebuild the package before publishing artifacts.