### PR TITLE
fix: Add supports-hyperlinks dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -95,6 +95,7 @@
     "port-pid": "^0.0.7",
     "ps-node": "^0.1.6",
     "semver": "^7.3.5",
+    "supports-hyperlinks": "^2.2.0",
     "w3c-xmlserializer": "^2.0.0",
     "yargs": "^17.1.1"
   }

--- a/packages/cli/src/cmds/open/openers.ts
+++ b/packages/cli/src/cmds/open/openers.ts
@@ -1,13 +1,11 @@
 import serveAndOpenAppMap from './serveAndOpenAppMap';
+import supportsHyperlinks from 'supports-hyperlinks';
 
 // See also: https://github.com/applandinc/scanner/pull/9/files#diff-3294a832ea2276e554177e0b3007cc2d401c082912c7fbde49fa09141bf1aed1R1
 function hyperlink(filePath: string, link: string): string {
   const OSC = '\u001B]';
   const BEL = '\u0007';
   const SEP = ';';
-
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const supportsHyperlinks = require('supports-hyperlinks');
 
   if (!supportsHyperlinks.stdout) {
     return filePath;

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,6 +108,7 @@ __metadata:
     semver: ^7.3.5
     sinon: ^11.1.2
     style-loader: ^3.2.1
+    supports-hyperlinks: ^2.2.0
     tmp: ^0.2.1
     ts-jest: ^26.0.0
     ts-node: ^10.2.1
@@ -27378,7 +27379,7 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
-"supports-hyperlinks@npm:^2.0.0, supports-hyperlinks@npm:^2.1.0":
+"supports-hyperlinks@npm:^2.0.0, supports-hyperlinks@npm:^2.1.0, supports-hyperlinks@npm:^2.2.0":
   version: 2.2.0
   resolution: "supports-hyperlinks@npm:2.2.0"
   dependencies:


### PR DESCRIPTION
The supports-hyperlinks dependency was added in such a way that it wasn't bundled (very odd - non-standard).

Now it should be fine and be included with the distribution.