### PR TITLE
fix: Handle spaces in CommandStruct.args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,11 @@ jobs:
       os: windows
       env:
         - YARN_GPG=no
-      script: yarn workspace @appland/appmap test --runTestsByPath tests/unit/agentInstall/gradleInstaller.spec.ts
-      
+      script: |
+        yarn workspace @appland/appmap test --runTestsByPath \
+          tests/unit/agentInstall/commandRunner.spec.ts \
+          tests/unit/agentInstall/gradleInstaller.spec.ts
+
     - stage: deploy
       if: branch != main
       script: yarn run chromatic

--- a/packages/cli/src/cmds/agentInstaller/commandStruct.ts
+++ b/packages/cli/src/cmds/agentInstaller/commandStruct.ts
@@ -3,14 +3,26 @@ import { env } from 'process';
 
 export default class CommandStruct {
   readonly environment: NodeJS.ProcessEnv;
+  readonly args: string[];
 
   constructor(
     readonly program: string,
-    readonly args: readonly string[],
+    args: readonly string[],
     readonly path: PathLike,
     environment: NodeJS.ProcessEnv = {}
   ) {
     this.environment = { ...env, ...environment };
+    this.args = args.map((a) => {
+      if (!a.includes(' ')) {
+        return a;
+      }
+
+      // There shouldn't be a need to embed quotes, so raise an error if the caller tries.
+      if (a.includes('"')) {
+        throw new Error("Don't embed quotes in args");
+      }
+      return `"${a}"`;
+    });
   }
 
   toString() {

--- a/packages/cli/tests/unit/agentInstall/commandRunner.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/commandRunner.spec.ts
@@ -1,15 +1,38 @@
 import { randomBytes } from 'crypto';
-import { run } from '../../../src/cmds/agentInstaller/commandRunner';
+import { run, runSync } from '../../../src/cmds/agentInstaller/commandRunner';
 import CommandStruct from '../../../src/cmds/agentInstaller/commandStruct';
 
 describe('CommandRunner', () => {
   describe('run', () => {
     it('raises an error when a command is not found', async () => {
       const unknownCmd = randomBytes(8).toString('hex');
-      const errorRegexp = new RegExp(`${unknownCmd}.*(not found|exited with code.*127)`, 's');
+      const errorRegexp = new RegExp(
+        `${unknownCmd}.*(not (found|recognized)|exited with code.*127)`,
+        's'
+      );
       await expect(async () => {
         await run(new CommandStruct(unknownCmd, [], process.cwd()));
       }).rejects.toThrow(errorRegexp);
+    });
+
+    it('run succeeds if an arg contains spaces', async () => {
+      const hw = 'Hello world!';
+      const cmd = new CommandStruct('node', ['-p', `'${hw}'`], process.cwd());
+      const { stdout } = await run(cmd);
+      expect(stdout).toStrictEqual(`${hw}\n`);
+    });
+
+    it('runSync success if an arg contains spaces', async () => {
+      const hw = 'Hello world!';
+      const cmd = new CommandStruct('node', ['-p', `'${hw}'`], process.cwd());
+      const output = runSync(cmd);
+      expect(output).toStrictEqual(`${hw}\n`);
+    });
+
+    it('raises an error if an arg has embedded quotes', async () => {
+      expect(() => {
+        new CommandStruct('node', ['-p', '"Hello world!"'], process.cwd());
+      }).toThrow("Don't embed quotes in args");
     });
   });
 });


### PR DESCRIPTION
When creating a CommandStruct, add quotes around any element of args that
contains a space.