### PR TITLE
feat: Port prune subcommand

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -30,7 +30,7 @@ const OpenCommand = require('./cmds/open/open');
 const RecordCommand = require('./cmds/record/record');
 import InstallCommand from './cmds/agentInstaller/install-agent';
 import StatusCommand from './cmds/agentInstaller/status';
-
+import PruneCommand from './cmds/prune/prune';
 class DiffCommand {
   public appMapNames: any;
   public baseDir?: string;
@@ -590,6 +590,7 @@ yargs(process.argv.slice(2))
   .command(OpenCommand)
   .command(RecordCommand)
   .command(StatusCommand)
+  .command(PruneCommand)
   .strict()
   .demandCommand()
   .help().argv;

--- a/packages/cli/src/cmds/prune/prune.ts
+++ b/packages/cli/src/cmds/prune/prune.ts
@@ -1,0 +1,77 @@
+import fs from 'fs';
+import JSONStream from 'JSONStream';
+import { basename } from 'path';
+import Yargs from 'yargs';
+import { AppMap, pruneAppMap } from './pruneAppMap';
+
+async function fromFile(filePath): Promise<AppMap> {
+  let data: AppMap = { events: [] };
+
+  return new Promise((resolve, reject) => {
+    const jsonStream = JSONStream.parse('events.*')
+      .on('header', (obj) => (data = { ...data, ...obj }))
+      .on('footer', (obj) => (data = { ...data, ...obj }))
+      .on('data', (e) => data.events.push(e))
+      .on('close', () => resolve(data));
+
+    fs.createReadStream(filePath).pipe(jsonStream);
+  });
+}
+
+const binaryPrefixes = {
+  B: 1,
+  KB: 1 << 10,
+  MB: 1 << 20,
+  GB: 1 << 30,
+};
+
+// This isn't very robust
+function parseSize(size: string) {
+  const parsed = /(\d+)[\s+]?(\w+)?/.exec(size);
+  if (!parsed) {
+    throw new Error(`Failed parsing size ${size}`);
+  }
+
+  const [_, byteStr, unit] = parsed;
+  if (!unit) {
+    return Number(byteStr);
+  }
+
+  const p = binaryPrefixes[unit.toUpperCase()];
+  if (!p) {
+    throw new Error(`unknown size ${size}`);
+  }
+
+  return Number(byteStr) * p;
+}
+
+export default {
+  command: 'prune <file> <size>',
+
+  describe: 'Prune an appmap file down to the given size',
+
+  builder: (argv: Yargs.Argv) => {
+    argv.option('output-dir', {
+      describe:
+        'Specifies the output directory. Pruned files will be written here.',
+      type: 'string',
+      default: '.',
+      alias: 'o',
+    });
+    argv.positional('file', {
+      describe: 'AppMap to prune',
+    });
+    argv.positional('size', {
+      describe: 'Prune input file to this size',
+    });
+  },
+
+  handler: async (argv: any): Promise<void> => {
+    const size = parseSize(argv.size);
+    const appMap = pruneAppMap(await fromFile(argv.file), size);
+
+    const outputPath = `${argv.outputDir}/${basename(argv.file)}`;
+    fs.writeFileSync(outputPath, JSON.stringify(appMap));
+    console.log('done');
+  },
+};

--- a/packages/cli/src/cmds/prune/pruneAppMap.ts
+++ b/packages/cli/src/cmds/prune/pruneAppMap.ts
@@ -1,0 +1,15 @@
+import { buildAppMap } from '@appland/models';
+
+// Simplified AppMap interface, just for pruning
+export interface AppMap {
+  events: any[],
+  [key: string]: any
+};
+
+export const pruneAppMap = (appMap: AppMap, size: number): any => {
+  return buildAppMap()
+    .source(appMap)
+    .prune(size)
+    .normalize()
+    .build();
+};

--- a/packages/cli/tests/unit/prune.spec.ts
+++ b/packages/cli/tests/unit/prune.spec.ts
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import fse from 'fs-extra';
+import path from 'path';
+import sinon from 'sinon';
+import tmp from 'tmp';
+import yargs from 'yargs';
+import * as PruneAppMap from '../../src/cmds/prune/pruneAppMap';
+const fixtureDir = path.join(__dirname, 'fixtures', 'ruby');
+tmp.setGracefulCleanup();
+
+describe('prune subcommand', () => {
+  let projectDir: string;
+  beforeEach(() => {
+    projectDir = tmp.dirSync({} as any).name;
+    fse.copySync(fixtureDir, projectDir);
+
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('works', async () => {
+    const cmd = require('../../src/cmds/prune/prune').default;
+    const parser = yargs.command(cmd);
+
+    sinon.stub(PruneAppMap, 'pruneAppMap').returns({events:[]});
+
+    const appMapFile = path.join(projectDir, 'revoke_api_key.appmap.json');
+    const cmdLine = `prune -o ${projectDir} ${appMapFile} 2MB`;
+    await new Promise((resolve, reject) => {
+      parser.parse(cmdLine, {}, (err, argv, output) => {
+        if (err) {
+          reject(err);
+        }
+        else {
+          resolve(output);
+        }
+      });
+    });
+
+    // Check that we wrote the output file correctly. Validity of pruning is
+    // tested in @appland/models.
+    const actual = fs.readFileSync(appMapFile)
+    expect(actual.toString()).toEqual('{"events":[]}');
+  });
+});

--- a/packages/models/PRUNING.md
+++ b/packages/models/PRUNING.md
@@ -1,0 +1,28 @@
+Pruning works by finding the most repetitive calls within a given "chunk" and
+removing events associated with those calls. A chunk is defined as a group of
+logic, consisting of one or more full call stacks. Boundaries of these chunks
+are created around application entrypoints such as inbound HTTP request.
+
+An example list of chunks is provided below:
+```
+HTTP request - GET /user
+Background thread processing
+HTTP request - PUT /user
+Background thread processing
+HTTP request - GET /
+```
+
+For each chunk, aggregate the total number of unique events. Starting from the
+most repetitive event type, remove instances of that event until the size of the
+chunk (in byte) is less than:
+```
+requested size / total event array size * starting chunk size
+```
+
+In essence, we're calculating a unique exclusion list for each chunk. This
+prevents an excessively noisy or repetitive call stack in one area of execution
+from affecting the results of unrelated areas of execution.
+
+Non-application events such as HTTP requests and SQL queries will always be
+retained. This means that the end result can never be smaller than the total
+size of these events combined.


### PR DESCRIPTION
Bring over the prune subcommand from appland/appmap-cli. That package
also exports an `appmap` command, which conflicts with ours.