### PR TITLE
feat: keyboard navigation for filter suggestions

### DIFF
--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -598,6 +598,15 @@ export default {
                   nodes.add(event.id);
                 }
               });
+            } else {
+              this.filteredAppMap.events.forEach((event) => {
+                if (
+                  event.isCall() &&
+                  event.toString().toLowerCase().includes(item.toLowerCase())
+                ) {
+                  nodes.add(event.id);
+                }
+              });
             }
           });
         }

--- a/packages/components/tests/e2e/specs/vsCodeExtension.spec.js
+++ b/packages/components/tests/e2e/specs/vsCodeExtension.spec.js
@@ -793,6 +793,29 @@ context('VS Code Extension', () => {
       cy.get('.nodes .node').should('have.length', 3);
     });
 
+    it('filters: navigate through filter suggestions with keyboard', () => {
+      cy.get('.tabs__controls .popper__button').click();
+
+      cy.get('.filters__form-input').first().focus();
+      cy.get('.filters__form-suggestions').should('be.visible');
+      cy.get('.filters__form-suggestions-item')
+        .eq(0)
+        .should('have.class', 'filters__form-suggestions-item--selected');
+
+      cy.get('.filters__form-input').first().type('{downarrow}');
+      cy.get('.filters__form-suggestions-item')
+        .eq(1)
+        .should('have.class', 'filters__form-suggestions-item--selected');
+
+      cy.get('.filters__form-input').first().type('{uparrow}');
+      cy.get('.filters__form-suggestions-item')
+        .eq(0)
+        .should('have.class', 'filters__form-suggestions-item--selected');
+
+      cy.get('.filters__form-input').first().type('{esc}');
+      cy.get('.filters__form-suggestions').should('not.be.visible');
+    });
+
     it('filters: limit root events', () => {
       cy.get('.tabs .tab-btn').last().click();
 

--- a/packages/components/tests/e2e/specs/vsCodeExtension.spec.js
+++ b/packages/components/tests/e2e/specs/vsCodeExtension.spec.js
@@ -707,7 +707,7 @@ context('VS Code Extension', () => {
       cy.get('.tabs .tab-btn').last().click();
 
       cy.get('.trace-view__search-input-element').type(
-        'event:1 event:3 event:15 event:99999 label:json'
+        'event:1 event:3 event:15 event:99999 label:json #link_to_edit_url'
       );
 
       cy.get('.trace-node[data-event-id="1"]')
@@ -718,7 +718,7 @@ context('VS Code Extension', () => {
 
       cy.get('.trace-view__search-arrows-text').should(
         'contain.text',
-        '1/30 results'
+        '1/32 results'
       );
 
       cy.get('.trace-view__search-arrow').last().click();


### PR DESCRIPTION
To check this functionality, you can open filters panel, focus into "Root objects" input and type ArrowUp and ArrowDown on the keyboard.

https://user-images.githubusercontent.com/17301016/146234893-719eb60a-e9e9-4d3b-866b-de672d64a001.mp4

Fixes #482 
Fixes #480 