### PR TITLE
fix: Use database hints to format SQL

### DIFF
--- a/packages/components/src/components/DetailsPanelEvent.vue
+++ b/packages/components/src/components/DetailsPanelEvent.vue
@@ -16,7 +16,11 @@
       </template>
     </v-details-panel-header>
 
-    <v-sql-code v-if="hasSql" :sql="object.sql.sql" />
+    <v-sql-code
+      v-if="hasSql"
+      :sql="object.sql.sql"
+      :database="object.sql.database_type"
+    />
 
     <div class="event-params" v-if="hasParameters">
       <h5>Parameters</h5>

--- a/packages/components/src/components/SqlCode.vue
+++ b/packages/components/src/components/SqlCode.vue
@@ -10,6 +10,18 @@ import hljs from 'highlight.js';
 import sql from 'highlight.js/lib/languages/sql';
 
 hljs.registerLanguage('sql', sql);
+const supportedSqlDialects = new Set([
+  'sql',
+  'mariadb',
+  'mysql',
+  'postgresql',
+  'db2',
+  'plsql',
+  'n1ql',
+  'redshift',
+  'spark',
+  'tsql',
+]);
 
 export default {
   name: 'v-sql-code',
@@ -19,11 +31,33 @@ export default {
       type: String,
       required: true,
     },
+    database: {
+      type: String,
+    },
   },
 
   computed: {
+    sqlDialect() {
+      if (this.database && supportedSqlDialects.has(this.database)) {
+        return this.database;
+      }
+
+      return 'sql';
+    },
+
     formattedSQL() {
-      return hljs.highlight(sqlFormatter(this.sql), {
+      let formattedSql = this.sql;
+
+      try {
+        formattedSql = sqlFormatter(this.sql, {
+          language: this.sqlDialect,
+        });
+      } catch (e) {
+        console.info(`Failed to format the following ${this.sqlDialect} query`);
+        console.info(this.sql);
+      }
+
+      return hljs.highlight(formattedSql, {
         language: 'sql',
         ignoreIllegals: true,
       }).value;

--- a/packages/components/src/components/trace/TraceNodeBodySql.vue
+++ b/packages/components/src/components/trace/TraceNodeBodySql.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="trace-node__body--sql">
-    <v-sql-code :sql="event.sqlQuery" />
+    <v-sql-code :sql="event.sqlQuery" :database="event.sql.database_type" />
   </div>
 </template>
 

--- a/packages/components/tests/unit/DetailsPanelEvent.spec.js
+++ b/packages/components/tests/unit/DetailsPanelEvent.spec.js
@@ -2,10 +2,51 @@ import { mount, createWrapper } from '@vue/test-utils';
 import DetailsPanelEvent from '@/components/DetailsPanelEvent.vue';
 import scenario from '@/stories/data/scenario.json';
 import { store, SET_APPMAP_DATA } from '@/store/vsCode';
+import { Event } from '@appland/models';
 
 store.commit(SET_APPMAP_DATA, scenario);
 
+function sqlEvent(sql, database) {
+  const event = new Event({
+    id: 1,
+    event: 'call',
+    sql_query: {
+      database_type: database,
+      sql,
+    },
+  });
+  event.link(new Event({ id: 2, event: 'return' }));
+  return event;
+}
+
 describe('DetailsPanelEvent.vue', () => {
+  it('formats SQL using the database hints', () => {
+    const wrapper = mount(DetailsPanelEvent, {
+      propsData: {
+        object: sqlEvent(
+          'INSERT INTO "misago_themes_css" ("theme_id", "name", "url", "source_file", "source_hash", "source_needs_building", "build_file", "build_hash", "size", "order", "modified_on") VALUES (279, \'test\', \'https://cdn.example.com/style.css\', \'\', NULL, false, \'\', NULL, 0, 0, \'2021-11-18T04:32:10.691674+00:00\'::timestamptz) RETURNING "misago_themes_css"."id"',
+          'postgresql'
+        ),
+      },
+      store,
+    });
+
+    expect(wrapper.text()).toContain('    "theme_id"');
+  });
+
+  it('renders SQL as-is upon failure to format', () => {
+    const expectedText =
+      'INSERT INTO "misago_themes_css" ("theme_id", "name", "url", "source_file", "source_hash", "source_needs_building", "build_file", "build_hash", "size", "order", "modified_on") VALUES (279, \'test\', \'https://cdn.example.com/style.css\', \'\', NULL, false, \'\', NULL, 0, 0, \'2021-11-18T04:32:10.691674+00:00\'::timestamptz) RETURNING "misago_themes_css"."id"';
+    const wrapper = mount(DetailsPanelEvent, {
+      propsData: {
+        object: sqlEvent(expectedText, 'sql'),
+      },
+      store,
+    });
+
+    expect(wrapper.text()).toContain(expectedText);
+  });
+
   it('HTTP events display response values', () => {
     const event = store.state.appMap.events.find(
       (e) => e.http_server_response && e.http_server_response.mime_type


### PR DESCRIPTION
In some cases, formatting PostgreSQL queries would fail when attempting to format them as generic SQL. We'll now use `database_type` as a hint for how to format the SQL query and if all else fails, we'll render it as-is instead of throwing an exception.

In practice, this error would result in empty query strings:
![image](https://user-images.githubusercontent.com/8737782/162829970-db651769-4625-44d6-9f81-84e4466d8a48.png)

They'll now render as intended:
![image](https://user-images.githubusercontent.com/8737782/162829897-24b21a28-d51b-41c7-b270-ad186c4203b4.png)
