### PR TITLE
fix: Delay mutation of the trace filter until the view has changed

### DIFF
--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -913,10 +913,6 @@ export default {
         }
       }
 
-      if (state.traceFilter) {
-        this.$refs.traceFilter.setValue(state.traceFilter);
-      }
-
       const { filters } = state;
       if (filters) {
         if ('rootObjects' in filters) {
@@ -946,11 +942,17 @@ export default {
         }
       }
 
-      if (state.currentView) {
-        this.$nextTick(() => {
+      this.$nextTick(() => {
+        if (state.currentView) {
           this.setView(state.currentView);
-        });
-      }
+        }
+
+        if (state.traceFilter) {
+          this.$nextTick(() => {
+            this.$refs.traceFilter.setValue(state.traceFilter);
+          });
+        }
+      });
     },
 
     clearSelection() {

--- a/packages/components/tests/unit/VsCodeExtension.spec.js
+++ b/packages/components/tests/unit/VsCodeExtension.spec.js
@@ -52,6 +52,16 @@ describe('VsCodeExtension.vue', () => {
     expect(wrapper.vm.getState()).toEqual(appState);
   });
 
+  it('changes views and modifies the trace filter after setState', async () => {
+    const appState = '{"currentView":"viewFlow","traceFilter":"id:44"}';
+    wrapper.vm.setState(appState);
+
+    await Vue.nextTick();
+
+    expect(wrapper.vm.isViewingFlow).toBe(true);
+    expect(wrapper.vm.$refs.traceFilter).toBeTruthy();
+  });
+
   it('toggles filters off if selectedObject is outside of the filtered set', async () => {
     wrapper.vm.setState('{"selectedObject":"event:3"}');
     expect(wrapper.vm.selectedObject.toString()).toMatch('Net::HTTP#request');


### PR DESCRIPTION
This is causing issues downstream. We're accessing `traceFilter` which may not yet exist if we're not in the trace view.