### PR TITLE
feat: Improved event hash

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/.yarn/releases/** binary
+/.yarn/plugins/** binary
+/packages/components/src/stories/data/** binary
+*.appmap.json binary

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -34,6 +34,7 @@
     "@rollup/plugin-commonjs": "^18.0.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-replace": "^2.4.2",
+    "cross-env": "^7.0.3",
     "eslint": "^7.25.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^8.3.0",
@@ -46,7 +47,6 @@
   },
   "dependencies": {
     "@appland/sql-parser": "^1.1.1",
-    "cross-env": "^7.0.3",
     "crypto-js": "^4.0.0"
   }
 }

--- a/packages/models/src/event.js
+++ b/packages/models/src/event.js
@@ -1,9 +1,5 @@
-import {
-  addHiddenProperty,
-  hasProp,
-  hashEvent,
-  identityHashEvent,
-} from './util';
+import { addHiddenProperty, hasProp, identityHashEvent } from './util';
+import hashEvent from './event/hash';
 
 // This class supercedes `CallTree` and `CallNode`. Events are stored in a flat
 // array and can also be traversed like a tree via `parent` and `children`.
@@ -395,6 +391,12 @@ export default class Event {
       .filter(Boolean);
   }
 
+  get qualifiedMethodId() {
+    const { definedClass, isStatic, methodId } = this;
+    if (!definedClass) return undefined;
+    return `${definedClass}${isStatic ? '.' : '#'}${methodId}`;
+  }
+
   toString() {
     const { sqlQuery } = this;
     if (sqlQuery) {
@@ -406,7 +408,6 @@ export default class Event {
       return route;
     }
 
-    const { definedClass, isStatic, methodId } = this;
-    return `${definedClass}${isStatic ? '.' : '#'}${methodId}`;
+    return this.qualifiedMethodId;
   }
 }

--- a/packages/models/src/event/hash.js
+++ b/packages/models/src/event/hash.js
@@ -1,0 +1,41 @@
+import sha256 from 'crypto-js/sha256';
+import { buildQueryAST } from '../util';
+
+// returns a JSON of SQL query AST
+// with all literals replaced by variables
+// and all variable names removed
+function abstractSqlAstJSON(query) {
+  const ast = buildQueryAST(query);
+  return JSON.stringify(ast, (_, value) => {
+    switch (value.type) {
+      case 'variable':
+      case 'literal':
+        return { type: 'variable' };
+      default:
+        return value;
+    }
+  });
+}
+
+// Returns a string suitable for durable identification of a call event
+// that's independent of parameters and return values.
+// For SQL queries, it's a JSON of abstract query AST.
+// For HTTP queries, it's the method plus normalized path info.
+// For function calls it's the qualified function id.
+function callEventToString(event) {
+  const { sqlQuery, route } = event;
+  if (sqlQuery) return abstractSqlAstJSON(sqlQuery);
+  if (route) return route;
+  return event.qualifiedMethodId;
+}
+
+// Returns a short string (hash) suitable for durable identification
+// of a call event that's independent of parameters and return values.
+// For SQL queries, it considers the abstract query (ignoring differences in literal values).
+// For HTTP queries, it considers the method plus normalized path info.
+// For function calls it's the qualified function id.
+// Non-call events will throw an error.
+export default function hashEvent(event) {
+  if (event.event !== 'call') throw new Error('tried to hash a non-call event');
+  return sha256(callEventToString(event)).toString();
+}

--- a/packages/models/src/event/hash.js
+++ b/packages/models/src/event/hash.js
@@ -1,11 +1,14 @@
 import sha256 from 'crypto-js/sha256';
+import normalize from '../sql/normalize';
 import parse from '../sql/parse';
 
 // returns a JSON of SQL query AST
 // with all literals replaced by variables
 // and all variable names removed
-function abstractSqlAstJSON(query) {
+function abstractSqlAstJSON(query, databaseType) {
   const ast = parse(query);
+  if (!ast) return normalize(query, databaseType);
+
   return JSON.stringify(ast, (_, value) => {
     switch (value.type) {
       case 'variable':
@@ -24,7 +27,7 @@ function abstractSqlAstJSON(query) {
 // For function calls it's the qualified function id.
 function callEventToString(event) {
   const { sqlQuery, route } = event;
-  if (sqlQuery) return abstractSqlAstJSON(sqlQuery);
+  if (sqlQuery) return abstractSqlAstJSON(sqlQuery, event.sql.database_type);
   if (route) return route;
   return event.qualifiedMethodId;
 }

--- a/packages/models/src/event/hash.js
+++ b/packages/models/src/event/hash.js
@@ -1,11 +1,11 @@
 import sha256 from 'crypto-js/sha256';
-import { buildQueryAST } from '../util';
+import parse from '../sql/parse';
 
 // returns a JSON of SQL query AST
 // with all literals replaced by variables
 // and all variable names removed
 function abstractSqlAstJSON(query) {
-  const ast = buildQueryAST(query);
+  const ast = parse(query);
   return JSON.stringify(ast, (_, value) => {
     switch (value.type) {
       case 'variable':

--- a/packages/models/src/sql/parse.js
+++ b/packages/models/src/sql/parse.js
@@ -1,11 +1,12 @@
 import sqliteParser from '@appland/sql-parser';
+import ParseError from './parseError';
 
 export default function parse(sql, errorCallback = () => {}) {
   const parseSQL = sql.replace(/\s+returning\s+\*/i, '');
   try {
     return sqliteParser(parseSQL);
   } catch (e) {
-    errorCallback(e.message, parseSQL);
+    errorCallback(new ParseError(e.message, parseSQL));
     return null;
   }
 }

