### PR TITLE
fix: remove credentials from git repository URLs

### DIFF
--- a/packages/models/src/appMapBuilder/index.js
+++ b/packages/models/src/appMapBuilder/index.js
@@ -85,6 +85,14 @@ class AppMapBuilder extends EventSource {
 
   // normalize the appmap data before returning an Appmap model
   normalize() {
+    // Remove credentials from git repository url
+    if (/^https?/.test(this.data.metadata?.git?.repository)) {
+      const url = new URL(this.data.metadata.git.repository);
+      url.username = '';
+      url.password = '';
+      this.data.metadata.git.repository = url.toString();
+    }
+
     // Re-index events
     let eventId = 1;
     this.event((event) => {

--- a/packages/models/tests/unit/appMapBuilder.spec.js
+++ b/packages/models/tests/unit/appMapBuilder.spec.js
@@ -8,7 +8,7 @@ test('build', () => {
 
   expect(numCodeObjects).toEqual(50);
   expect(appMap.events.length).toEqual(815);
-  expect(Object.keys(appMap.metadata).length).toEqual(9);
+  expect(Object.keys(appMap.metadata).length).toEqual(10);
 });
 
 test('build with data source in constructor', () => {
@@ -18,7 +18,7 @@ test('build with data source in constructor', () => {
 
   expect(numCodeObjects).toEqual(50);
   expect(appMap.events.length).toEqual(815);
-  expect(Object.keys(appMap.metadata).length).toEqual(9);
+  expect(Object.keys(appMap.metadata).length).toEqual(10);
 });
 
 describe('normalize', () => {
@@ -59,6 +59,37 @@ describe('normalize', () => {
       }
 
       expect(e.thread_id).toEqual(currentThreadId);
+    });
+  });
+
+  it('removes credentials from git repository urls', () => {
+    function normalizeRepository(repository) {
+      const appMapData = {
+        metadata: {
+          git: { repository },
+        },
+        events: [],
+        classMap: [],
+      };
+
+      return buildAppMap(appMapData).normalize().build().metadata.git
+        .repository;
+    }
+
+    Object.entries({
+      'https://github.com/organization/repository':
+        'https://github.com/organization/repository',
+
+      'https://username@github.com/organization/repository':
+        'https://github.com/organization/repository',
+
+      'http://username:password@github.com/organization/repository':
+        'http://github.com/organization/repository',
+
+      'https://username:password@github.com/organization/repository.git':
+        'https://github.com/organization/repository.git',
+    }).forEach(([actual, expected]) => {
+      expect(normalizeRepository(actual)).toEqual(expected);
     });
   });
 });

--- a/packages/models/tests/unit/fixtures/large_scenario.json
+++ b/packages/models/tests/unit/fixtures/large_scenario.json
@@ -1,1 +1,12218 @@
-{"version":"1.2","metadata":{"name":"Curator master elect single master","app":"ZooKeeper Book","feature":"Elect single master","feature_group":"Curator master","language":{"name":"java","version":"11.0.2+9","engine":"OpenJDK 64-Bit Server VM"},"client":{"name":"appmap-java","url":"https://github.com/appland/appmap-java"},"recorder":{"name":"toggle_record_receiver"},"recording":{"defined_class":"org.apache.zookeeper.book.TestCuratorMaster","method_id":"electSingleMaster"},"framework":{"name":"junit"}},"events":[{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":318673,"lineno":113,"method_id":"startZK","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":2005843134,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.ConnectStringParser","event":"call","id":318674,"lineno":85,"method_id":"getServerAddresses","path":"src/main/java/org/apache/zookeeper/client/ConnectStringParser.java","receiver":{"class":"org.apache.zookeeper.client.ConnectStringParser","object_id":947144196,"value":"org.apache.zookeeper.client.ConnectStringParser@38744604"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.ConnectStringParser","event":"return","id":318675,"lineno":85,"method_id":"getServerAddresses","path":"src/main/java/org/apache/zookeeper/client/ConnectStringParser.java","return_value":{"class":"java.util.ArrayList","object_id":975009528,"value":"[localhost:11224]"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.ConnectStringParser","event":"call","id":318676,"lineno":81,"method_id":"getChrootPath","path":"src/main/java/org/apache/zookeeper/client/ConnectStringParser.java","receiver":{"class":"org.apache.zookeeper.client.ConnectStringParser","object_id":947144196,"value":"org.apache.zookeeper.client.ConnectStringParser@38744604"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.ConnectStringParser","event":"return","id":318677,"lineno":81,"method_id":"getChrootPath","path":"src/main/java/org/apache/zookeeper/client/ConnectStringParser.java","static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"call","id":318678,"lineno":91,"method_id":"size","path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","receiver":{"class":"org.apache.zookeeper.client.StaticHostProvider","object_id":1482406219,"value":"org.apache.zookeeper.client.StaticHostProvider@585bb94b"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"call","id":318680,"lineno":95,"method_id":"next","parameters":[{"class":"java.lang.Long","kind":"req","name":"spinDelay","object_id":1530428453,"value":"1000"}],"path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","receiver":{"class":"org.apache.zookeeper.client.StaticHostProvider","object_id":1482406219,"value":"org.apache.zookeeper.client.StaticHostProvider@585bb94b"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"return","id":318679,"lineno":91,"method_id":"size","path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","return_value":{"class":"java.lang.Integer","object_id":161525262,"value":"2"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":318682,"lineno":113,"method_id":"startZK","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":318683,"lineno":113,"method_id":"startZK","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":1493302843,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.ConnectStringParser","event":"call","id":318684,"lineno":85,"method_id":"getServerAddresses","path":"src/main/java/org/apache/zookeeper/client/ConnectStringParser.java","receiver":{"class":"org.apache.zookeeper.client.ConnectStringParser","object_id":1785304456,"value":"org.apache.zookeeper.client.ConnectStringParser@6a699588"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.ConnectStringParser","event":"return","id":318685,"lineno":85,"method_id":"getServerAddresses","path":"src/main/java/org/apache/zookeeper/client/ConnectStringParser.java","return_value":{"class":"java.util.ArrayList","object_id":1020219096,"value":"[localhost:11224]"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.ConnectStringParser","event":"call","id":318686,"lineno":81,"method_id":"getChrootPath","path":"src/main/java/org/apache/zookeeper/client/ConnectStringParser.java","receiver":{"class":"org.apache.zookeeper.client.ConnectStringParser","object_id":1785304456,"value":"org.apache.zookeeper.client.ConnectStringParser@6a699588"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"return","id":318681,"lineno":95,"method_id":"next","path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","return_value":{"class":"java.net.InetSocketAddress","object_id":1442810162,"value":"localhost/127.0.0.1:11224"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318688,"lineno":183,"method_id":"getConfigStatus","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ConnectStringParser","event":"return","id":318687,"lineno":81,"method_id":"getChrootPath","path":"src/main/java/org/apache/zookeeper/client/ConnectStringParser.java","static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"call","id":318690,"lineno":91,"method_id":"size","path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","receiver":{"class":"org.apache.zookeeper.client.StaticHostProvider","object_id":1283947773,"value":"org.apache.zookeeper.client.StaticHostProvider@4c877cfd"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"call","id":318692,"lineno":95,"method_id":"next","parameters":[{"class":"java.lang.Long","kind":"req","name":"spinDelay","object_id":1777693618,"value":"1000"}],"path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","receiver":{"class":"org.apache.zookeeper.client.StaticHostProvider","object_id":1283947773,"value":"org.apache.zookeeper.client.StaticHostProvider@4c877cfd"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"return","id":318691,"lineno":91,"method_id":"size","path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","return_value":{"class":"java.lang.Integer","object_id":1347793670,"value":"2"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":318694,"lineno":113,"method_id":"startZK","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318689,"lineno":183,"method_id":"getConfigStatus","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.String","object_id":348291849,"value":"Will not attempt to authenticate using SASL (unknown error)"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318696,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"return","id":318693,"lineno":95,"method_id":"next","path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","return_value":{"class":"java.net.InetSocketAddress","object_id":1731367164,"value":"localhost/127.0.0.1:11224"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318698,"lineno":183,"method_id":"getConfigStatus","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318699,"lineno":183,"method_id":"getConfigStatus","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.String","object_id":638556871,"value":"Will not attempt to authenticate using SASL (unknown error)"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318700,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318697,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":622637659,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"call","id":318702,"lineno":91,"method_id":"size","path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","receiver":{"class":"org.apache.zookeeper.client.StaticHostProvider","object_id":1482406219,"value":"org.apache.zookeeper.client.StaticHostProvider@585bb94b"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"return","id":318703,"lineno":91,"method_id":"size","path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","return_value":{"class":"java.lang.Integer","object_id":1958179602,"value":"2"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"call","id":318704,"lineno":114,"method_id":"onConnected","path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","receiver":{"class":"org.apache.zookeeper.client.StaticHostProvider","object_id":1482406219,"value":"org.apache.zookeeper.client.StaticHostProvider@585bb94b"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"return","id":318705,"lineno":114,"method_id":"onConnected","path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318706,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318701,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":392420447,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318707,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1961720902,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"call","id":318708,"lineno":91,"method_id":"size","path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","receiver":{"class":"org.apache.zookeeper.client.StaticHostProvider","object_id":1283947773,"value":"org.apache.zookeeper.client.StaticHostProvider@4c877cfd"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318710,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"return","id":318709,"lineno":91,"method_id":"size","path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","return_value":{"class":"java.lang.Integer","object_id":480447865,"value":"2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318711,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1058227040,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"call","id":318712,"lineno":114,"method_id":"onConnected","path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","receiver":{"class":"org.apache.zookeeper.client.StaticHostProvider","object_id":1283947773,"value":"org.apache.zookeeper.client.StaticHostProvider@4c877cfd"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318713,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318715,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318716,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318717,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318718,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318719,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":348354323,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318720,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318721,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1430166811,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318722,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318723,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318724,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"return","id":318714,"lineno":114,"method_id":"onConnected","path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318726,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318727,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1176528264,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318728,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318729,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":182673334,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318730,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318731,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318732,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318725,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318734,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318735,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":955297751,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318736,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318737,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318738,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318739,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318740,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318741,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":222133686,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318742,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318743,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":826746253,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318744,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318745,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318746,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318747,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318748,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318749,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":9604439,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318750,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318751,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318752,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318753,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318754,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318755,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":27340831,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318756,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318757,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1729576272,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318758,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318759,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318760,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318761,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318762,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318763,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1869875058,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318764,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318765,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318766,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318767,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318768,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318769,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":2073614334,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318770,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318771,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1932599642,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318772,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318773,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318774,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318775,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318776,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318777,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1498922571,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318778,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318779,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318780,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318781,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318782,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318783,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":931993316,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318784,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318785,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":919156473,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318786,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318787,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318788,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318789,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318790,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318791,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":234821554,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318792,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318793,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318794,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318795,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318796,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318797,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1765688736,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318798,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318799,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":911955029,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318800,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318801,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318802,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318803,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318804,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318805,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1864961183,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318806,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318807,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318808,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318809,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318810,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318811,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":420198323,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318812,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318813,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1872311921,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318814,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318815,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318816,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318817,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318818,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318819,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1825466636,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318820,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318821,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318822,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318823,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318824,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318825,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1269095934,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318826,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318827,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":265702678,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318828,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318829,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318830,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":318695,"lineno":118,"method_id":"bootstrap","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":2005843134,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":318832,"lineno":118,"method_id":"bootstrap","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":318833,"lineno":128,"method_id":"runForMaster","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":1493302843,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":318834,"lineno":128,"method_id":"runForMaster","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318733,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318836,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318837,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":65792913,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318838,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318839,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318840,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318841,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318842,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318843,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":128443984,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318844,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318845,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1114562313,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318846,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318847,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318848,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":318835,"lineno":128,"method_id":"runForMaster","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":2005843134,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":318850,"lineno":128,"method_id":"runForMaster","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":318851,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":2005843134,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":318852,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","return_value":{"class":"java.lang.Boolean","object_id":1005257904,"value":"false"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":318853,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":1493302843,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":318854,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","return_value":{"class":"java.lang.Boolean","object_id":1369165951,"value":"false"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":318855,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":2005843134,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":318856,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","return_value":{"class":"java.lang.Boolean","object_id":1285004645,"value":"false"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":318857,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":1493302843,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318831,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318859,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318860,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":702203939,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318861,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318862,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318863,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318864,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318865,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318866,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":910381597,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318867,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318869,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":2071758674,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318870,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318871,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318872,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318873,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318874,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318875,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":656368767,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318876,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318877,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318878,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318849,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318879,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318868,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318880,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318881,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1390421533,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318883,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318884,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318885,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318882,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1495641934,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318887,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318888,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1920247300,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318886,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318890,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318889,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318891,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318893,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318892,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":235661491,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318895,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318896,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":908462660,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318897,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318898,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318899,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318894,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318901,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318902,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318904,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":192812261,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318900,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318905,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318906,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318907,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318903,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1840118031,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318909,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318910,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318911,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318908,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318913,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318912,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318915,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318914,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":129599837,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318917,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318918,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":525475742,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318919,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318920,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318921,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318916,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":835535961,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318922,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318924,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1172755185,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318925,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318926,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318927,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318928,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318929,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318923,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318931,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318933,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":947069245,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318934,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318935,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318936,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318937,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318938,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318939,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1494084980,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318930,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":309659855,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318940,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318941,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1651587849,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318942,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318943,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318945,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318932,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318944,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318947,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318948,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318949,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318946,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318951,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318952,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":2114670281,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318953,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318954,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318955,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318950,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":278064655,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318957,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318958,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1269211080,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318959,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318956,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318960,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318961,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318963,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1607529212,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318965,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318966,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1996974886,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318967,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318968,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318969,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318962,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318964,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318971,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318972,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":941931799,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318973,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318974,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318975,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318976,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318977,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318978,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":44951980,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318979,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318980,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":88644960,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318981,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318982,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318983,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318970,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318985,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318986,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":134776076,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318987,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318988,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318989,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318990,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318991,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318992,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":697736858,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318993,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318994,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":272811052,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318995,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318997,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318998,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318984,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":318999,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319000,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319001,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":142589019,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319003,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319004,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":318996,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319005,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319002,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":2054101726,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319006,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319007,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319008,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319009,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319011,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319010,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1048143501,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319013,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319014,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":808113569,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319012,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319015,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319017,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319016,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319019,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319018,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1732172929,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319021,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319022,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":179546435,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319023,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319024,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319025,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319026,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319027,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319028,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1172684783,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319029,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319030,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319031,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319032,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319033,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319034,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":862944398,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319035,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319036,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1788435799,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319037,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319038,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319039,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319020,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319041,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319042,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1685824211,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319043,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319044,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319045,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319046,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319047,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319048,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":286476131,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319049,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319050,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1688929986,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319051,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319052,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319053,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319054,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319055,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319056,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":46809131,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319057,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319058,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319059,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319061,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319040,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319062,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319060,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319064,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1320273327,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319065,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319063,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":351979673,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319066,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319067,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319068,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319069,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":84098896,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319071,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319072,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319073,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319070,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319075,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319076,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":641925457,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319077,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319078,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1853915675,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319079,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319080,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319081,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319082,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319083,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319084,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1322457465,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319085,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319086,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319087,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319088,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319089,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319090,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":235876785,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319091,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319093,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1657790592,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319094,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319095,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319096,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319097,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319098,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319099,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":287550385,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319074,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319100,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319101,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319102,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319092,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319104,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1640546105,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319105,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319106,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319107,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319103,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319109,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319110,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":64031076,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319111,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319112,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1771657506,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319108,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319114,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319115,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319113,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319117,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319116,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1495118100,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319119,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319120,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":459347118,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319121,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319122,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319123,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319125,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319126,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319127,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":2023690625,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319128,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319129,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319130,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319131,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319132,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319133,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":375613298,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319134,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319135,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":558138172,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319136,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319137,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319138,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319139,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319140,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319141,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":678985800,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319142,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319143,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319144,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319145,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319146,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319147,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":678141919,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319148,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319149,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":633218391,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319150,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319151,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319152,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319153,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319154,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319155,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":543563711,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319156,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319158,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319159,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319160,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319161,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319118,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319162,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1571450377,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319164,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319157,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319165,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":2118792007,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319166,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319163,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1959755633,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319167,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319168,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319169,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319170,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319172,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319173,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319174,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319175,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":2017279098,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319176,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319177,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1940684848,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319178,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319179,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319180,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319181,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319171,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319182,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319184,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1348441902,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319183,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319186,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319187,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319188,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319190,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319191,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319185,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":2144228622,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319192,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1157364806,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319193,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319194,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1746800229,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319196,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319189,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319197,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319198,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319195,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319200,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319201,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319202,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319203,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":43242111,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319204,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319205,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":214380034,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319206,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319207,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319208,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319209,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319210,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319211,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":599319766,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319212,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319213,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319214,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319215,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319216,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319217,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":777233290,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319218,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319219,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":852466709,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319220,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319221,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319222,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319223,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319224,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319225,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1830301698,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319226,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319227,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319228,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319229,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319230,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319231,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1728944553,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319232,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319233,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1368007580,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319234,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319235,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319236,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":319124,"lineno":155,"method_id":"takeLeadership","parameters":[{"class":"org.apache.curator.framework.imps.CuratorFrameworkImpl","kind":"req","name":"client","object_id":1214368614,"value":"org.apache.curator.framework.imps.CuratorFrameworkImpl@4861cb66"}],"path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":1493302843,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"},"static":false,"thread_id":115},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","event":"call","id":319238,"lineno":92,"method_id":"recover","parameters":[{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector$1","kind":"req","name":"recoveryCallback","object_id":1832756184,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector$1@6d3da3d8"}],"path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","receiver":{"class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","object_id":1060809318,"value":"org.apache.zookeeper.book.recovery.RecoveredAssignments@3f3aaa66"},"static":false,"thread_id":115},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","event":"call","id":319239,"lineno":97,"method_id":"getTasks","path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","receiver":{"class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","object_id":1060809318,"value":"org.apache.zookeeper.book.recovery.RecoveredAssignments@3f3aaa66"},"static":false,"thread_id":115},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","event":"return","id":319240,"lineno":97,"method_id":"getTasks","path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","static":false,"thread_id":115},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319237,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319242,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319243,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1711248881,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319244,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319245,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319246,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319247,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319248,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319249,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1238049132,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319250,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319251,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1115695405,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319252,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319253,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319254,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319255,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319256,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319257,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":2055598887,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319258,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319259,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319260,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319261,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319262,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319263,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1059363195,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319264,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319265,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1740752945,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319266,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319267,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":798649820,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319269,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319270,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319271,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments$1","event":"call","id":319268,"lineno":102,"method_id":"processResult","parameters":[{"class":"java.lang.Integer","kind":"req","name":"rc","object_id":1995784069,"value":"0"},{"class":"java.lang.String","kind":"req","name":"path","object_id":1729119463,"value":"/tasks"},{"class":"java.lang.Object","kind":"req","name":"ctx","object_id":0},{"class":"java.util.ArrayList","kind":"req","name":"children","object_id":2016599851,"value":"[]"}],"path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","receiver":{"class":"org.apache.zookeeper.book.recovery.RecoveredAssignments$1","object_id":2081248501,"value":"org.apache.zookeeper.book.recovery.RecoveredAssignments$1@7c0d54f5"},"static":false,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","event":"call","id":319273,"lineno":47,"method_id":"access$200","parameters":[{"class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","kind":"req","name":"x0","object_id":1060809318,"value":"org.apache.zookeeper.book.recovery.RecoveredAssignments@3f3aaa66"}],"path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","static":true,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","event":"call","id":319274,"lineno":121,"method_id":"getAssignedWorkers","path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","receiver":{"class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","object_id":1060809318,"value":"org.apache.zookeeper.book.recovery.RecoveredAssignments@3f3aaa66"},"static":false,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","event":"return","id":319275,"lineno":121,"method_id":"getAssignedWorkers","path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","static":false,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","event":"return","id":319276,"lineno":47,"method_id":"access$200","path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","static":true,"thread_id":113},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319272,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319278,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319279,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":2060693443,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319280,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319281,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319282,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319283,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319284,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319285,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1629953699,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319286,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319287,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":240854055,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319288,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319289,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1197338229,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319290,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319291,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319292,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319293,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319294,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319295,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":2076228097,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319296,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319297,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319298,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319299,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319300,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319301,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1207426334,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319302,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319303,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":274375643,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319304,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319305,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319306,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319307,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319308,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319309,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":953993699,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319310,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319311,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319312,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319313,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319314,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319315,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1177713739,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319316,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319317,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1062487742,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319319,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319320,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319321,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319322,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319323,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319324,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1898245408,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319325,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319326,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319327,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments$1","event":"return","id":319277,"lineno":102,"method_id":"processResult","path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","static":false,"thread_id":113},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319328,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319329,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319330,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":548989726,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319331,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319332,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1530927512,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319333,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319334,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319335,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments$2","event":"call","id":319318,"lineno":126,"method_id":"processResult","parameters":[{"class":"java.lang.Integer","kind":"req","name":"rc","object_id":957338896,"value":"0"},{"class":"java.lang.String","kind":"req","name":"path","object_id":221125140,"value":"/assign"},{"class":"java.lang.Object","kind":"req","name":"ctx","object_id":0},{"class":"java.util.ArrayList","kind":"req","name":"children","object_id":1717161123,"value":"[]"}],"path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","receiver":{"class":"org.apache.zookeeper.book.recovery.RecoveredAssignments$2","object_id":142380228,"value":"org.apache.zookeeper.book.recovery.RecoveredAssignments$2@87c8cc4"},"static":false,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","event":"call","id":319337,"lineno":47,"method_id":"access$300","parameters":[{"class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","kind":"req","name":"x0","object_id":1060809318,"value":"org.apache.zookeeper.book.recovery.RecoveredAssignments@3f3aaa66"},{"class":"java.util.ArrayList","kind":"req","name":"x1","object_id":1717161123,"value":"[]"}],"path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","static":true,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","event":"call","id":319338,"lineno":144,"method_id":"getWorkers","parameters":[{"class":"java.util.ArrayList","kind":"req","name":"ctx","object_id":1717161123,"value":"[]"}],"path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","receiver":{"class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","object_id":1060809318,"value":"org.apache.zookeeper.book.recovery.RecoveredAssignments@3f3aaa66"},"static":false,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","event":"return","id":319339,"lineno":144,"method_id":"getWorkers","path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","static":false,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","event":"return","id":319340,"lineno":47,"method_id":"access$300","path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","static":true,"thread_id":113},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319336,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319342,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319343,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":224109117,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319344,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319345,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319346,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319347,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319348,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319349,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1792821395,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319350,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319351,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":2003240145,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319352,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319353,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319354,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319355,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319356,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319357,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1109117952,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319358,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319359,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319360,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319361,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319362,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319363,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1425809278,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319364,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319365,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":562421962,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319366,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319367,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319368,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments$2","event":"return","id":319341,"lineno":126,"method_id":"processResult","path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","static":false,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments$3","event":"call","id":319370,"lineno":150,"method_id":"processResult","parameters":[{"class":"java.lang.Integer","kind":"req","name":"rc","object_id":515951554,"value":"0"},{"class":"java.lang.String","kind":"req","name":"path","object_id":2000914517,"value":"/workers"},{"class":"java.util.ArrayList","kind":"req","name":"ctx","object_id":1717161123,"value":"[]"},{"class":"java.util.ArrayList","kind":"req","name":"children","object_id":1495280223,"value":"[]"}],"path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","receiver":{"class":"org.apache.zookeeper.book.recovery.RecoveredAssignments$3","object_id":1907677452,"value":"org.apache.zookeeper.book.recovery.RecoveredAssignments$3@71b4d90c"},"static":false,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector$1","event":"call","id":319371,"lineno":166,"method_id":"recoveryComplete","parameters":[{"class":"java.lang.Integer","kind":"req","name":"rc","object_id":499278162,"value":"0"},{"class":"java.util.ArrayList","kind":"req","name":"tasks","object_id":96741363,"value":"[]"}],"path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector$1","object_id":1832756184,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector$1@6d3da3d8"},"static":false,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":319372,"lineno":384,"method_id":"assignTasks","parameters":[{"class":"java.util.ArrayList","kind":"req","name":"tasks","object_id":96741363,"value":"[]"}],"path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":1493302843,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"},"static":false,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":319373,"lineno":384,"method_id":"assignTasks","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","static":false,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":319374,"lineno":71,"method_id":"access$200","parameters":[{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","kind":"req","name":"x0","object_id":1493302843,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"}],"path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","static":true,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":319375,"lineno":71,"method_id":"access$200","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","return_value":{"class":"java.util.concurrent.CountDownLatch","object_id":1567528902,"value":"java.util.concurrent.CountDownLatch@5d6e97c6[Count = 0]"},"static":true,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector$1","event":"return","id":319376,"lineno":166,"method_id":"recoveryComplete","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","static":false,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector$1$1","event":"call","id":319378,"lineno":181,"method_id":"run","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector$1$1","object_id":1194864864,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector$1$1@473830e0"},"static":false,"thread_id":118},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":319379,"lineno":71,"method_id":"access$100","parameters":[{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","kind":"req","name":"x0","object_id":1493302843,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"}],"path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","static":true,"thread_id":118},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":319380,"lineno":71,"method_id":"access$100","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","return_value":{"class":"org.apache.curator.framework.recipes.cache.PathChildrenCache","object_id":1241503351,"value":"org.apache.curator.framework.recipes.cache.PathChildrenCache@49ffd677"},"static":true,"thread_id":118},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":319381,"lineno":71,"method_id":"access$100","parameters":[{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","kind":"req","name":"x0","object_id":1493302843,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"}],"path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","static":true,"thread_id":118},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":319382,"lineno":71,"method_id":"access$100","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","return_value":{"class":"org.apache.curator.framework.recipes.cache.PathChildrenCache","object_id":1241503351,"value":"org.apache.curator.framework.recipes.cache.PathChildrenCache@49ffd677"},"static":true,"thread_id":118},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319369,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319384,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319385,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1846229415,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319386,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319387,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319388,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319389,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319390,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319391,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1928102826,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319392,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319393,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1189049702,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319394,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319395,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319396,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319397,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319398,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319399,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1221746375,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319400,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319401,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319402,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319403,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319404,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319405,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":2133037179,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319406,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319407,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1766112742,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319408,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319409,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319410,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319411,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319412,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319413,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1410175469,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319414,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319415,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319416,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319417,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319418,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319419,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":28496836,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319420,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319421,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1671196085,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319422,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319423,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319424,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319425,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319426,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319427,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1270216571,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319428,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319429,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319430,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319431,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319432,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319433,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1794624,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319434,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319435,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":391220192,"value":"false"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319436,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319437,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319438,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1661802690,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"},"static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.book.Client","event":"call","id":319440,"lineno":60,"method_id":"process","parameters":[{"class":"org.apache.zookeeper.WatchedEvent","kind":"req","name":"e","object_id":1427177940,"value":"WatchedEvent state:Disconnected type:None path:null"}],"path":"src/main/java/org/apache/zookeeper/book/Client.java","receiver":{"class":"org.apache.zookeeper.book.Client","object_id":1304842786,"value":"org.apache.zookeeper.book.Client@4dc65222"},"static":false,"thread_id":91},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"call","id":319442,"lineno":95,"method_id":"next","parameters":[{"class":"java.lang.Long","kind":"req","name":"spinDelay","object_id":890355375,"value":"1000"}],"path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","receiver":{"class":"org.apache.zookeeper.client.StaticHostProvider","object_id":2031510031,"value":"org.apache.zookeeper.client.StaticHostProvider@7916620f"},"static":false,"thread_id":45},{"defined_class":"org.apache.zookeeper.client.StaticHostProvider","event":"return","id":319443,"lineno":95,"method_id":"next","path":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","return_value":{"class":"java.net.InetSocketAddress","object_id":1739839955,"value":"localhost/0:0:0:0:0:0:0:1:11221"},"static":false,"thread_id":45},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319444,"lineno":183,"method_id":"getConfigStatus","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1200928593,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@4794b751"},"static":false,"thread_id":45},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":318858,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","return_value":{"class":"java.lang.Boolean","object_id":1752192179,"value":"false"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":319446,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":2005843134,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":319447,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","return_value":{"class":"java.lang.Boolean","object_id":190645129,"value":"false"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":319448,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":1493302843,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":319449,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","return_value":{"class":"java.lang.Boolean","object_id":1916528642,"value":"true"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":319450,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":2005843134,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":319451,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","return_value":{"class":"java.lang.Boolean","object_id":1812075786,"value":"false"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":319452,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":2005843134,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":319453,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","return_value":{"class":"java.lang.Boolean","object_id":1713845098,"value":"false"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":319454,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":1493302843,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":319455,"lineno":146,"method_id":"isLeader","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","return_value":{"class":"java.lang.Boolean","object_id":1807572095,"value":"true"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"call","id":319456,"lineno":437,"method_id":"close","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","object_id":2005843134,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector$2","event":"call","id":319457,"lineno":259,"method_id":"eventReceived","parameters":[{"class":"org.apache.curator.framework.imps.CuratorFrameworkImpl","kind":"req","name":"client","object_id":1189855986,"value":"org.apache.curator.framework.imps.CuratorFrameworkImpl@46ebc2f2"},{"class":"org.apache.curator.framework.imps.CuratorEventImpl","kind":"req","name":"event","object_id":977089888,"value":"CuratorEventImpl{type=CLOSING, resultCode=0, path='null', name='null', children=null, context=null, stat=null, data=null, watchedEvent=null, aclList=null}"}],"path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","receiver":{"class":"org.apache.zookeeper.book.curator.CuratorMasterSelector$2","object_id":1712423275,"value":"org.apache.zookeeper.book.curator.CuratorMasterSelector$2@6611816b"},"static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319199,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319459,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319460,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1996410814,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319461,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319462,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319463,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319464,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319465,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319466,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1845236971,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319467,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319468,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1433100507,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319469,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319470,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319471,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319472,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319473,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319474,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1293824309,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319475,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319476,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319477,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319478,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319479,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319480,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1293784087,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319481,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319482,"lineno":538,"method_id":"clientTunneledAuthenticationInProgress","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.Boolean","object_id":1401253939,"value":"false"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319483,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319484,"lineno":98,"method_id":"getSaslState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState","object_id":321093019,"value":"FAILED"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"call","id":319485,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","receiver":{"class":"org.apache.zookeeper.client.ZooKeeperSaslClient","object_id":1371543381,"value":"org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"},"static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector$2","event":"return","id":319458,"lineno":259,"method_id":"eventReceived","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector","event":"return","id":319487,"lineno":437,"method_id":"close","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","static":false,"thread_id":102},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319486,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":108},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319445,"lineno":183,"method_id":"getConfigStatus","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","return_value":{"class":"java.lang.String","object_id":900058285,"value":"Will not attempt to authenticate using SASL (unknown error)"},"static":false,"thread_id":45},{"defined_class":"org.apache.zookeeper.client.ZooKeeperSaslClient","event":"return","id":319439,"lineno":434,"method_id":"getKeeperState","path":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","static":false,"thread_id":112},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments$3","event":"return","id":319377,"lineno":150,"method_id":"processResult","path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","static":false,"thread_id":113},{"defined_class":"org.apache.zookeeper.book.recovery.RecoveredAssignments","event":"return","id":319241,"lineno":92,"method_id":"recover","path":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","static":false,"thread_id":115},{"defined_class":"org.apache.zookeeper.book.curator.CuratorMasterSelector$1$1","event":"return","id":319383,"lineno":181,"method_id":"run","path":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","static":false,"thread_id":118},{"defined_class":"org.apache.zookeeper.book.Client","event":"return","id":319441,"lineno":60,"method_id":"process","path":"src/main/java/org/apache/zookeeper/book/Client.java","static":false,"thread_id":91}],"classMap":[{"children":[{"children":[{"children":[{"children":[{"children":[{"children":[{"children":[],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:113","name":"startZK","static":false,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:118","name":"bootstrap","static":false,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:128","name":"runForMaster","static":false,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:146","name":"isLeader","static":false,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:155","name":"takeLeadership","static":false,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:384","name":"assignTasks","static":false,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:71","name":"access$200","static":true,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:71","name":"access$100","static":true,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:437","name":"close","static":false,"type":"function"}],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","name":"CuratorMasterSelector","static":false,"type":"class"},{"children":[{"children":[],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:166","name":"recoveryComplete","static":false,"type":"function"}],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","name":"CuratorMasterSelector$1","static":false,"type":"class"},{"children":[{"children":[],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:181","name":"run","static":false,"type":"function"}],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","name":"CuratorMasterSelector$1$1","static":false,"type":"class"},{"children":[{"children":[],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:259","name":"eventReceived","static":false,"type":"function"}],"location":"src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java","name":"CuratorMasterSelector$2","static":false,"type":"class"}],"location":"","name":"curator","type":"package"},{"children":[{"children":[{"children":[],"location":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:92","name":"recover","static":false,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:97","name":"getTasks","static":false,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:47","name":"access$200","static":true,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:121","name":"getAssignedWorkers","static":false,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:47","name":"access$300","static":true,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:144","name":"getWorkers","static":false,"type":"function"}],"location":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","name":"RecoveredAssignments","static":false,"type":"class"},{"children":[{"children":[],"location":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:102","name":"processResult","static":false,"type":"function"}],"location":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","name":"RecoveredAssignments$1","static":false,"type":"class"},{"children":[{"children":[],"location":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:126","name":"processResult","static":false,"type":"function"}],"location":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","name":"RecoveredAssignments$2","static":false,"type":"class"},{"children":[{"children":[],"location":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:150","name":"processResult","static":false,"type":"function"}],"location":"src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java","name":"RecoveredAssignments$3","static":false,"type":"class"}],"location":"","name":"recovery","type":"package"},{"children":[{"children":[],"location":"src/main/java/org/apache/zookeeper/book/Client.java:60","name":"process","static":false,"type":"function"}],"location":"src/main/java/org/apache/zookeeper/book/Client.java","name":"Client","static":false,"type":"class"}],"location":"","name":"book","type":"package"},{"children":[{"children":[{"children":[],"location":"src/main/java/org/apache/zookeeper/client/ConnectStringParser.java:85","name":"getServerAddresses","static":false,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/client/ConnectStringParser.java:81","name":"getChrootPath","static":false,"type":"function"}],"location":"src/main/java/org/apache/zookeeper/client/ConnectStringParser.java","name":"ConnectStringParser","static":false,"type":"class"},{"children":[{"children":[],"location":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java:91","name":"size","static":false,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java:95","name":"next","static":false,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java:114","name":"onConnected","static":false,"type":"function"}],"location":"src/main/java/org/apache/zookeeper/client/StaticHostProvider.java","name":"StaticHostProvider","static":false,"type":"class"},{"children":[{"children":[],"location":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java:183","name":"getConfigStatus","static":false,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java:538","name":"clientTunneledAuthenticationInProgress","static":false,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java:98","name":"getSaslState","static":false,"type":"function"},{"children":[],"location":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java:434","name":"getKeeperState","static":false,"type":"function"}],"location":"src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java","name":"ZooKeeperSaslClient","static":false,"type":"class"}],"location":"","name":"client","type":"package"}],"location":"","name":"zookeeper","type":"package"}],"location":"","name":"apache","type":"package"}],"location":"","name":"org","type":"package"}]}
+{
+  "version": "1.2",
+  "metadata": {
+    "name": "Curator master elect single master",
+    "app": "ZooKeeper Book",
+    "feature": "Elect single master",
+    "feature_group": "Curator master",
+    "language": {
+      "name": "java",
+      "version": "11.0.2+9",
+      "engine": "OpenJDK 64-Bit Server VM"
+    },
+    "client": {
+      "name": "appmap-java",
+      "url": "https://github.com/appland/appmap-java"
+    },
+    "recorder": {
+      "name": "toggle_record_receiver"
+    },
+    "recording": {
+      "defined_class": "org.apache.zookeeper.book.TestCuratorMaster",
+      "method_id": "electSingleMaster"
+    },
+    "framework": {
+      "name": "junit"
+    },
+    "git": {
+      "repository": "https://user-ci:token-ci@github.com/applandinc/appmap",
+      "branch": "master",
+      "commit": "c3424f9"
+    }
+  },
+  "events": [
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 318673,
+      "lineno": 113,
+      "method_id": "startZK",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 2005843134,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ConnectStringParser",
+      "event": "call",
+      "id": 318674,
+      "lineno": 85,
+      "method_id": "getServerAddresses",
+      "path": "src/main/java/org/apache/zookeeper/client/ConnectStringParser.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ConnectStringParser",
+        "object_id": 947144196,
+        "value": "org.apache.zookeeper.client.ConnectStringParser@38744604"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ConnectStringParser",
+      "event": "return",
+      "id": 318675,
+      "lineno": 85,
+      "method_id": "getServerAddresses",
+      "path": "src/main/java/org/apache/zookeeper/client/ConnectStringParser.java",
+      "return_value": {
+        "class": "java.util.ArrayList",
+        "object_id": 975009528,
+        "value": "[localhost:11224]"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ConnectStringParser",
+      "event": "call",
+      "id": 318676,
+      "lineno": 81,
+      "method_id": "getChrootPath",
+      "path": "src/main/java/org/apache/zookeeper/client/ConnectStringParser.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ConnectStringParser",
+        "object_id": 947144196,
+        "value": "org.apache.zookeeper.client.ConnectStringParser@38744604"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ConnectStringParser",
+      "event": "return",
+      "id": 318677,
+      "lineno": 81,
+      "method_id": "getChrootPath",
+      "path": "src/main/java/org/apache/zookeeper/client/ConnectStringParser.java",
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "call",
+      "id": 318678,
+      "lineno": 91,
+      "method_id": "size",
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.StaticHostProvider",
+        "object_id": 1482406219,
+        "value": "org.apache.zookeeper.client.StaticHostProvider@585bb94b"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "call",
+      "id": 318680,
+      "lineno": 95,
+      "method_id": "next",
+      "parameters": [
+        {
+          "class": "java.lang.Long",
+          "kind": "req",
+          "name": "spinDelay",
+          "object_id": 1530428453,
+          "value": "1000"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.StaticHostProvider",
+        "object_id": 1482406219,
+        "value": "org.apache.zookeeper.client.StaticHostProvider@585bb94b"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "return",
+      "id": 318679,
+      "lineno": 91,
+      "method_id": "size",
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "return_value": {
+        "class": "java.lang.Integer",
+        "object_id": 161525262,
+        "value": "2"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 318682,
+      "lineno": 113,
+      "method_id": "startZK",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 318683,
+      "lineno": 113,
+      "method_id": "startZK",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 1493302843,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ConnectStringParser",
+      "event": "call",
+      "id": 318684,
+      "lineno": 85,
+      "method_id": "getServerAddresses",
+      "path": "src/main/java/org/apache/zookeeper/client/ConnectStringParser.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ConnectStringParser",
+        "object_id": 1785304456,
+        "value": "org.apache.zookeeper.client.ConnectStringParser@6a699588"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ConnectStringParser",
+      "event": "return",
+      "id": 318685,
+      "lineno": 85,
+      "method_id": "getServerAddresses",
+      "path": "src/main/java/org/apache/zookeeper/client/ConnectStringParser.java",
+      "return_value": {
+        "class": "java.util.ArrayList",
+        "object_id": 1020219096,
+        "value": "[localhost:11224]"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ConnectStringParser",
+      "event": "call",
+      "id": 318686,
+      "lineno": 81,
+      "method_id": "getChrootPath",
+      "path": "src/main/java/org/apache/zookeeper/client/ConnectStringParser.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ConnectStringParser",
+        "object_id": 1785304456,
+        "value": "org.apache.zookeeper.client.ConnectStringParser@6a699588"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "return",
+      "id": 318681,
+      "lineno": 95,
+      "method_id": "next",
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "return_value": {
+        "class": "java.net.InetSocketAddress",
+        "object_id": 1442810162,
+        "value": "localhost/127.0.0.1:11224"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318688,
+      "lineno": 183,
+      "method_id": "getConfigStatus",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ConnectStringParser",
+      "event": "return",
+      "id": 318687,
+      "lineno": 81,
+      "method_id": "getChrootPath",
+      "path": "src/main/java/org/apache/zookeeper/client/ConnectStringParser.java",
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "call",
+      "id": 318690,
+      "lineno": 91,
+      "method_id": "size",
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.StaticHostProvider",
+        "object_id": 1283947773,
+        "value": "org.apache.zookeeper.client.StaticHostProvider@4c877cfd"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "call",
+      "id": 318692,
+      "lineno": 95,
+      "method_id": "next",
+      "parameters": [
+        {
+          "class": "java.lang.Long",
+          "kind": "req",
+          "name": "spinDelay",
+          "object_id": 1777693618,
+          "value": "1000"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.StaticHostProvider",
+        "object_id": 1283947773,
+        "value": "org.apache.zookeeper.client.StaticHostProvider@4c877cfd"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "return",
+      "id": 318691,
+      "lineno": 91,
+      "method_id": "size",
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "return_value": {
+        "class": "java.lang.Integer",
+        "object_id": 1347793670,
+        "value": "2"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 318694,
+      "lineno": 113,
+      "method_id": "startZK",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318689,
+      "lineno": 183,
+      "method_id": "getConfigStatus",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.String",
+        "object_id": 348291849,
+        "value": "Will not attempt to authenticate using SASL (unknown error)"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318696,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "return",
+      "id": 318693,
+      "lineno": 95,
+      "method_id": "next",
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "return_value": {
+        "class": "java.net.InetSocketAddress",
+        "object_id": 1731367164,
+        "value": "localhost/127.0.0.1:11224"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318698,
+      "lineno": 183,
+      "method_id": "getConfigStatus",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318699,
+      "lineno": 183,
+      "method_id": "getConfigStatus",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.String",
+        "object_id": 638556871,
+        "value": "Will not attempt to authenticate using SASL (unknown error)"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318700,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318697,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 622637659,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "call",
+      "id": 318702,
+      "lineno": 91,
+      "method_id": "size",
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.StaticHostProvider",
+        "object_id": 1482406219,
+        "value": "org.apache.zookeeper.client.StaticHostProvider@585bb94b"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "return",
+      "id": 318703,
+      "lineno": 91,
+      "method_id": "size",
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "return_value": {
+        "class": "java.lang.Integer",
+        "object_id": 1958179602,
+        "value": "2"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "call",
+      "id": 318704,
+      "lineno": 114,
+      "method_id": "onConnected",
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.StaticHostProvider",
+        "object_id": 1482406219,
+        "value": "org.apache.zookeeper.client.StaticHostProvider@585bb94b"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "return",
+      "id": 318705,
+      "lineno": 114,
+      "method_id": "onConnected",
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318706,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318701,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 392420447,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318707,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1961720902,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "call",
+      "id": 318708,
+      "lineno": 91,
+      "method_id": "size",
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.StaticHostProvider",
+        "object_id": 1283947773,
+        "value": "org.apache.zookeeper.client.StaticHostProvider@4c877cfd"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318710,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "return",
+      "id": 318709,
+      "lineno": 91,
+      "method_id": "size",
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "return_value": {
+        "class": "java.lang.Integer",
+        "object_id": 480447865,
+        "value": "2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318711,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1058227040,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "call",
+      "id": 318712,
+      "lineno": 114,
+      "method_id": "onConnected",
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.StaticHostProvider",
+        "object_id": 1283947773,
+        "value": "org.apache.zookeeper.client.StaticHostProvider@4c877cfd"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318713,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318715,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318716,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318717,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318718,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318719,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 348354323,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318720,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318721,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1430166811,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318722,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318723,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318724,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "return",
+      "id": 318714,
+      "lineno": 114,
+      "method_id": "onConnected",
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318726,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318727,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1176528264,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318728,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318729,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 182673334,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318730,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318731,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318732,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318725,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318734,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318735,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 955297751,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318736,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318737,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318738,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318739,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318740,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318741,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 222133686,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318742,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318743,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 826746253,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318744,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318745,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318746,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318747,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318748,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318749,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 9604439,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318750,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318751,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318752,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318753,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318754,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318755,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 27340831,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318756,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318757,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1729576272,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318758,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318759,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318760,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318761,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318762,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318763,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1869875058,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318764,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318765,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318766,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318767,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318768,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318769,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 2073614334,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318770,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318771,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1932599642,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318772,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318773,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318774,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318775,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318776,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318777,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1498922571,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318778,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318779,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318780,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318781,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318782,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318783,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 931993316,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318784,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318785,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 919156473,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318786,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318787,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318788,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318789,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318790,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318791,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 234821554,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318792,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318793,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318794,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318795,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318796,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318797,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1765688736,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318798,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318799,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 911955029,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318800,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318801,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318802,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318803,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318804,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318805,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1864961183,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318806,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318807,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318808,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318809,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318810,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318811,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 420198323,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318812,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318813,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1872311921,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318814,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318815,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318816,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318817,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318818,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318819,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1825466636,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318820,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318821,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318822,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318823,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318824,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318825,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1269095934,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318826,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318827,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 265702678,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318828,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318829,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318830,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 318695,
+      "lineno": 118,
+      "method_id": "bootstrap",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 2005843134,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 318832,
+      "lineno": 118,
+      "method_id": "bootstrap",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 318833,
+      "lineno": 128,
+      "method_id": "runForMaster",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 1493302843,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 318834,
+      "lineno": 128,
+      "method_id": "runForMaster",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318733,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318836,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318837,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 65792913,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318838,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318839,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318840,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318841,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318842,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318843,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 128443984,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318844,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318845,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1114562313,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318846,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318847,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318848,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 318835,
+      "lineno": 128,
+      "method_id": "runForMaster",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 2005843134,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 318850,
+      "lineno": 128,
+      "method_id": "runForMaster",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 318851,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 2005843134,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 318852,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1005257904,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 318853,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 1493302843,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 318854,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1369165951,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 318855,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 2005843134,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 318856,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1285004645,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 318857,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 1493302843,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318831,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318859,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318860,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 702203939,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318861,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318862,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318863,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318864,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318865,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318866,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 910381597,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318867,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318869,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 2071758674,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318870,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318871,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318872,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318873,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318874,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318875,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 656368767,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318876,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318877,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318878,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318849,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318879,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318868,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318880,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318881,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1390421533,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318883,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318884,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318885,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318882,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1495641934,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318887,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318888,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1920247300,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318886,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318890,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318889,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318891,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318893,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318892,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 235661491,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318895,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318896,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 908462660,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318897,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318898,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318899,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318894,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318901,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318902,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318904,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 192812261,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318900,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318905,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318906,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318907,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318903,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1840118031,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318909,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318910,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318911,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318908,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318913,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318912,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318915,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318914,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 129599837,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318917,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318918,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 525475742,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318919,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318920,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318921,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318916,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 835535961,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318922,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318924,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1172755185,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318925,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318926,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318927,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318928,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318929,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318923,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318931,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318933,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 947069245,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318934,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318935,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318936,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318937,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318938,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318939,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1494084980,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318930,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 309659855,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318940,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318941,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1651587849,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318942,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318943,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318945,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318932,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318944,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318947,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318948,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318949,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318946,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318951,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318952,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 2114670281,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318953,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318954,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318955,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318950,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 278064655,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318957,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318958,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1269211080,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318959,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318956,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318960,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318961,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318963,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1607529212,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318965,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318966,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1996974886,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318967,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318968,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318969,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318962,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318964,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318971,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318972,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 941931799,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318973,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318974,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318975,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318976,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318977,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318978,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 44951980,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318979,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318980,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 88644960,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318981,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318982,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318983,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318970,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318985,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318986,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 134776076,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318987,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318988,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318989,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318990,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318991,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318992,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 697736858,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318993,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318994,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 272811052,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318995,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318997,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318998,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318984,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 318999,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319000,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319001,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 142589019,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319003,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319004,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 318996,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319005,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319002,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 2054101726,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319006,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319007,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319008,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319009,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319011,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319010,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1048143501,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319013,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319014,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 808113569,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319012,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319015,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319017,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319016,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319019,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319018,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1732172929,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319021,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319022,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 179546435,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319023,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319024,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319025,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319026,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319027,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319028,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1172684783,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319029,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319030,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319031,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319032,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319033,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319034,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 862944398,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319035,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319036,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1788435799,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319037,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319038,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319039,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319020,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319041,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319042,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1685824211,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319043,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319044,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319045,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319046,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319047,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319048,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 286476131,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319049,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319050,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1688929986,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319051,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319052,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319053,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319054,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319055,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319056,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 46809131,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319057,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319058,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319059,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319061,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319040,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319062,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319060,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319064,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1320273327,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319065,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319063,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 351979673,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319066,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319067,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319068,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319069,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 84098896,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319071,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319072,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319073,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319070,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319075,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319076,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 641925457,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319077,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319078,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1853915675,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319079,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319080,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319081,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319082,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319083,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319084,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1322457465,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319085,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319086,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319087,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319088,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319089,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319090,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 235876785,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319091,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319093,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1657790592,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319094,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319095,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319096,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319097,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319098,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319099,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 287550385,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319074,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319100,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319101,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319102,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319092,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319104,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1640546105,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319105,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319106,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319107,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319103,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319109,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319110,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 64031076,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319111,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319112,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1771657506,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319108,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319114,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319115,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319113,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319117,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319116,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1495118100,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319119,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319120,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 459347118,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319121,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319122,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319123,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319125,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319126,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319127,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 2023690625,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319128,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319129,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319130,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319131,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319132,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319133,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 375613298,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319134,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319135,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 558138172,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319136,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319137,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319138,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319139,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319140,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319141,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 678985800,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319142,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319143,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319144,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319145,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319146,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319147,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 678141919,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319148,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319149,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 633218391,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319150,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319151,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319152,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319153,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319154,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319155,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 543563711,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319156,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319158,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319159,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319160,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319161,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319118,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319162,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1571450377,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319164,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319157,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319165,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 2118792007,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319166,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319163,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1959755633,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319167,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319168,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319169,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319170,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319172,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319173,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319174,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319175,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 2017279098,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319176,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319177,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1940684848,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319178,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319179,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319180,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319181,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319171,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319182,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319184,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1348441902,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319183,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319186,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319187,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319188,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319190,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319191,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319185,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 2144228622,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319192,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1157364806,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319193,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319194,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1746800229,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319196,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319189,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319197,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319198,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319195,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319200,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319201,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319202,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319203,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 43242111,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319204,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319205,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 214380034,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319206,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319207,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319208,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319209,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319210,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319211,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 599319766,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319212,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319213,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319214,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319215,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319216,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319217,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 777233290,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319218,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319219,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 852466709,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319220,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319221,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319222,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319223,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319224,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319225,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1830301698,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319226,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319227,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319228,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319229,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319230,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319231,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1728944553,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319232,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319233,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1368007580,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319234,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319235,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319236,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 319124,
+      "lineno": 155,
+      "method_id": "takeLeadership",
+      "parameters": [
+        {
+          "class": "org.apache.curator.framework.imps.CuratorFrameworkImpl",
+          "kind": "req",
+          "name": "client",
+          "object_id": 1214368614,
+          "value": "org.apache.curator.framework.imps.CuratorFrameworkImpl@4861cb66"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 1493302843,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"
+      },
+      "static": false,
+      "thread_id": 115
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+      "event": "call",
+      "id": 319238,
+      "lineno": 92,
+      "method_id": "recover",
+      "parameters": [
+        {
+          "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector$1",
+          "kind": "req",
+          "name": "recoveryCallback",
+          "object_id": 1832756184,
+          "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector$1@6d3da3d8"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+        "object_id": 1060809318,
+        "value": "org.apache.zookeeper.book.recovery.RecoveredAssignments@3f3aaa66"
+      },
+      "static": false,
+      "thread_id": 115
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+      "event": "call",
+      "id": 319239,
+      "lineno": 97,
+      "method_id": "getTasks",
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+        "object_id": 1060809318,
+        "value": "org.apache.zookeeper.book.recovery.RecoveredAssignments@3f3aaa66"
+      },
+      "static": false,
+      "thread_id": 115
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+      "event": "return",
+      "id": 319240,
+      "lineno": 97,
+      "method_id": "getTasks",
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "static": false,
+      "thread_id": 115
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319237,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319242,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319243,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1711248881,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319244,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319245,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319246,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319247,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319248,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319249,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1238049132,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319250,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319251,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1115695405,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319252,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319253,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319254,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319255,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319256,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319257,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 2055598887,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319258,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319259,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319260,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319261,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319262,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319263,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1059363195,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319264,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319265,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1740752945,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319266,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319267,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 798649820,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319269,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319270,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319271,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments$1",
+      "event": "call",
+      "id": 319268,
+      "lineno": 102,
+      "method_id": "processResult",
+      "parameters": [
+        {
+          "class": "java.lang.Integer",
+          "kind": "req",
+          "name": "rc",
+          "object_id": 1995784069,
+          "value": "0"
+        },
+        {
+          "class": "java.lang.String",
+          "kind": "req",
+          "name": "path",
+          "object_id": 1729119463,
+          "value": "/tasks"
+        },
+        {
+          "class": "java.lang.Object",
+          "kind": "req",
+          "name": "ctx",
+          "object_id": 0
+        },
+        {
+          "class": "java.util.ArrayList",
+          "kind": "req",
+          "name": "children",
+          "object_id": 2016599851,
+          "value": "[]"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.recovery.RecoveredAssignments$1",
+        "object_id": 2081248501,
+        "value": "org.apache.zookeeper.book.recovery.RecoveredAssignments$1@7c0d54f5"
+      },
+      "static": false,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+      "event": "call",
+      "id": 319273,
+      "lineno": 47,
+      "method_id": "access$200",
+      "parameters": [
+        {
+          "class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+          "kind": "req",
+          "name": "x0",
+          "object_id": 1060809318,
+          "value": "org.apache.zookeeper.book.recovery.RecoveredAssignments@3f3aaa66"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "static": true,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+      "event": "call",
+      "id": 319274,
+      "lineno": 121,
+      "method_id": "getAssignedWorkers",
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+        "object_id": 1060809318,
+        "value": "org.apache.zookeeper.book.recovery.RecoveredAssignments@3f3aaa66"
+      },
+      "static": false,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+      "event": "return",
+      "id": 319275,
+      "lineno": 121,
+      "method_id": "getAssignedWorkers",
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "static": false,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+      "event": "return",
+      "id": 319276,
+      "lineno": 47,
+      "method_id": "access$200",
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "static": true,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319272,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319278,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319279,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 2060693443,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319280,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319281,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319282,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319283,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319284,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319285,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1629953699,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319286,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319287,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 240854055,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319288,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319289,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1197338229,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319290,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319291,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319292,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319293,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319294,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319295,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 2076228097,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319296,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319297,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319298,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319299,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319300,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319301,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1207426334,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319302,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319303,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 274375643,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319304,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319305,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319306,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319307,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319308,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319309,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 953993699,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319310,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319311,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319312,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319313,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319314,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319315,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1177713739,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319316,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319317,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1062487742,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319319,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319320,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319321,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319322,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319323,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319324,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1898245408,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319325,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319326,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319327,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments$1",
+      "event": "return",
+      "id": 319277,
+      "lineno": 102,
+      "method_id": "processResult",
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "static": false,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319328,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319329,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319330,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 548989726,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319331,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319332,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1530927512,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319333,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319334,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319335,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments$2",
+      "event": "call",
+      "id": 319318,
+      "lineno": 126,
+      "method_id": "processResult",
+      "parameters": [
+        {
+          "class": "java.lang.Integer",
+          "kind": "req",
+          "name": "rc",
+          "object_id": 957338896,
+          "value": "0"
+        },
+        {
+          "class": "java.lang.String",
+          "kind": "req",
+          "name": "path",
+          "object_id": 221125140,
+          "value": "/assign"
+        },
+        {
+          "class": "java.lang.Object",
+          "kind": "req",
+          "name": "ctx",
+          "object_id": 0
+        },
+        {
+          "class": "java.util.ArrayList",
+          "kind": "req",
+          "name": "children",
+          "object_id": 1717161123,
+          "value": "[]"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.recovery.RecoveredAssignments$2",
+        "object_id": 142380228,
+        "value": "org.apache.zookeeper.book.recovery.RecoveredAssignments$2@87c8cc4"
+      },
+      "static": false,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+      "event": "call",
+      "id": 319337,
+      "lineno": 47,
+      "method_id": "access$300",
+      "parameters": [
+        {
+          "class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+          "kind": "req",
+          "name": "x0",
+          "object_id": 1060809318,
+          "value": "org.apache.zookeeper.book.recovery.RecoveredAssignments@3f3aaa66"
+        },
+        {
+          "class": "java.util.ArrayList",
+          "kind": "req",
+          "name": "x1",
+          "object_id": 1717161123,
+          "value": "[]"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "static": true,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+      "event": "call",
+      "id": 319338,
+      "lineno": 144,
+      "method_id": "getWorkers",
+      "parameters": [
+        {
+          "class": "java.util.ArrayList",
+          "kind": "req",
+          "name": "ctx",
+          "object_id": 1717161123,
+          "value": "[]"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+        "object_id": 1060809318,
+        "value": "org.apache.zookeeper.book.recovery.RecoveredAssignments@3f3aaa66"
+      },
+      "static": false,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+      "event": "return",
+      "id": 319339,
+      "lineno": 144,
+      "method_id": "getWorkers",
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "static": false,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+      "event": "return",
+      "id": 319340,
+      "lineno": 47,
+      "method_id": "access$300",
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "static": true,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319336,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319342,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319343,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 224109117,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319344,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319345,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319346,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319347,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319348,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319349,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1792821395,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319350,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319351,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 2003240145,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319352,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319353,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319354,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319355,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319356,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319357,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1109117952,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319358,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319359,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319360,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319361,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319362,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319363,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1425809278,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319364,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319365,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 562421962,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319366,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319367,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319368,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments$2",
+      "event": "return",
+      "id": 319341,
+      "lineno": 126,
+      "method_id": "processResult",
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "static": false,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments$3",
+      "event": "call",
+      "id": 319370,
+      "lineno": 150,
+      "method_id": "processResult",
+      "parameters": [
+        {
+          "class": "java.lang.Integer",
+          "kind": "req",
+          "name": "rc",
+          "object_id": 515951554,
+          "value": "0"
+        },
+        {
+          "class": "java.lang.String",
+          "kind": "req",
+          "name": "path",
+          "object_id": 2000914517,
+          "value": "/workers"
+        },
+        {
+          "class": "java.util.ArrayList",
+          "kind": "req",
+          "name": "ctx",
+          "object_id": 1717161123,
+          "value": "[]"
+        },
+        {
+          "class": "java.util.ArrayList",
+          "kind": "req",
+          "name": "children",
+          "object_id": 1495280223,
+          "value": "[]"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.recovery.RecoveredAssignments$3",
+        "object_id": 1907677452,
+        "value": "org.apache.zookeeper.book.recovery.RecoveredAssignments$3@71b4d90c"
+      },
+      "static": false,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector$1",
+      "event": "call",
+      "id": 319371,
+      "lineno": 166,
+      "method_id": "recoveryComplete",
+      "parameters": [
+        {
+          "class": "java.lang.Integer",
+          "kind": "req",
+          "name": "rc",
+          "object_id": 499278162,
+          "value": "0"
+        },
+        {
+          "class": "java.util.ArrayList",
+          "kind": "req",
+          "name": "tasks",
+          "object_id": 96741363,
+          "value": "[]"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector$1",
+        "object_id": 1832756184,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector$1@6d3da3d8"
+      },
+      "static": false,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 319372,
+      "lineno": 384,
+      "method_id": "assignTasks",
+      "parameters": [
+        {
+          "class": "java.util.ArrayList",
+          "kind": "req",
+          "name": "tasks",
+          "object_id": 96741363,
+          "value": "[]"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 1493302843,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"
+      },
+      "static": false,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 319373,
+      "lineno": 384,
+      "method_id": "assignTasks",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "static": false,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 319374,
+      "lineno": 71,
+      "method_id": "access$200",
+      "parameters": [
+        {
+          "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+          "kind": "req",
+          "name": "x0",
+          "object_id": 1493302843,
+          "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "static": true,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 319375,
+      "lineno": 71,
+      "method_id": "access$200",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "return_value": {
+        "class": "java.util.concurrent.CountDownLatch",
+        "object_id": 1567528902,
+        "value": "java.util.concurrent.CountDownLatch@5d6e97c6[Count = 0]"
+      },
+      "static": true,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector$1",
+      "event": "return",
+      "id": 319376,
+      "lineno": 166,
+      "method_id": "recoveryComplete",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "static": false,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector$1$1",
+      "event": "call",
+      "id": 319378,
+      "lineno": 181,
+      "method_id": "run",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector$1$1",
+        "object_id": 1194864864,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector$1$1@473830e0"
+      },
+      "static": false,
+      "thread_id": 118
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 319379,
+      "lineno": 71,
+      "method_id": "access$100",
+      "parameters": [
+        {
+          "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+          "kind": "req",
+          "name": "x0",
+          "object_id": 1493302843,
+          "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "static": true,
+      "thread_id": 118
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 319380,
+      "lineno": 71,
+      "method_id": "access$100",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "return_value": {
+        "class": "org.apache.curator.framework.recipes.cache.PathChildrenCache",
+        "object_id": 1241503351,
+        "value": "org.apache.curator.framework.recipes.cache.PathChildrenCache@49ffd677"
+      },
+      "static": true,
+      "thread_id": 118
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 319381,
+      "lineno": 71,
+      "method_id": "access$100",
+      "parameters": [
+        {
+          "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+          "kind": "req",
+          "name": "x0",
+          "object_id": 1493302843,
+          "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "static": true,
+      "thread_id": 118
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 319382,
+      "lineno": 71,
+      "method_id": "access$100",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "return_value": {
+        "class": "org.apache.curator.framework.recipes.cache.PathChildrenCache",
+        "object_id": 1241503351,
+        "value": "org.apache.curator.framework.recipes.cache.PathChildrenCache@49ffd677"
+      },
+      "static": true,
+      "thread_id": 118
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319369,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319384,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319385,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1846229415,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319386,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319387,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319388,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319389,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319390,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319391,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1928102826,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319392,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319393,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1189049702,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319394,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319395,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319396,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319397,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319398,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319399,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1221746375,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319400,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319401,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319402,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319403,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319404,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319405,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 2133037179,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319406,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319407,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1766112742,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319408,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319409,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319410,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319411,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319412,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319413,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1410175469,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319414,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319415,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319416,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319417,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319418,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319419,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 28496836,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319420,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319421,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1671196085,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319422,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319423,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319424,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319425,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319426,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319427,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1270216571,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319428,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319429,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319430,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319431,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319432,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319433,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1794624,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319434,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319435,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 391220192,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319436,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319437,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319438,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1661802690,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@630d18c2"
+      },
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.Client",
+      "event": "call",
+      "id": 319440,
+      "lineno": 60,
+      "method_id": "process",
+      "parameters": [
+        {
+          "class": "org.apache.zookeeper.WatchedEvent",
+          "kind": "req",
+          "name": "e",
+          "object_id": 1427177940,
+          "value": "WatchedEvent state:Disconnected type:None path:null"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/book/Client.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.Client",
+        "object_id": 1304842786,
+        "value": "org.apache.zookeeper.book.Client@4dc65222"
+      },
+      "static": false,
+      "thread_id": 91
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "call",
+      "id": 319442,
+      "lineno": 95,
+      "method_id": "next",
+      "parameters": [
+        {
+          "class": "java.lang.Long",
+          "kind": "req",
+          "name": "spinDelay",
+          "object_id": 890355375,
+          "value": "1000"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.StaticHostProvider",
+        "object_id": 2031510031,
+        "value": "org.apache.zookeeper.client.StaticHostProvider@7916620f"
+      },
+      "static": false,
+      "thread_id": 45
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.StaticHostProvider",
+      "event": "return",
+      "id": 319443,
+      "lineno": 95,
+      "method_id": "next",
+      "path": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+      "return_value": {
+        "class": "java.net.InetSocketAddress",
+        "object_id": 1739839955,
+        "value": "localhost/0:0:0:0:0:0:0:1:11221"
+      },
+      "static": false,
+      "thread_id": 45
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319444,
+      "lineno": 183,
+      "method_id": "getConfigStatus",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1200928593,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@4794b751"
+      },
+      "static": false,
+      "thread_id": 45
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 318858,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1752192179,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 319446,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 2005843134,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 319447,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 190645129,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 319448,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 1493302843,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 319449,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1916528642,
+        "value": "true"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 319450,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 2005843134,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 319451,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1812075786,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 319452,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 2005843134,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 319453,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1713845098,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 319454,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 1493302843,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@5901fe3b"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 319455,
+      "lineno": 146,
+      "method_id": "isLeader",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1807572095,
+        "value": "true"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "call",
+      "id": 319456,
+      "lineno": 437,
+      "method_id": "close",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+        "object_id": 2005843134,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector@778ebcbe"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector$2",
+      "event": "call",
+      "id": 319457,
+      "lineno": 259,
+      "method_id": "eventReceived",
+      "parameters": [
+        {
+          "class": "org.apache.curator.framework.imps.CuratorFrameworkImpl",
+          "kind": "req",
+          "name": "client",
+          "object_id": 1189855986,
+          "value": "org.apache.curator.framework.imps.CuratorFrameworkImpl@46ebc2f2"
+        },
+        {
+          "class": "org.apache.curator.framework.imps.CuratorEventImpl",
+          "kind": "req",
+          "name": "event",
+          "object_id": 977089888,
+          "value": "CuratorEventImpl{type=CLOSING, resultCode=0, path='null', name='null', children=null, context=null, stat=null, data=null, watchedEvent=null, aclList=null}"
+        }
+      ],
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.book.curator.CuratorMasterSelector$2",
+        "object_id": 1712423275,
+        "value": "org.apache.zookeeper.book.curator.CuratorMasterSelector$2@6611816b"
+      },
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319199,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319459,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319460,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1996410814,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319461,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319462,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319463,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319464,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319465,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319466,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1845236971,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319467,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319468,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1433100507,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319469,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319470,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319471,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319472,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319473,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319474,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1293824309,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319475,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319476,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319477,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319478,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319479,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319480,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1293784087,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319481,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319482,
+      "lineno": 538,
+      "method_id": "clientTunneledAuthenticationInProgress",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.Boolean",
+        "object_id": 1401253939,
+        "value": "false"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319483,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319484,
+      "lineno": 98,
+      "method_id": "getSaslState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient$SaslState",
+        "object_id": 321093019,
+        "value": "FAILED"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "call",
+      "id": 319485,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "receiver": {
+        "class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+        "object_id": 1371543381,
+        "value": "org.apache.zookeeper.client.ZooKeeperSaslClient@51c01755"
+      },
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector$2",
+      "event": "return",
+      "id": 319458,
+      "lineno": 259,
+      "method_id": "eventReceived",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector",
+      "event": "return",
+      "id": 319487,
+      "lineno": 437,
+      "method_id": "close",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "static": false,
+      "thread_id": 102
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319486,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 108
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319445,
+      "lineno": 183,
+      "method_id": "getConfigStatus",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "return_value": {
+        "class": "java.lang.String",
+        "object_id": 900058285,
+        "value": "Will not attempt to authenticate using SASL (unknown error)"
+      },
+      "static": false,
+      "thread_id": 45
+    },
+    {
+      "defined_class": "org.apache.zookeeper.client.ZooKeeperSaslClient",
+      "event": "return",
+      "id": 319439,
+      "lineno": 434,
+      "method_id": "getKeeperState",
+      "path": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+      "static": false,
+      "thread_id": 112
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments$3",
+      "event": "return",
+      "id": 319377,
+      "lineno": 150,
+      "method_id": "processResult",
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "static": false,
+      "thread_id": 113
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.recovery.RecoveredAssignments",
+      "event": "return",
+      "id": 319241,
+      "lineno": 92,
+      "method_id": "recover",
+      "path": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+      "static": false,
+      "thread_id": 115
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.curator.CuratorMasterSelector$1$1",
+      "event": "return",
+      "id": 319383,
+      "lineno": 181,
+      "method_id": "run",
+      "path": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+      "static": false,
+      "thread_id": 118
+    },
+    {
+      "defined_class": "org.apache.zookeeper.book.Client",
+      "event": "return",
+      "id": 319441,
+      "lineno": 60,
+      "method_id": "process",
+      "path": "src/main/java/org/apache/zookeeper/book/Client.java",
+      "static": false,
+      "thread_id": 91
+    }
+  ],
+  "classMap": [
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:113",
+                              "name": "startZK",
+                              "static": false,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:118",
+                              "name": "bootstrap",
+                              "static": false,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:128",
+                              "name": "runForMaster",
+                              "static": false,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:146",
+                              "name": "isLeader",
+                              "static": false,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:155",
+                              "name": "takeLeadership",
+                              "static": false,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:384",
+                              "name": "assignTasks",
+                              "static": false,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:71",
+                              "name": "access$200",
+                              "static": true,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:71",
+                              "name": "access$100",
+                              "static": true,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:437",
+                              "name": "close",
+                              "static": false,
+                              "type": "function"
+                            }
+                          ],
+                          "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+                          "name": "CuratorMasterSelector",
+                          "static": false,
+                          "type": "class"
+                        },
+                        {
+                          "children": [
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:166",
+                              "name": "recoveryComplete",
+                              "static": false,
+                              "type": "function"
+                            }
+                          ],
+                          "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+                          "name": "CuratorMasterSelector$1",
+                          "static": false,
+                          "type": "class"
+                        },
+                        {
+                          "children": [
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:181",
+                              "name": "run",
+                              "static": false,
+                              "type": "function"
+                            }
+                          ],
+                          "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+                          "name": "CuratorMasterSelector$1$1",
+                          "static": false,
+                          "type": "class"
+                        },
+                        {
+                          "children": [
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java:259",
+                              "name": "eventReceived",
+                              "static": false,
+                              "type": "function"
+                            }
+                          ],
+                          "location": "src/main/java/org/apache/zookeeper/book/curator/CuratorMasterSelector.java",
+                          "name": "CuratorMasterSelector$2",
+                          "static": false,
+                          "type": "class"
+                        }
+                      ],
+                      "location": "",
+                      "name": "curator",
+                      "type": "package"
+                    },
+                    {
+                      "children": [
+                        {
+                          "children": [
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:92",
+                              "name": "recover",
+                              "static": false,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:97",
+                              "name": "getTasks",
+                              "static": false,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:47",
+                              "name": "access$200",
+                              "static": true,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:121",
+                              "name": "getAssignedWorkers",
+                              "static": false,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:47",
+                              "name": "access$300",
+                              "static": true,
+                              "type": "function"
+                            },
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:144",
+                              "name": "getWorkers",
+                              "static": false,
+                              "type": "function"
+                            }
+                          ],
+                          "location": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+                          "name": "RecoveredAssignments",
+                          "static": false,
+                          "type": "class"
+                        },
+                        {
+                          "children": [
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:102",
+                              "name": "processResult",
+                              "static": false,
+                              "type": "function"
+                            }
+                          ],
+                          "location": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+                          "name": "RecoveredAssignments$1",
+                          "static": false,
+                          "type": "class"
+                        },
+                        {
+                          "children": [
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:126",
+                              "name": "processResult",
+                              "static": false,
+                              "type": "function"
+                            }
+                          ],
+                          "location": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+                          "name": "RecoveredAssignments$2",
+                          "static": false,
+                          "type": "class"
+                        },
+                        {
+                          "children": [
+                            {
+                              "children": [],
+                              "location": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java:150",
+                              "name": "processResult",
+                              "static": false,
+                              "type": "function"
+                            }
+                          ],
+                          "location": "src/main/java/org/apache/zookeeper/book/recovery/RecoveredAssignments.java",
+                          "name": "RecoveredAssignments$3",
+                          "static": false,
+                          "type": "class"
+                        }
+                      ],
+                      "location": "",
+                      "name": "recovery",
+                      "type": "package"
+                    },
+                    {
+                      "children": [
+                        {
+                          "children": [],
+                          "location": "src/main/java/org/apache/zookeeper/book/Client.java:60",
+                          "name": "process",
+                          "static": false,
+                          "type": "function"
+                        }
+                      ],
+                      "location": "src/main/java/org/apache/zookeeper/book/Client.java",
+                      "name": "Client",
+                      "static": false,
+                      "type": "class"
+                    }
+                  ],
+                  "location": "",
+                  "name": "book",
+                  "type": "package"
+                },
+                {
+                  "children": [
+                    {
+                      "children": [
+                        {
+                          "children": [],
+                          "location": "src/main/java/org/apache/zookeeper/client/ConnectStringParser.java:85",
+                          "name": "getServerAddresses",
+                          "static": false,
+                          "type": "function"
+                        },
+                        {
+                          "children": [],
+                          "location": "src/main/java/org/apache/zookeeper/client/ConnectStringParser.java:81",
+                          "name": "getChrootPath",
+                          "static": false,
+                          "type": "function"
+                        }
+                      ],
+                      "location": "src/main/java/org/apache/zookeeper/client/ConnectStringParser.java",
+                      "name": "ConnectStringParser",
+                      "static": false,
+                      "type": "class"
+                    },
+                    {
+                      "children": [
+                        {
+                          "children": [],
+                          "location": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java:91",
+                          "name": "size",
+                          "static": false,
+                          "type": "function"
+                        },
+                        {
+                          "children": [],
+                          "location": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java:95",
+                          "name": "next",
+                          "static": false,
+                          "type": "function"
+                        },
+                        {
+                          "children": [],
+                          "location": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java:114",
+                          "name": "onConnected",
+                          "static": false,
+                          "type": "function"
+                        }
+                      ],
+                      "location": "src/main/java/org/apache/zookeeper/client/StaticHostProvider.java",
+                      "name": "StaticHostProvider",
+                      "static": false,
+                      "type": "class"
+                    },
+                    {
+                      "children": [
+                        {
+                          "children": [],
+                          "location": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java:183",
+                          "name": "getConfigStatus",
+                          "static": false,
+                          "type": "function"
+                        },
+                        {
+                          "children": [],
+                          "location": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java:538",
+                          "name": "clientTunneledAuthenticationInProgress",
+                          "static": false,
+                          "type": "function"
+                        },
+                        {
+                          "children": [],
+                          "location": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java:98",
+                          "name": "getSaslState",
+                          "static": false,
+                          "type": "function"
+                        },
+                        {
+                          "children": [],
+                          "location": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java:434",
+                          "name": "getKeeperState",
+                          "static": false,
+                          "type": "function"
+                        }
+                      ],
+                      "location": "src/main/java/org/apache/zookeeper/client/ZooKeeperSaslClient.java",
+                      "name": "ZooKeeperSaslClient",
+                      "static": false,
+                      "type": "class"
+                    }
+                  ],
+                  "location": "",
+                  "name": "client",
+                  "type": "package"
+                }
+              ],
+              "location": "",
+              "name": "zookeeper",
+              "type": "package"
+            }
+          ],
+          "location": "",
+          "name": "apache",
+          "type": "package"
+        }
+      ],
+      "location": "",
+      "name": "org",
+      "type": "package"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes SCAN-196

This change is needed to remove username/password from git repository URLs.