### PR TITLE
fix: Drop node protocol import

### DIFF
--- a/packages/client/.eslintrc.js
+++ b/packages/client/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'unicorn/no-array-for-each': 'off',
     'unicorn/prevent-abbreviations': 'warn',
+    'unicorn/prefer-node-protocol': 'off',
     '@typescript-eslint/lines-between-class-members': 'off',
     'no-restricted-syntax': 'off',
     'import/no-cycle': 'off',

--- a/packages/client/src/buildRequest.ts
+++ b/packages/client/src/buildRequest.ts
@@ -3,9 +3,9 @@ import {
   ClientRequest,
   RequestOptions,
   IncomingMessage,
-} from 'node:http';
-import { request as httpsRequest } from 'node:https';
-import { URL } from 'node:url';
+} from 'http';
+import { request as httpsRequest } from 'https';
+import { URL } from 'url';
 import loadConfiguration from './loadConfiguration';
 
 type Request = {

--- a/packages/client/src/get.ts
+++ b/packages/client/src/get.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage } from 'node:http';
+import { IncomingMessage } from 'http';
 
 import buildRequest from './buildRequest';
 import handleError from './handleError';

--- a/packages/client/src/handleError.ts
+++ b/packages/client/src/handleError.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage } from 'node:http';
+import { IncomingMessage } from 'http';
 
 type Error = {
   message: string;

--- a/packages/client/src/loadConfiguration.ts
+++ b/packages/client/src/loadConfiguration.ts
@@ -1,6 +1,6 @@
-import { readFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { readFile } from 'fs/promises';
+import { homedir } from 'os';
+import { join } from 'path';
 import yaml from 'js-yaml';
 import Configuration from './configuration';
 

--- a/packages/client/src/loadConfiguration.ts
+++ b/packages/client/src/loadConfiguration.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'fs/promises';
 import { homedir } from 'os';
-import { join } from 'path';
+import path from 'path';
 import yaml from 'js-yaml';
 import Configuration from './configuration';
 
@@ -28,7 +28,7 @@ const failUsage = (message: string): Settings => {
 };
 
 async function loadFromFile(): Promise<Settings> {
-  const applandConfigFilePath = join(homedir(), '.appland');
+  const applandConfigFilePath = path.join(homedir(), '.appland');
   let applandConfigData: Buffer | undefined;
   try {
     applandConfigData = await readFile(applandConfigFilePath);

--- a/packages/client/src/reportJson.ts
+++ b/packages/client/src/reportJson.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage } from 'node:http';
+import { IncomingMessage } from 'http';
 
 export default function <T>(response: IncomingMessage): Promise<T> {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
These imports restrict the node version to v16+. We could potentially remove them in a post-process build step, but I don't think it's worth the effort.