### PR TITLE
fix: Update post-install messages

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/agentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentInstaller.ts
@@ -15,7 +15,6 @@ export default abstract class AgentInstaller {
   abstract validateAgentCommand(): Promise<CommandStruct | undefined>;
   abstract initCommand(): Promise<CommandStruct>;
   abstract verifyCommand(): Promise<CommandStruct | undefined>;
-  abstract postInstallMessage(): Promise<string>;
   abstract environment(): Promise<Record<string, string>>;
   abstract available(): Promise<boolean>;
 }

--- a/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
@@ -79,13 +79,9 @@ export default class AgentInstallerProcedure extends AgentProcedure {
       chalk.green('Success! The AppMap agent has been installed.'),
     ];
 
-    if (this.installer.postInstallMessage) {
-      successMessage.push('', await this.installer.postInstallMessage(), '');
-    }
-
     if (this.installer.documentation) {
       successMessage.push(
-        'For more information, visit',
+        'For more information on recording AppMaps, visit',
         chalk.blue(this.installer.documentation)
       );
     }

--- a/packages/cli/src/cmds/agentInstaller/gradleInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/gradleInstaller.ts
@@ -34,17 +34,6 @@ export default class GradleInstaller
     );
   }
 
-  async postInstallMessage(): Promise<string> {
-    let gradleBin = await this.runCommand();
-
-    return [
-      `Record your tests by running ${chalk.blue(`${gradleBin} appmap test`)}`,
-      `By default, AppMap files will be output to ${chalk.blue(
-        'build/appmap'
-      )}`,
-    ].join('\n');
-  }
-
   async available(): Promise<boolean> {
     return await exists(this.buildFilePath);
   }

--- a/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
@@ -102,7 +102,6 @@ export class YarnInstaller
 
   async postInstallMessage(): Promise<string> {
     return [
-      `Run your tests with ${chalk.blue('APPMAP=true')} in the environment.`,
       `By default, AppMap files will be output to ${chalk.blue('tmp/appmap')}.`,
     ].join('\n');
   }

--- a/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/javaScriptAgentInstaller.ts
@@ -59,13 +59,6 @@ export class NpmInstaller
     return join(this.path, this.buildFile);
   }
 
-  async postInstallMessage(): Promise<string> {
-    return [
-      `Run your tests with ${chalk.blue('npx appmap-agent-js -- mocha ...')}.`,
-      `By default, AppMap files will be output to ${chalk.blue('tmp/appmap')}.`,
-    ].join('\n');
-  }
-
   async available(): Promise<boolean> {
     return await exists(this.buildFilePath);
   }
@@ -98,12 +91,6 @@ export class YarnInstaller
 
   get buildFilePath(): string {
     return join(this.path, this.buildFile);
-  }
-
-  async postInstallMessage(): Promise<string> {
-    return [
-      `By default, AppMap files will be output to ${chalk.blue('tmp/appmap')}.`,
-    ].join('\n');
   }
 
   async available(): Promise<boolean> {

--- a/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
@@ -25,19 +25,6 @@ export default class MavenInstaller
     return join(this.path, this.buildFile);
   }
 
-  async postInstallMessage(): Promise<string> {
-    const mvn = this.runCommand();
-
-    return [
-      `The AppMap agent will automatically record your tests when you run ${chalk.blue(
-        `${mvn} test`
-      )}`,
-      `By default, AppMap files will be output to ${chalk.blue(
-        'target/appmap'
-      )}`,
-    ].join('\n');
-  }
-
   async available(): Promise<boolean> {
     return await exists(this.buildFilePath);
   }

--- a/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/pythonAgentInstaller.ts
@@ -57,13 +57,6 @@ export class PoetryInstaller extends PythonInstaller {
     return join(this.path, this.buildFile);
   }
 
-  async postInstallMessage(): Promise<string> {
-    return [
-      `Run your tests with ${chalk.blue('APPMAP=true')} in the environment.`,
-      `By default, AppMap files will be output to ${chalk.blue('tmp/appmap')}.`,
-    ].join('\n');
-  }
-
   async available(): Promise<boolean> {
     return await exists(this.buildFilePath);
   }
@@ -106,13 +99,6 @@ export class PipInstaller extends PythonInstaller {
 
   get buildFilePath(): string {
     return join(this.path, this.buildFile);
-  }
-
-  async postInstallMessage(): Promise<string> {
-    return [
-      `Run your tests with ${chalk.blue('APPMAP=true')} in the environment.`,
-      `By default, AppMap files will be output to ${chalk.blue('tmp/appmap')}.`,
-    ].join('\n');
   }
 
   async available(): Promise<boolean> {

--- a/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/rubyAgentInstaller.ts
@@ -33,13 +33,6 @@ export class BundleInstaller extends AgentInstaller {
     return 'https://appland.com/docs/reference/appmap-ruby';
   }
 
-  async postInstallMessage(): Promise<string> {
-    return [
-      `Run your tests with ${chalk.blue('APPMAP=true')} in the environment.`,
-      `AppMap files will be output to ${chalk.blue('tmp/appmap')}.`,
-    ].join('\n');
-  }
-
   async available(): Promise<boolean> {
     return await exists(this.buildFilePath);
   }

--- a/packages/cli/tests/unit/agentInstall/agentInstaller.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentInstaller.spec.ts
@@ -21,9 +21,6 @@ class FakeInstaller extends AgentInstaller {
   verifyCommand(): Promise<commandStruct> {
     throw new Error("Method not implemented.");
   }
-  postInstallMessage(): Promise<string> {
-    throw new Error("Method not implemented.");
-  }
   environment(): Promise<Record<string, string>> {
     throw new Error("Method not implemented.");
   }


### PR DESCRIPTION
Get rid of the language-specific post-install message after successful install. Just direct the user to the  doc page for the agent.