### PR TITLE
feat: N+1 queries must have the same common ancestor

### DIFF
--- a/packages/scanner/src/cli/scan/command.ts
+++ b/packages/scanner/src/cli/scan/command.ts
@@ -3,8 +3,6 @@ import { writeFile } from 'fs/promises';
 import { promisify } from 'util';
 import { Arguments, Argv } from 'yargs';
 
-import { FindingStatusListItem } from '@appland/client/dist/src';
-
 import { parseConfigFile } from '../../configuration/configurationProvider';
 import { ValidationError } from '../../errors';
 import { ScanResults } from '../../report/scanResults';

--- a/packages/scanner/test/scanner/nPlusOneQuery.spec.ts
+++ b/packages/scanner/test/scanner/nPlusOneQuery.spec.ts
@@ -17,7 +17,7 @@ it('n+1 query', async () => {
   expect(finding1.relatedEvents!).toHaveLength(30);
   expect(finding1.hash).toEqual(EXPECTED_HASH);
   expect(finding1.message).toEqual(
-    `30 occurrences of SQL: SELECT "active_storage_attachments".* FROM "active_storage_attachments" WHERE "active_storage_attachments"."record_id" = ? AND "active_storage_attachments"."record_type" = ? AND "active_storage_attachments"."name" = ? LIMIT ?`
+    `app_views_microposts__micropost_html_erb.render[120] contains 30 occurrences of SQL: SELECT "active_storage_attachments".* FROM "active_storage_attachments" WHERE "active_storage_attachments"."record_id" = ? AND "active_storage_attachments"."record_type" = ? AND "active_storage_attachments"."name" = ? LIMIT ?`
   );
 });
 


### PR DESCRIPTION
N+1 SQL must have the same ancestor at the same depth.

This differentiates true N+1 queries from cases where there are duplicate queries in a request, but they are not true N+1.
