### PR TITLE
feat: Correctly parse some PostgreSQL-specific constructs

### DIFF
--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -45,6 +45,6 @@
   "dependencies": {
     "cross-env": "^7.0.3",
     "crypto-js": "^4.0.0",
-    "sqlite-parser": "^1.0.1"
+    "sqlite-parser": "applandinc/sqlite-parser"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,7 +239,7 @@ __metadata:
     lint-staged: ^10.5.4
     prettier: ^2.2.1
     rollup: ^2.48.0
-    sqlite-parser: ^1.0.1
+    sqlite-parser: applandinc/sqlite-parser
   languageName: unknown
   linkType: soft
 
@@ -24867,12 +24867,12 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
-"sqlite-parser@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "sqlite-parser@npm:1.0.1"
+sqlite-parser@applandinc/sqlite-parser:
+  version: 1.1.0
+  resolution: "sqlite-parser@https://github.com/applandinc/sqlite-parser.git#commit=ecd7db3afc8ca32ebf6c13612665bd334330b809"
   bin:
     sqlite-parser: bin/sqlite-parser
-  checksum: cc4131f3347a1963252619d6bd39d44e7d7e0f7ba10619412ae0bb9c7aa28dccc6baad5c97f2fad3f2295088eea176ea39bc32c20946265c5ccde4a0aa390df7
+  checksum: ee07464d79841214a854bd3f957269fc5b230ad64ff6bf6284970987d90debdcc8b2cb999512f73af46229a2ceed344f91166ffa2ed4b3e38cffddcfe5449da5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This bumps sqlite-parser to a patched version that accepts PSQL-style casts and custom operators.