### PR TITLE
fix: Add missing import of URL

### DIFF
--- a/packages/client/src/buildRequest.ts
+++ b/packages/client/src/buildRequest.ts
@@ -5,6 +5,7 @@ import {
   IncomingMessage,
 } from 'node:http';
 import { request as httpsRequest } from 'node:https';
+import { URL } from 'node:url';
 import loadConfiguration from './loadConfiguration';
 
 type Request = {


### PR DESCRIPTION
Add a missing import of `URL` from `node:url`.