### PR TITLE
Fix installer tests

### DIFF
--- a/packages/cli/tests/unit/agentInstall/commandRunner.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/commandRunner.spec.ts
@@ -6,9 +6,10 @@ describe('CommandRunner', () => {
   describe('run', () => {
     it('raises an error when a command is not found', async () => {
       const unknownCmd = randomBytes(8).toString('hex');
+      const errorRegexp = new RegExp(`${unknownCmd}.*(not found|exited with code.*127)`, 's');
       await expect(async () => {
         await run(new CommandStruct(unknownCmd, [], process.cwd()));
-      }).rejects.toThrow(`/bin/sh: ${unknownCmd}: command not found`);
+      }).rejects.toThrow(errorRegexp);
     });
   });
 });

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -189,6 +189,7 @@ packages:
       });
 
       it('installs as expected', async () => {
+        expect.assertions(12);
         const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
@@ -209,6 +210,7 @@ packages:
       });
 
       it('fails when validation fails', async () => {
+        expect.assertions(9);
         const msg = 'failValidate, validation failed';
         const failValidate = () => Promise.reject(new Error(msg));
         const evalResults = (err, argv, output) => {
@@ -265,6 +267,7 @@ packages:
       });
 
       it('installs as expected', async () => {
+        expect.assertions(12);
         const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
@@ -285,6 +288,7 @@ packages:
       });
 
       it('fails when validation fails', async () => {
+        expect.assertions(9);
         const msg = 'failValidate, validation failed';
         const failValidate = () => Promise.reject(new Error(msg));
         const evalResults = (err, argv, output) => {
@@ -386,6 +390,7 @@ packages:
     };
 
     it('installs as expected', async () => {
+      expect.assertions(11);
       const evalResults = (err, argv, output) => {
         expect(err).toBeNull();
 
@@ -406,6 +411,7 @@ packages:
     });
 
     it('fails when validation fails', async () => {
+      expect.assertions(8);
       const msg = 'failValidate, validation failed';
       const failValidate = () => {
         return Promise.reject(new Error(msg));
@@ -446,10 +452,12 @@ packages:
 
       const errorArray = `[{"message": "${msg}"}]`;
       it('fails for old output format', async () => {
+        expect.assertions(8);
         await testValidation(errorArray);
       });
 
       it('fails for new output format', async () => {
+        expect.assertions(8);
         const errorObj = `{"errors": ${errorArray}}`;
         await testValidation(errorObj);
       });
@@ -529,6 +537,7 @@ packages:
       };
 
       it('installs as expected', async () => {
+        expect.assertions(10);
         const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
@@ -584,6 +593,7 @@ packages:
       };
 
       it('installs as expected', async () => {
+        expect.assertions(10);
         const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
@@ -685,6 +695,7 @@ packages:
 
 
       it('installs as expected', async () => {
+        expect.assertions(10);
         const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
@@ -705,6 +716,7 @@ packages:
       });
 
       it('fails when validation fails', async () => {
+        expect.assertions(7);
         const msg = 'failValidate, validation failed';
         const failValidate = () => Promise.reject(new Error(msg));
         const evalResults = (err, argv, output) => {
@@ -742,6 +754,7 @@ packages:
 
 
       it('installs as expected', async () => {
+        expect.assertions(10);
         const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
@@ -762,6 +775,7 @@ packages:
       });
 
       it('fails when validation fails', async () => {
+        expect.assertions(7);
         const msg = 'failValidate, validation failed';
         const failValidate = () => Promise.reject(new Error(msg));
         const evalResults = (err, argv, output) => {
@@ -784,6 +798,7 @@ packages:
     });
 
     it('requests the user to select a project type if more than one exist', async () => {
+      expect.assertions(2);
       const projectFixture = path.join(fixtureDir, 'python', 'mixed');
       const { name: projectDir } = tmp.dirSync({} as any);
       await fse.copy(projectFixture, projectDir);
@@ -804,6 +819,7 @@ packages:
     });
 
     it('fails if no supported project is found', async () => {
+      expect.assertions(5);
       const { name: projectDir } = tmp.dirSync({} as any);
       const installProcedureStub = sinon
         .stub(AgentInstallerProcedure.prototype, 'run')
@@ -857,6 +873,7 @@ packages:
     });
 
     it('succeeds when the config syntax is valid', async () => {
+      expect.assertions(1);
       const validateConfig = sinon
         .stub(validator, 'validateConfig')
         .returns({ valid: true });
@@ -866,6 +883,7 @@ packages:
     });
 
     it('fails when the config syntax is invalid', async () => {
+      expect.assertions(2);
       const jsError = [
         {
           start: { line: 0, column: 0, offset: 0 },
@@ -927,6 +945,7 @@ packages:
     });
 
     it('installs as expected', async () => {
+      expect.assertions(16);
       const projectFixture = path.join(fixtureDir, 'java', 'multi-project');
       fse.copySync(projectFixture, projectDir);
 
@@ -964,6 +983,7 @@ packages:
     });
 
     it('installs the root project by default', async () => {
+      expect.assertions(2);
       const projectFixture = path.join(fixtureDir, 'java', 'multi-project-root');
       fse.copySync(projectFixture, projectDir);
       const promptStub = sinon.stub(inquirer, 'prompt').resolves({

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -189,10 +189,10 @@ packages:
       });
 
       it('installs as expected', async () => {
-        const evalResults = async (err, argv, output) => {
+        const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
-          const actualConfig = await fse.readFile(
+          const actualConfig = fse.readFileSync(
             path.join(projectDir, 'appmap.yml'),
             { encoding: 'utf-8' }
           );
@@ -265,10 +265,10 @@ packages:
       });
 
       it('installs as expected', async () => {
-        const evalResults = async (err, argv, output) => {
+        const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
-          const actualConfig = await fse.readFile(
+          const actualConfig = fse.readFileSync(
             path.join(projectDir, 'appmap.yml'),
             { encoding: 'utf-8' }
           );
@@ -386,10 +386,10 @@ packages:
     };
 
     it('installs as expected', async () => {
-      const evalResults = async (err, argv, output) => {
+      const evalResults = (err, argv, output) => {
         expect(err).toBeNull();
 
-        const actualConfig = await fse.readFile(
+        const actualConfig = fse.readFileSync(
           path.join(projectDir, 'appmap.yml'),
           { encoding: 'utf-8' }
         );
@@ -529,10 +529,10 @@ packages:
       };
 
       it('installs as expected', async () => {
-        const evalResults = async (err, argv, output) => {
+        const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
-          const actualConfig = await fse.readFile(
+          const actualConfig = fse.readFileSync(
             path.join(projectDir, 'appmap.yml'),
             { encoding: 'utf-8' }
           );
@@ -584,10 +584,10 @@ packages:
       };
 
       it('installs as expected', async () => {
-        const evalResults = async (err, argv, output) => {
+        const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
-          const actualConfig = await fse.readFile(
+          const actualConfig = fse.readFileSync(
             path.join(projectDir, 'appmap.yml'),
             { encoding: 'utf-8' }
           );
@@ -685,10 +685,10 @@ packages:
 
 
       it('installs as expected', async () => {
-        const evalResults = async (err, argv, output) => {
+        const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
-          const actualConfig = await fse.readFile(
+          const actualConfig = fse.readFileSync(
             path.join(projectDir, 'appmap.yml'),
             { encoding: 'utf-8' }
           );
@@ -742,10 +742,10 @@ packages:
 
 
       it('installs as expected', async () => {
-        const evalResults = async (err, argv, output) => {
+        const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
-          const actualConfig = await fse.readFile(
+          const actualConfig = fse.readFileSync(
             path.join(projectDir, 'appmap.yml'),
             { encoding: 'utf-8' }
           );

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -62,7 +62,8 @@ describe('install sub-command', () => {
   beforeEach(() => {
     // Stub all Telemetry methods. flush still needs to work, though.
     sinon.stub(Telemetry);
-    (Telemetry.flush as sinon.SinonStub).callThrough();
+    const callCB = (cb) => { return cb() };
+    (Telemetry.flush as sinon.SinonStub).callsFake(callCB);
     projectDir = tmp.dirSync({} as any).name;
   });
 


### PR DESCRIPTION
The change to use a timeout to call `Yargs.exit` after flushing telemetry events broke many of the installer tests. (In one case, the way the test failed meant it called `process.exit(0)`, which hid all the failures.)

These changes ensure that `Yargs.exit` is called synchronously by `Telemetry.flush`, and use a regexp to verify that "command not found" errors are detected. They also add calls to `expect.assertions` to make sure all `expect` calls are actually getting executed.