### PR TITLE
fix: OpenAPI gen

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@appland/components": "workspace:*",
     "@appland/diagrams": "workspace:*",
-    "@appland/models": "workspace:1.14.1",
+    "@appland/models": "workspace:^1.14.1",
     "@sidvind/better-ajv-errors": "^0.9.1",
     "@types/moo": "^0.5.5",
     "JSONStream": "^1.3.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@appland/components": "workspace:*",
     "@appland/diagrams": "workspace:*",
-    "@appland/models": "workspace:^1.8.1",
+    "@appland/models": "workspace:1.14.1",
     "@sidvind/better-ajv-errors": "^0.9.1",
     "@types/moo": "^0.5.5",
     "JSONStream": "^1.3.5",

--- a/packages/cli/src/fingerprint/canonicalize/sqlTables.js
+++ b/packages/cli/src/fingerprint/canonicalize/sqlTables.js
@@ -13,7 +13,7 @@ class Canonicalize extends Unique {
    */
   sql(event) {
     const analyzedQuery = analyzeSQL(event.sqlQuery);
-    if (typeof analyzedQuery === 'object') {
+    if (analyzedQuery && typeof analyzedQuery === 'object') {
       return analyzedQuery.tables;
     }
 

--- a/packages/cli/src/fingerprint/canonicalize/trace.js
+++ b/packages/cli/src/fingerprint/canonicalize/trace.js
@@ -16,7 +16,7 @@ class Canonicalize extends EventTree {
         normalized_query: normalizeSQL(event.sqlQuery, event.sql.database_type),
       },
     };
-    if (typeof analyzedQuery === 'object') {
+    if (analyzedQuery && typeof analyzedQuery === 'object') {
       result.analyzed_query = analyzedQuery;
     }
     return result;

--- a/packages/cli/src/functionStats.js
+++ b/packages/cli/src/functionStats.js
@@ -98,6 +98,7 @@ class FunctionStats {
           .map((e) => [e.event].concat(e.descendants).filter((d) => d.sql))
           .flat()
           .map((e) => analyzeSQL(e.sqlQuery))
+          .filter(Boolean)
           .filter((e) => typeof e === 'object')
           .map((sql) => sql.tables)
           .flat()

--- a/packages/cli/tests/unit/fingerprint/sqlTables.spec.js
+++ b/packages/cli/tests/unit/fingerprint/sqlTables.spec.js
@@ -1,0 +1,35 @@
+const { buildAppMap } = require('@appland/models');
+const SQLTables = require('../../../src/fingerprint/canonicalize/sqlTables');
+
+describe('sqlTables', () => {
+  test('Simple SELECT', () => {
+    const result = SQLTables(
+      buildAppMap({
+        events: [
+          {
+            event: 'call',
+            sql_query: {
+              sql: 'SELECT * FROM users',
+            },
+          },
+        ],
+      }).build()
+    );
+    expect(result).toEqual(['users']);
+  });
+  test('Unparseable query', () => {
+    const result = SQLTables(
+      buildAppMap({
+        events: [
+          {
+            event: 'call',
+            sql_query: {
+              sql: `u can't parse this`,
+            },
+          },
+        ],
+      }).build()
+    );
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/cli/tests/unit/fingerprint/trace.spec.js
+++ b/packages/cli/tests/unit/fingerprint/trace.spec.js
@@ -1,0 +1,55 @@
+const { buildAppMap } = require('@appland/models');
+const Trace = require('../../../src/fingerprint/canonicalize/trace');
+
+describe('Trace', () => {
+  test('Simple SELECT', () => {
+    const result = Trace(
+      buildAppMap({
+        events: [
+          {
+            event: 'call',
+            sql_query: {
+              sql: 'SELECT * FROM users',
+            },
+          },
+        ],
+      }).build()
+    );
+    expect(result).toEqual([
+      {
+        kind: 'sql',
+        sql: {
+          normalized_query: 'SELECT * FROM users',
+        },
+        analyzed_query: {
+          actions: ['select'],
+          tables: ['users'],
+          columns: ['*'],
+          joinCount: 0,
+        },
+      },
+    ]);
+  });
+  test('Unparseable query', () => {
+    const result = Trace(
+      buildAppMap({
+        events: [
+          {
+            event: 'call',
+            sql_query: {
+              sql: `u can't parse this`,
+            },
+          },
+        ],
+      }).build()
+    );
+    expect(result).toEqual([
+      {
+        kind: 'sql',
+        sql: {
+          normalized_query: `u can't parse this`,
+        },
+      },
+    ]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -67,7 +67,7 @@ __metadata:
   dependencies:
     "@appland/components": "workspace:*"
     "@appland/diagrams": "workspace:*"
-    "@appland/models": "workspace:^1.8.1"
+    "@appland/models": "workspace:^1.14.1"
     "@sidvind/better-ajv-errors": ^0.9.1
     "@types/fs-extra": ^9.0.12
     "@types/inquirer": ^7.3.3
@@ -264,7 +264,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@appland/models@workspace:^1.8.1, @appland/models@workspace:^1.9.0, @appland/models@workspace:packages/models":
+"@appland/models@workspace:^1.14.1, @appland/models@workspace:^1.8.1, @appland/models@workspace:^1.9.0, @appland/models@workspace:packages/models":
   version: 0.0.0-use.local
   resolution: "@appland/models@workspace:packages/models"
   dependencies:


### PR DESCRIPTION
* Require minimum necessary version of `@appland/models`.
* Handle cases where `analyzeSQL` returns null.

Does this surprise you? It did me:

```
> typeof(null)
'object'
```