### PR TITLE
fix: empty "normalized_path_info" of HTTP server request is present as empty array in AppMap

### DIFF
--- a/packages/models/src/appMapBuilder/index.js
+++ b/packages/models/src/appMapBuilder/index.js
@@ -109,6 +109,16 @@ class AppMapBuilder extends EventSource {
         }
       }
 
+      // Normalize path info
+      const { httpServerRequest } = event;
+      if (httpServerRequest && httpServerRequest.normalized_path_info) {
+        httpServerRequest.normalized_path_info =
+          httpServerRequest.normalized_path_info.toString();
+      }
+      if (httpServerRequest && httpServerRequest.path_info) {
+        httpServerRequest.path_info = httpServerRequest.path_info.toString();
+      }
+
       return event;
       /* eslint-enable no-param-reassign */
     });

--- a/packages/models/src/event.js
+++ b/packages/models/src/event.js
@@ -161,14 +161,10 @@ export default class Event {
 
   get requestPath() {
     if (this.httpServerRequest) {
-      const normalizedPathInfo = this.httpServerRequest.normalized_path_info
-        ? this.httpServerRequest.normalized_path_info.toString()
-        : '';
-      const pathInfo = this.httpServerRequest.path_info
-        ? this.httpServerRequest.path_info.toString()
-        : '';
-
-      return normalizedPathInfo || pathInfo;
+      return (
+        this.httpServerRequest.normalized_path_info ||
+        this.httpServerRequest.path_info
+      );
     }
     if (this.httpClientRequest) {
       return this.httpClientRequest.url;

--- a/packages/models/src/event.js
+++ b/packages/models/src/event.js
@@ -161,10 +161,14 @@ export default class Event {
 
   get requestPath() {
     if (this.httpServerRequest) {
-      return (
-        this.httpServerRequest.normalized_path_info ||
-        this.httpServerRequest.path_info
-      );
+      const normalizedPathInfo = this.httpServerRequest.normalized_path_info
+        ? this.httpServerRequest.normalized_path_info.toString()
+        : '';
+      const pathInfo = this.httpServerRequest.path_info
+        ? this.httpServerRequest.path_info.toString()
+        : '';
+
+      return normalizedPathInfo || pathInfo;
     }
     if (this.httpClientRequest) {
       return this.httpClientRequest.url;


### PR DESCRIPTION
For some reason in some AppMaps `normalized_path_info` is preset as empty array.
According to [AppMap specification ](https://github.com/applandinc/appmap#http-server-request-call-attributes) it's not expected behavior, but to make plugin work with such AppMaps I've added type cast to `string`.