### PR TITLE
Use absolute path when installing

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/agentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentInstaller.ts
@@ -1,16 +1,20 @@
 import CommandStruct from './commandStruct';
 
-export default interface AgentInstaller {
-  readonly path: string;
-  readonly name: string;
-  readonly buildFile?: string;
-  readonly documentation?: string;
+export default abstract class AgentInstaller {
+  public abstract buildFile: string;
+  public abstract documentation: string;
 
-  installAgent(): Promise<void>;
-  validateAgentCommand?(): Promise<CommandStruct>;
-  initCommand(): Promise<CommandStruct>;
-  verifyCommand?(): Promise<CommandStruct>;
-  postInstallMessage?(): Promise<string>;
-  environment?(): Promise<Record<string, string>>;
-  available(): Promise<boolean>;
+  public path: string;
+
+  constructor(readonly name: string, path: string) {
+    this.path = path;
+  }
+
+  abstract installAgent(): Promise<void>;
+  abstract validateAgentCommand(): Promise<CommandStruct | undefined>;
+  abstract initCommand(): Promise<CommandStruct>;
+  abstract verifyCommand(): Promise<CommandStruct | undefined>;
+  abstract postInstallMessage(): Promise<string>;
+  abstract environment(): Promise<Record<string, string>>;
+  abstract available(): Promise<boolean>;
 }

--- a/packages/cli/src/cmds/agentInstaller/agentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentInstaller.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'path';
 import CommandStruct from './commandStruct';
 
 export default abstract class AgentInstaller {
@@ -7,7 +8,7 @@ export default abstract class AgentInstaller {
   public path: string;
 
   constructor(readonly name: string, path: string) {
-    this.path = path;
+    this.path = resolve(path);
   }
 
   abstract installAgent(): Promise<void>;

--- a/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentProcedure.ts
@@ -54,8 +54,9 @@ export default abstract class AgentProcedure {
   }
 
   async verifyProject() {
-    if (this.installer.verifyCommand) {
-      await this.installer.verifyCommand().then(run);
+    const verifyCommand = await this.installer.verifyCommand();
+    if (verifyCommand) {
+      await run(verifyCommand);
     }
   }
 
@@ -69,13 +70,13 @@ export default abstract class AgentProcedure {
   }
 
   async validateProject(checkSyntax: boolean) {
-    if (!this.installer.validateAgentCommand) {
+    const validateCmd = await this.installer.validateAgentCommand();
+    if (!validateCmd) {
       return;
     }
 
     UI.status = 'Validating the AppMap agent...';
 
-    const validateCmd = await this.installer.validateAgentCommand();
     let { stdout } = await this.validateAgent(validateCmd);
 
     const validationResult = JSON.parse(stdout);

--- a/packages/cli/src/cmds/agentInstaller/gradleInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/gradleInstaller.ts
@@ -13,14 +13,9 @@ import EncodedFile from '../../encodedFile';
 
 export default class GradleInstaller
   extends JavaBuildToolInstaller
-  implements AgentInstaller
 {
-  constructor(readonly path: string) {
-    super(path);
-  }
-
-  get name(): string {
-    return 'Gradle';
+  constructor(path: string) {
+    super('Gradle', path);
   }
 
   get buildFile(): string {

--- a/packages/cli/src/cmds/agentInstaller/javaBuildToolInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/javaBuildToolInstaller.ts
@@ -6,6 +6,7 @@ import CommandStruct from './commandStruct';
 import { run } from './commandRunner';
 import { getOutput } from './commandUtil';
 import { findIntelliJHome } from './jetBrainsSupport';
+import AgentInstaller from './agentInstaller';
 
 export function addJetBrainsEnv() {
   const jbHome = findIntelliJHome();
@@ -25,12 +26,12 @@ export function addJetBrainsEnv() {
 }
 addJetBrainsEnv();
 
-export default abstract class JavaBuildToolInstaller {
+export default abstract class JavaBuildToolInstaller extends AgentInstaller {
   private _agentJar?: string;
 
   protected abstract printJarPathCommand(): Promise<CommandStruct>;
-  protected constructor(readonly path: string) {
-    this.path = path;
+  protected constructor(name: string, path: string) {
+    super(name, path);
   }
 
   get documentation(): string {

--- a/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
@@ -8,8 +8,10 @@ import CommandStruct from './commandStruct';
 
 const AGENT_PACKAGE = '@appland/appmap-agent-js@latest';
 
-abstract class JavaScriptInstaller {
-  constructor(readonly path: string) {}
+abstract class JavaScriptInstaller extends AgentInstaller {
+  constructor(name: string, path: string) {
+    super(name, path);
+  }
 
   get documentation() {
     return 'https://appland.com/docs/reference/appmap-agent-js';
@@ -44,14 +46,9 @@ abstract class JavaScriptInstaller {
 
 export class NpmInstaller
   extends JavaScriptInstaller
-  implements AgentInstaller
 {
-  constructor(readonly path: string) {
-    super(path);
-  }
-
-  get name(): string {
-    return 'npm';
+  constructor(path: string) {
+    super('npm', path);
   }
 
   get buildFile(): string {
@@ -82,18 +79,17 @@ export class NpmInstaller
 
     await run(cmd);
   }
+
+  async verifyCommand() {
+    return undefined;
+  }
 }
 
 export class YarnInstaller
   extends JavaScriptInstaller
-  implements AgentInstaller
 {
-  constructor(readonly path: string) {
-    super(path);
-  }
-
-  get name(): string {
-    return 'yarn';
+  constructor(path: string) {
+    super('yarn', path);
   }
 
   get buildFile(): string {
@@ -123,5 +119,9 @@ export class YarnInstaller
     );
 
     await run(cmd);
+  }
+
+  async verifyCommand() { 
+    return undefined;
   }
 }

--- a/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
@@ -61,7 +61,7 @@ export class NpmInstaller
 
   async postInstallMessage(): Promise<string> {
     return [
-      `Run your tests with ${chalk.blue('APPMAP=true')} in the environment.`,
+      `Run your tests with ${chalk.blue('npx appmap-agent-js -- mocha ...')}.`,
       `By default, AppMap files will be output to ${chalk.blue('tmp/appmap')}.`,
     ].join('\n');
   }

--- a/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
@@ -12,14 +12,9 @@ import EncodedFile from '../../encodedFile';
 
 export default class MavenInstaller
   extends JavaBuildToolInstaller
-  implements AgentInstaller
 {
-  constructor(readonly path: string) {
-    super(path);
-  }
-
-  get name(): string {
-    return 'Maven';
+  constructor(path: string) {
+    super('Maven', path);
   }
 
   get buildFile(): string {

--- a/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.ts
@@ -14,8 +14,10 @@ const REGEX_PKG_DEPENDENCY = /^\s*appmap\s*[=>~]+=.*$/m;
 // include .dev0 so pip will allow prereleases
 const PKG_DEPENDENCY = 'appmap>=1.1.0.dev0';
 
-abstract class PythonInstaller {
-  constructor(readonly path: string) {}
+abstract class PythonInstaller extends AgentInstaller {
+  constructor(name:string, path: string) {
+    super(name, path);
+  }
 
   get documentation() {
     return 'https://appland.com/docs/reference/appmap-python';
@@ -42,13 +44,9 @@ abstract class PythonInstaller {
   }
 }
 
-export class PoetryInstaller extends PythonInstaller implements AgentInstaller {
-  constructor(readonly path: string) {
-    super(path);
-  }
-
-  get name(): string {
-    return 'poetry';
+export class PoetryInstaller extends PythonInstaller {
+  constructor(path: string) {
+    super('poetry', path);
   }
 
   get buildFile(): string {
@@ -83,15 +81,23 @@ export class PoetryInstaller extends PythonInstaller implements AgentInstaller {
 
     await run(cmd);
   }
-}
 
-export class PipInstaller extends PythonInstaller implements AgentInstaller {
-  constructor(readonly path: string) {
-    super(path);
+  async verifyCommand() {
+    return undefined;
   }
 
-  get name(): string {
-    return 'pip';
+  async validateCommand() {
+    return undefined;
+  }
+
+  async validateAgentCommand() {
+    return undefined;
+  }  
+}
+
+export class PipInstaller extends PythonInstaller {
+  constructor(path: string) {
+    super('pip', path);
   }
 
   get buildFile(): string {
@@ -140,5 +146,17 @@ export class PipInstaller extends PythonInstaller implements AgentInstaller {
 
   async initCommand(): Promise<CommandStruct> {
     return new CommandStruct('appmap-agent-init', [], this.path);
+  }
+
+  async verifyCommand() {
+    return undefined;
+  }
+
+  async validateCommand() {
+    return undefined;
+  }
+
+  async validateAgentCommand() {
+    return undefined;
   }
 }

--- a/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.ts
@@ -16,11 +16,9 @@ const REGEX_GEM_DECLARATION = /^(?:gem|group|require)\s/m;
 const REGEX_GEM_DEPENDENCY = /^\s*gem\s+['|"]appmap['|"].*$/m;
 const GEM_DEPENDENCY = "gem 'appmap', :groups => [:development, :test]";
 
-export class BundleInstaller implements AgentInstaller {
-  constructor(readonly path: string) {}
-
-  get name(): string {
-    return 'Bundler';
+export class BundleInstaller extends AgentInstaller {
+  constructor(path: string) {
+    super('Bundler', path);
   }
 
   get buildFile(): string {
@@ -102,5 +100,9 @@ export class BundleInstaller implements AgentInstaller {
         : chalk.red(version.output),
       'Gem home': gemHome.ok ? gemHome.output : chalk.red(gemHome.output),
     };
+  }
+
+  async verifyCommand() {
+    return undefined;
   }
 }

--- a/packages/cli/tests/unit/agentInstall/agentInstaller.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentInstaller.spec.ts
@@ -1,0 +1,41 @@
+import path from "path";
+import AgentInstaller from "../../../src/cmds/agentInstaller/agentInstaller";
+import commandStruct from "../../../src/cmds/agentInstaller/commandStruct";
+
+class FakeInstaller extends AgentInstaller {
+  public buildFile: string = 'bf';
+  public documentation: string = 'http://www.example.com';
+  constructor(path: string) {
+    super('Fake', path);
+  }
+
+  installAgent(): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+  validateAgentCommand(): Promise<commandStruct> {
+    throw new Error("Method not implemented.");
+  }
+  initCommand(): Promise<commandStruct> {
+    throw new Error("Method not implemented.");
+  }
+  verifyCommand(): Promise<commandStruct> {
+    throw new Error("Method not implemented.");
+  }
+  postInstallMessage(): Promise<string> {
+    throw new Error("Method not implemented.");
+  }
+  environment(): Promise<Record<string, string>> {
+    throw new Error("Method not implemented.");
+  }
+  available(): Promise<boolean> {
+    throw new Error("Method not implemented.");
+  }
+}
+
+describe('agentInstaller', () => {
+  it('resolves the path', () => {
+    const installer = new FakeInstaller('.');
+
+    expect(path.isAbsolute(installer.path)).toBeTruthy();
+  });
+});

--- a/packages/cli/tests/unit/agentInstall/statusCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/statusCommand.spec.ts
@@ -38,8 +38,7 @@ describe('status sub-command', () => {
       .stub(AgentStatusProcedure.prototype, 'getEnvironmentForDisplay')
       .resolves(['env']);
 
-    const installer = stubInterface<AgentInstaller>();
-    installer.verifyCommand = undefined;
+    const installer = stubInterface<AgentInstaller>({verifyCommand: undefined});
 
     getInstallersForProject = sinon
       .stub(ProjectConfiguration, 'getProjects')


### PR DESCRIPTION
Resolve the path passed to the installer to ensure that we always know where the project is, even if the working directory is changed.

There are no functional changes the `refactor` commit b905bb3.

Fixes #467.
Fixes #469.
Fixes #471.