--- a/packages/models/src/sql/parseError.js
+++ b/packages/models/src/sql/parseError.js
@@ -6,6 +6,6 @@ export default class ParseError extends Error {
   }
 
   toString() {
-    return `Unable to parse ${this.sql} : ${this.message}`;
+    return `${this.message}: ${this.sql}`;
   }
 }

--- a/packages/models/src/util.js
+++ b/packages/models/src/util.js
@@ -351,16 +351,6 @@ export function buildLabels(classMap, events) {
 // ~2. This is awfully wasteful, slow and inaccurate but it works for now. -DB
 export const sizeof = (obj) => JSON.stringify(obj).length;
 
-const DYNAMIC_FIELDS = new Set([
-  'id',
-  'value',
-  'thread_id',
-  'elapsed',
-  'object_id',
-  'lineno',
-  'path',
-]);
-
 // Returns a unique 'hash' (or really, a key) tied to the event's core identity: SQL, HTTP, or a
 // specific method on a specific class. This is _really_ naive. The idea is that this better finds
 // a singular change versus an existing object that has been removed and a new object added in its

--- a/packages/models/src/util.js
+++ b/packages/models/src/util.js
@@ -1,6 +1,5 @@
 import sha256 from 'crypto-js/sha256';
 import analyze from './sql/analyze';
-import normalize from './sql/normalize';
 
 export const hasProp = (obj, prop) =>
   Object.prototype.hasOwnProperty.call(obj, prop);
@@ -362,77 +361,6 @@ const DYNAMIC_FIELDS = new Set([
   'path',
 ]);
 
-function getStaticPropValues(obj) {
-  return Object.getOwnPropertyNames(obj)
-    .filter((k) => typeof obj[k] !== 'object' && !DYNAMIC_FIELDS.has(k))
-    .sort()
-    .map((k) => obj[k]);
-}
-
-// #region ========= BEGIN UNUSED CODE =========
-// These are called from Event.compare, but that method may be removed.
-// Don't merge me!
-
-export function appMapObjectCompare(a, b) {
-  if (a === b) {
-    return true;
-  }
-
-  if (!a || !b) {
-    return false;
-  }
-
-  const props = [
-    ...new Set([
-      ...Object.getOwnPropertyNames(a),
-      ...Object.getOwnPropertyNames(b),
-    ]),
-  ].filter((k) => !DYNAMIC_FIELDS.has(k));
-
-  // return the props that differ
-  return props.filter((k) => a[k] !== b[k]);
-}
-
-export function hashHttp(e) {
-  const { httpServerRequest } = e;
-  if (!httpServerRequest) {
-    return null;
-  }
-
-  const { message, httpServerResponse } = e;
-  const content = [];
-  message.forEach((m) =>
-    getStaticPropValues(m).forEach((v) => content.push(v))
-  );
-  getStaticPropValues(httpServerResponse).forEach((v) => content.push(v));
-  getStaticPropValues(httpServerRequest).forEach((v) => content.push(v));
-
-  return sha256(content.join('')).toString();
-}
-
-export function hashSql(/** @type {Event} */ e) {
-  const { sqlQuery } = e;
-  if (!sqlQuery) {
-    return null;
-  }
-
-  const analyzedSql = analyze(sqlQuery);
-  if (!analyzedSql) {
-    return normalize(sqlQuery, e.sql.database);
-  }
-  const content = [analyzedSql.action];
-
-  if (analyzedSql.columns) {
-    analyzedSql.columns.forEach((c) => content.push(c));
-  }
-
-  if (analyzedSql.tables) {
-    analyzedSql.tables.forEach((t) => content.push(t));
-  }
-
-  return sha256(content.join('')).toString();
-}
-
 // Returns a unique 'hash' (or really, a key) tied to the event's core identity: SQL, HTTP, or a
 // specific method on a specific class. This is _really_ naive. The idea is that this better finds
 // a singular change versus an existing object that has been removed and a new object added in its
@@ -452,28 +380,6 @@ export function identityHashEvent(e) {
   }
 
   return e.toString();
-}
-
-export function hashEvent(e) {
-  let hash = hashHttp(e);
-  if (hash) {
-    return hash;
-  }
-
-  hash = hashSql(e);
-  if (hash) {
-    return hash;
-  }
-
-  const content = [];
-  getStaticPropValues(e).forEach((v) => content.push(v));
-  if (e.parameters) {
-    e.parameters.forEach((p) =>
-      getStaticPropValues(p).forEach((v) => content.push(v))
-    );
-  }
-
-  return sha256(content.join('')).toString();
 }
 
 export function resolveDifferences(arr1, arr2) {

--- a/packages/models/tests/unit/event/hash.spec.js
+++ b/packages/models/tests/unit/event/hash.spec.js
@@ -1,0 +1,114 @@
+import Event from '../../../src/event';
+import hashEvent from '../../../src/event/hash';
+
+function checkSimplification(event, simplified) {
+  return () =>
+    expect(hashEvent(new Event(event))).toEqual(
+      hashEvent(new Event(simplified))
+    );
+}
+
+describe('event/hash', () => {
+  test('only accepts call events', () => {
+    expect(() => hashEvent({ event: 'return' })).toThrow();
+  });
+
+  test(
+    'simplifies HTTP events',
+    checkSimplification(
+      {
+        id: 6369,
+        event: 'call',
+        thread_id: 5609880,
+        http_server_request: {
+          request_method: 'GET',
+          path_info: '/api/users/1/credit_cards',
+          normalized_path_info: '/api/users/:user_id/credit_cards(.:format)',
+        },
+        message: [
+          {
+            name: 'format',
+            class: 'String',
+            value: 'json',
+            object_id: 6887560,
+          },
+          {
+            name: 'controller',
+            class: 'String',
+            value: 'spree/api/credit_cards',
+            object_id: 39005300,
+          },
+          {
+            name: 'action',
+            class: 'String',
+            value: 'index',
+            object_id: 5700040,
+          },
+          {
+            name: 'user_id',
+            class: 'String',
+            value: '1',
+            object_id: 76120140,
+          },
+        ],
+      },
+      {
+        event: 'call',
+        http_server_request: {
+          request_method: 'GET',
+          normalized_path_info: '/api/users/:user_id/credit_cards(.:format)',
+        },
+      }
+    )
+  );
+
+  test(
+    'simplifies plain call events',
+    checkSimplification(
+      {
+        id: 6370,
+        event: 'call',
+        thread_id: 5609880,
+        defined_class: 'Spree',
+        method_id: 'user_class',
+        path: '/home/user/projects/solidus/core/lib/spree/core.rb',
+        lineno: 26,
+        static: true,
+        parameters: [],
+        receiver: {
+          class: 'Module',
+          object_id: 10676620,
+          value: 'Spree',
+        },
+      },
+      {
+        event: 'call',
+        defined_class: 'Spree',
+        method_id: 'user_class',
+        static: true,
+      }
+    )
+  );
+
+  test(
+    'simplifies SQL events',
+    checkSimplification(
+      {
+        id: 6392,
+        event: 'call',
+        thread_id: 5609880,
+        sql_query: {
+          sql: 'SELECT "spree_orders".* FROM "spree_orders" WHERE "spree_orders"."user_id" = ? LIMIT ?',
+          database_type: 'sqlite',
+          server_version: '3.22.0',
+        },
+      },
+      {
+        event: 'call',
+        sql_query: {
+          sql: 'SELECT "spree_orders".* FROM "spree_orders" WHERE "spree_orders"."user_id" = 55 LIMIT 30',
+        },
+      }
+    )
+  );
+});

--- a/packages/models/tests/unit/sql.spec.js
+++ b/packages/models/tests/unit/sql.spec.js
@@ -72,7 +72,9 @@ describe('parse SQL', () => {
         }
       )
     ).toBeNull();
-    expect(err).toEqual(`Syntax error found near Star (SELECT Results Clause)`);
+    expect(err.toString()).toEqual(
+      `Syntax error found near Star (SELECT Results Clause): SELECT users.*, a.* JOIN addresses a ON a.user_id = users.id`
+    );
   });
 });
 


### PR DESCRIPTION
Hashing a call event now only considers the fields which are truly specific to the call generalically and not specific arguments that     were used. This also includes literals and variables in SQL queries.

Note that all events will now have different hashes than previously calculated, so the transition can confuse change tracking. Also the new algorithm refuses to hash non-call events (as they don't really have any data that is generic enough to make sense).