### PR TITLE
fix: filter out other children of package when one child was set as root

### DIFF
--- a/packages/components/tests/e2e/specs/vsCodeExtension.spec.js
+++ b/packages/components/tests/e2e/specs/vsCodeExtension.spec.js
@@ -882,6 +882,24 @@ context('VS Code Extension', () => {
       cy.get('.nodes .node').should('have.length', 3);
     });
 
+    it('filters: when child of package was set as root - another children are filtered out', () => {
+      cy.get('.nodes .node').should('have.length', 9);
+
+      cy.get('.tabs__controls .popper__button').click();
+
+      cy.get('.filters__form-input')
+        .first()
+        .type('class:json/JSON::Ext::Generator::State')
+        .parent()
+        .submit();
+
+      cy.get('.nodes .node').should('have.length', 1);
+      cy.get('.nodes .node')
+        .first()
+        .should('have.class', 'class')
+        .should('have.attr', 'data-id', 'json/JSON::Ext::Generator::State');
+    });
+
     it('filters: navigate through filter suggestions with keyboard', () => {
       cy.get('.tabs__controls .popper__button').click();
 

--- a/packages/models/src/classMap.js
+++ b/packages/models/src/classMap.js
@@ -150,7 +150,17 @@ export default class ClassMap {
       validCodeObjects.has(obj)
     );
 
-    this.roots = this.roots.filter((obj) => validCodeObjects.has(obj));
+    function filterCodeObjects(objectsList, allObjects) {
+      return objectsList.filter((obj) => {
+        if (allObjects.has(obj)) {
+          obj.children = filterCodeObjects(obj.children, allObjects);
+          return true;
+        }
+        return false;
+      });
+    }
+
+    this.roots = filterCodeObjects(this.roots, validCodeObjects);
 
     Object.keys(this.codeObjectsByLocation).forEach((obj) => {
       if (!validCodeObjects.has(obj)) {

--- a/packages/models/tests/unit/classMap.spec.js
+++ b/packages/models/tests/unit/classMap.spec.js
@@ -173,9 +173,8 @@ describe('ClassMap', () => {
       expect(roots[1].id).toEqual(
         'org/springframework/samples/petclinic/owner'
       );
-      expect(roots[2].id).toEqual('org/springframework/mock/web');
-      expect(roots[3].id).toEqual('HTTP server requests');
-      expect(roots).toHaveLength(4);
+      expect(roots[2].id).toEqual('HTTP server requests');
+      expect(roots).toHaveLength(3);
     });
   });
 });


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1647695/152396312-5e1a0cf5-d358-41f3-884d-1629cddab0e1.png)

After:
![image](https://user-images.githubusercontent.com/1647695/152396088-87978cd8-1457-436b-b00d-566147b79068.png)

Fixes #477 