### PR TITLE
fix: View source event

### DIFF
--- a/packages/components/src/components/SourceCodeLink.vue
+++ b/packages/components/src/components/SourceCodeLink.vue
@@ -3,7 +3,7 @@
     <div class="source-code-link__path" data-cy="source-location">
       {{ sourceLocation }}
       <v-external-link-icon
-        v-if="externalLink"
+        v-if="externalUrl"
         data-cy="external-link"
         class="source-code-link__extern-link"
       />
@@ -40,9 +40,9 @@ export default {
 
   data() {
     return {
-      sourceLocation: null,
-      sourceLocationError: null,
-      externalLink: false,
+      sourceLocation: undefined,
+      sourceLocationError: undefined,
+      externalUrl: undefined,
     };
   },
 
@@ -72,7 +72,7 @@ export default {
       return {
         'source-code-link': true,
         'source-code-link--has-external-link':
-          this.$data.sourceLocation && this.$data.externalLink,
+          this.$data.sourceLocation && this.$data.externalUrl,
       };
     },
   },
@@ -83,7 +83,7 @@ export default {
         this.$root.$emit('viewSource', {
           location: this.$data.sourceLocation,
           error: this.$data.sourceLocationError,
-          external: this.$data.externalLink,
+          externalUrl: this.$data.externalUrl,
         });
       }
     },
@@ -91,11 +91,11 @@ export default {
     onResolveLocation(response) {
       this.$data.sourceLocation = response.location;
       this.$data.sourceLocationError = response.error;
-      this.$data.externalLink = response.external;
+      this.$data.externalUrl = response.externalUrl;
     },
 
     requestLocation() {
-      this.sourceLocation = null;
+      this.sourceLocation = undefined;
       if (this.defaultLocation) {
         this.$root.$emit('request-resolve-location', this.defaultLocation);
       }

--- a/packages/components/src/components/SourceCodeLink.vue
+++ b/packages/components/src/components/SourceCodeLink.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="classes" v-if="sourceLocation">
+  <div :class="classes" v-if="sourceLocation" @click="viewSource">
     <div class="source-code-link__path" data-cy="source-location">
       {{ sourceLocation }}
       <v-external-link-icon

--- a/packages/components/src/components/SourceCodeLink.vue
+++ b/packages/components/src/components/SourceCodeLink.vue
@@ -118,15 +118,15 @@ export default {
   display: flex;
   flex-direction: column;
   margin-bottom: 1em;
+  color: $gray4;
+  transition: $transition;
 
   &__path {
     flex-direction: row;
-    border: 1px solid rgba(0, 0, 0, 0.1);
     font-family: monospace;
     border-radius: 8px;
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: #2c2b32;
     padding: 0.6em;
-    color: #e7e7e7;
     display: flex;
     align-items: center;
   }
@@ -139,7 +139,7 @@ export default {
     margin-left: auto;
 
     path {
-      fill: #e7e7e7;
+      fill: #716e85;
     }
   }
 
@@ -163,7 +163,12 @@ export default {
     &:hover {
       cursor: pointer;
       color: #fff;
-      background-color: rgba(127, 127, 127, 0.05);
+      background-color: rgba(255, 255, 255, 0.05);
+      border-radius: 8px;
+
+      path {
+        fill: #fff !important;
+      }
     }
   }
 }

--- a/packages/components/src/stories/VsCodeExtension.stories.js
+++ b/packages/components/src/stories/VsCodeExtension.stories.js
@@ -48,13 +48,7 @@ export const extension = (args, { argTypes }) => ({
       this.$refs.vsCode.loadData(scenario);
     }
 
-    this.$root.$on('request-resolve-location', (location) => {
-      this.$root.$emit('response-resolve-location', {
-        location,
-        error: location.startsWith('/') && 'External source not available',
-        external: !location.startsWith('/'),
-      });
-    });
+    bindResolvePath(this);
   },
 });
 

--- a/packages/components/src/stories/support/resolvePath.js
+++ b/packages/components/src/stories/support/resolvePath.js
@@ -5,7 +5,12 @@ export default function resolvePath(vm) {
     vm.$root.$emit('response-resolve-location', {
       location,
       error: isAbsolute && 'External source not available',
-      external: !isAbsolute,
+      externalUrl:
+        !isAbsolute &&
+        `https://github.com/example-org/example-repo/blob/master/${location.replace(
+          /:(\d+)$/,
+          '#L$1'
+        )}`,
     });
   });
 }


### PR DESCRIPTION
- `viewSource` was not being emitted on click. The only means of emitting the event would be to have access to the element.
- Instead of an `external` boolean flag, the logic responsible for resolving external source code paths can cache an external URL by providing an `externalUrl` property in the response.
- The test case to validate the `viewSource` event was failing yet silently passing.