### PR TITLE
Add support for APPMAP_AGENT_PACKAGE

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
@@ -76,7 +76,7 @@ export class NpmInstaller
   async installAgent(): Promise<void> {
     const cmd = new CommandStruct(
       'npm',
-      ['install', '--saveDev', AGENT_PACKAGE],
+      ['install', '--saveDev', process.env.APPMAP_AGENT_PACKAGE || AGENT_PACKAGE],
       this.path
     );
 
@@ -118,7 +118,7 @@ export class YarnInstaller
   async installAgent(): Promise<void> {
     const cmd = new CommandStruct(
       'yarn',
-      ['add', '--dev', AGENT_PACKAGE],
+      ['add', '--dev', process.env.APPMAP_AGENT_PACKAGE || AGENT_PACKAGE],
       this.path
     );
 

--- a/packages/cli/src/encodedFile.ts
+++ b/packages/cli/src/encodedFile.ts
@@ -46,10 +46,20 @@ export default class EncodedFile {
     bom1: number | undefined,
     encoding: TranscodeEncoding | undefined
   } {
-    const buf = fs.readFileSync(path);
-    let bom0: number | undefined = buf.readUInt8(0);
-    let bom1: number | undefined = buf.readUInt8(1);
+    let bom0, bom1: number | undefined;
     let encoding: TranscodeEncoding | undefined;
+    const buf = fs.readFileSync(path);
+    if (!buf.length) {
+      return {
+        buf,
+        bom0,
+        bom1,
+        encoding,
+      };
+    }
+
+    bom0 = buf.readUInt8(0);
+    bom1= buf.readUInt8(1);
     if (bom0 === 0xff && bom1 === 0xfe) {
       encoding = 'utf16le';
     } else if (bom0 < 0x80) {

--- a/packages/cli/tests/unit/encodedFile.spec.ts
+++ b/packages/cli/tests/unit/encodedFile.spec.ts
@@ -65,5 +65,11 @@ describe('EncodedFile', () => {
       new EncodedFile(join(fixtureDir, 'utf8.txt'));
     }).toThrowError(/Unknown encoding/);
   });
+
+  it('reads an empty file', () => {
+    const ef = new EncodedFile(join(fixtureDir, 'empty.txt'));
+    const str = ef.toString();
+    expect(str).toEqual('');
+  });
 });
 


### PR DESCRIPTION
Allow the user to specify a different appmap-agent-js package by setting `APPMAP_AGENT_PACKAGE`.

Also, fix #455.