### PR TITLE
Bring back install-agent:success

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/install-agent.ts
+++ b/packages/cli/src/cmds/agentInstaller/install-agent.ts
@@ -190,6 +190,17 @@ export default {
 
         try {
           await installProcedure.run();
+
+          Telemetry.sendEvent({
+            name: 'install-agent:success',
+            properties: {
+              installer: project.selectedInstaller!.name,
+              path: project.path,
+            },
+            metrics: {
+              duration: endTime(),
+            },
+          });
         } catch (e) {
           let installerError = new InstallerError(e, endTime(), project);
           const handled = await installerError.handle();

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -60,7 +60,9 @@ const invokeCommand = (
 describe('install sub-command', () => {
   let projectDir: string;
   beforeEach(() => {
+    // Stub all Telemetry methods. flush still needs to work, though.
     sinon.stub(Telemetry);
+    (Telemetry.flush as sinon.SinonStub).callThrough();
     projectDir = tmp.dirSync({} as any).name;
   });
 

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -638,6 +638,10 @@ packages:
       });
 
       expect(installProcedureStub).not.toBeCalled();
+      const sendEventStub = Telemetry.sendEvent as sinon.SinonStub;
+      expect(sendEventStub).toBeCalledTwice();
+      expect(sendEventStub.getCall(0)).toBeCalledWithMatch({name: 'install-agent:start'});
+      expect(sendEventStub.getCall(1)).toBeCalledWithMatch({name: 'install-agent:soft_failure'});
     });
   });
 
@@ -755,6 +759,12 @@ packages:
       });
 
       expectedStubs.forEach((stub) => expect(stub.called).toBe(true));
+      const sendEventStub = (Telemetry.sendEvent as sinon.SinonStub);
+      expect(sendEventStub).toBeCalledTimes(3);
+      expect(sendEventStub.getCall(0)).toBeCalledWithMatch({name: 'install-agent:start'});
+      expect(sendEventStub.getCall(1)).toBeCalledWithMatch({name: 'install-agent:success', properties: {installer: 'Maven'}});
+      expect(sendEventStub.getCall(2)).toBeCalledWithMatch({name: 'install-agent:success', properties: {installer: 'Gradle'}});
+      
     });
   });
 });


### PR DESCRIPTION
Make sure we send `install-agent:success`. Also, move the call to `Telemetry.flush()` into an exit handler.