### PR TITLE
fix: Nudge user to install in current project

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/projectConfiguration.ts
+++ b/packages/cli/src/cmds/agentInstaller/projectConfiguration.ts
@@ -101,7 +101,8 @@ async function resolveSelectedInstallers(
  *          undefined
  */
 async function getSubprojects(
-  dir: string
+  dir: string,
+  rootHasInstaller: boolean
 ): Promise<ProjectConfiguration[] | undefined> {
   const ents = await fs.readdir(dir, { withFileTypes: true });
   const subprojects = (
@@ -140,6 +141,7 @@ async function getSubprojects(
 
   const { addSubprojects } = await UI.prompt({
     type: 'confirm',
+    default: !rootHasInstaller,
     name: 'addSubprojects',
     message:
       'This directory contains sub-projects. Would you like to choose sub-projects for installation?',
@@ -174,8 +176,10 @@ export async function getProjects(
 ): Promise<ProjectConfiguration[]> {
   let projectConfigurations: ProjectConfiguration[] = [];
 
+  const availableInstallers = await getAvailableInstallers(dir);
+  const rootHasInstaller = !!availableInstallers.length;
   if (allowMulti) {
-    const subprojects = await getSubprojects(dir);
+    const subprojects = await getSubprojects(dir, rootHasInstaller);
     if (subprojects?.length) {
       projectConfigurations.push(...(subprojects as ProjectConfiguration[]));
     } else if (subprojects?.length === 0) {
@@ -188,7 +192,6 @@ export async function getProjects(
 
   // If there are no subprojects, we will continue by installing to the current directory.
   if (!projectConfigurations.length) {
-    const availableInstallers = await getAvailableInstallers(dir);
     if (availableInstallers.length) {
       projectConfigurations = [
         {

--- a/packages/cli/tests/unit/fixtures/java/multi-project-root/pom.xml
+++ b/packages/cli/tests/unit/fixtures/java/multi-project-root/pom.xml
@@ -1,0 +1,28 @@
+<!-- This is a comment as the first child node. -->
+<!-- There doesn't appear to be a way to control w3c-xmlserializer's
+indentation, so the spacing in expected-pom.xml is a bit wonky -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.springframework.samples</groupId>
+  <artifactId>spring-petclinic</artifactId>
+  <version>2.4.5</version>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.spring.javaformat</groupId>
+        <artifactId>spring-javaformat-maven-plugin</artifactId>
+        <version>${spring-format.version}</version>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/packages/cli/tests/unit/fixtures/java/multi-project-root/project-a/pom.xml
+++ b/packages/cli/tests/unit/fixtures/java/multi-project-root/project-a/pom.xml
@@ -1,0 +1,28 @@
+<!-- This is a comment as the first child node. -->
+<!-- There doesn't appear to be a way to control w3c-xmlserializer's
+indentation, so the spacing in expected-pom.xml is a bit wonky -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.springframework.samples</groupId>
+  <artifactId>spring-petclinic</artifactId>
+  <version>2.4.5</version>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.spring.javaformat</groupId>
+        <artifactId>spring-javaformat-maven-plugin</artifactId>
+        <version>${spring-format.version}</version>
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/packages/cli/tests/unit/fixtures/java/multi-project-root/project-b/build.gradle
+++ b/packages/cli/tests/unit/fixtures/java/multi-project-root/project-b/build.gradle
@@ -1,0 +1,12 @@
+buildscript { }
+
+plugins {
+  id 'java'
+}
+
+repositories {
+  mavenCentral()
+}
+
+group = 'com.example'
+version = '0.0.0-test'


### PR DESCRIPTION
If a project has a build config file in the current directory, but also
has sub-projects, make installing in the current directory be the
default choice.

Fixes #461 .