### PR TITLE
feat: add links for JavaScript docs in Quickstart

### DIFF
--- a/packages/components/src/pages/quickstart-docs/RecordAppMaps.vue
+++ b/packages/components/src/pages/quickstart-docs/RecordAppMaps.vue
@@ -17,6 +17,9 @@
               href="https://appland.com/docs/quickstart/vscode/java-step-3.html"
               >Java</a
             >&nbsp;&nbsp;|&nbsp;&nbsp;<a
+              href="https://appland.com/docs/quickstart/vscode/javascript-step-3.html"
+              >JavaScript</a
+            >&nbsp;&nbsp;|&nbsp;&nbsp;<a
               href="https://appland.com/docs/quickstart/vscode/python-step-3.html"
               >Python</a
             >&nbsp;&nbsp;|&nbsp;&nbsp;<a
@@ -27,6 +30,9 @@
           <p class="mb20" v-if="editor === 'jetbrains'">
             <a href="https://appland.com/docs/quickstart/intellij/step-3"
               >Java</a
+            >&nbsp;&nbsp;|&nbsp;&nbsp;<a
+              href="https://appland.com/docs/quickstart/webstorm/step-3"
+              >JavaScript</a
             >&nbsp;&nbsp;|&nbsp;&nbsp;<a
               href="https://appland.com/docs/quickstart/pycharm/step-3"
               >Python</a


### PR DESCRIPTION
**NB!** For vscode link I added `.html` extension to the end of link, because all other links have it:
https://appland.com/docs/quickstart/vscode/java-step-3.html
https://appland.com/docs/quickstart/vscode/python-step-3.html
https://appland.com/docs/quickstart/vscode/ruby-step-3.html

![image](https://user-images.githubusercontent.com/1647695/144292439-7f9c10d9-add1-4a90-a6fc-914c31409f55.png)

Fixes #465 