### PR TITLE
fix: set container max-width to 100%

### DIFF
--- a/packages/components/src/components/Container.vue
+++ b/packages/components/src/components/Container.vue
@@ -84,6 +84,7 @@ export default {
   overflow: hidden;
   height: 100%;
   width: 100%;
+  max-width: 100%;
   outline: none;
 }
 </style>


### PR DESCRIPTION
This change will prevent clipping Trace view on https://app.land
![image](https://user-images.githubusercontent.com/1647695/146812311-0884b0ae-e5be-465a-9e0b-f3a4392ce490.png)
