### PR TITLE
fix: Use a shell when running a command

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/commandRunner.ts
+++ b/packages/cli/src/cmds/agentInstaller/commandRunner.ts
@@ -70,6 +70,7 @@ class CommandOutput {
 export async function run(command: CommandStruct): Promise<CommandReturn> {
   return new Promise((resolve, reject) => {
     const cp = spawn(command.program, command.args, {
+      shell: true,
       env: command.environment,
       cwd: command.path as string,
     });

--- a/packages/cli/tests/unit/agentInstall/commandRunner.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/commandRunner.spec.ts
@@ -8,7 +8,7 @@ describe('CommandRunner', () => {
       const unknownCmd = randomBytes(8).toString('hex');
       await expect(async () => {
         await run(new CommandStruct(unknownCmd, [], process.cwd()));
-      }).rejects.toThrow(`${unknownCmd} was not found`);
+      }).rejects.toThrow(`/bin/sh: ${unknownCmd}: command not found`);
     });
   });
 });


### PR DESCRIPTION
Tell child_process.spawn to use a shell. If we don't, on Windows it can
only find .exe's, and npm and npx are .cmd files.