### PR TITLE
feat: Change filename defaults

### DIFF
--- a/packages/cli/src/fingerprint/canonicalize/classes.js
+++ b/packages/cli/src/fingerprint/canonicalize/classes.js
@@ -3,7 +3,7 @@ const Unique = require('./unique');
 
 class Canonicalize extends Unique {
   functionCall(event) {
-    if (event.isFunction) {
+    if (event.isFunction && event.codeObject.classObject) {
       return event.codeObject.classObject.id;
     }
 

--- a/packages/scanner/bin/upload.rb
+++ b/packages/scanner/bin/upload.rb
@@ -1,4 +1,4 @@
-Command = "node ./built/cli.js upload -v -d ../../land-of-apps/sample_app_6th_ed --report-file ../../land-of-apps/sample_app_6th_ed/appland-findings.json --app scanner-demo/sample_app_6th_ed"
+Command = "node ./built/cli.js upload -v -d ../../land-of-apps/sample_app_6th_ed --report-file ../../land-of-apps/sample_app_6th_ed/appmap-findings.json --app scanner-demo/sample_app_6th_ed"
 Times = (ARGV[0] || 3).to_i
 
 threads = ([Command] * Times).map do |cmd|

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -77,7 +77,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "packageManager": "yarn@3.1.0",
   "pkg": {
     "targets": [
       "node14-linux-x64",

--- a/packages/scanner/src/cli/ci/command.ts
+++ b/packages/scanner/src/cli/ci/command.ts
@@ -8,7 +8,7 @@ import { FindingStatusListItem } from '@appland/client/dist/src';
 import { parseConfigFile } from '../../configuration/configurationProvider';
 import { AbortError, ValidationError } from '../../errors';
 import { ScanResults } from '../../report/scanResults';
-import { verbose } from '../../rules/lib/util';
+import { appmapDirFromConfig, verbose } from '../../rules/lib/util';
 import { newFindings } from '../../findings';
 import findingsReport from '../../report/findingsReport';
 import summaryReport from '../../report/summaryReport';
@@ -55,8 +55,8 @@ export default {
     return args.strict();
   },
   async handler(options: Arguments): Promise<void> {
+    let { appmapDir } = options as unknown as CommandOptions;
     const {
-      appmapDir,
       config,
       verbose: isVerbose,
       fail: failOption,
@@ -76,6 +76,10 @@ export default {
 
     try {
       if (!appmapDir) {
+        appmapDir = await appmapDirFromConfig();
+      }
+      if (!appmapDir) {
+        appmapDir = await appmapDirFromConfig();
         throw new ValidationError('--appmap-dir is required');
       }
 

--- a/packages/scanner/src/cli/scan/command.ts
+++ b/packages/scanner/src/cli/scan/command.ts
@@ -6,13 +6,12 @@ import { Arguments, Argv } from 'yargs';
 import { parseConfigFile } from '../../configuration/configurationProvider';
 import { ValidationError } from '../../errors';
 import { ScanResults } from '../../report/scanResults';
-import { verbose } from '../../rules/lib/util';
+import { appmapDirFromConfig, verbose } from '../../rules/lib/util';
 import { newFindings } from '../../findings';
 import findingsReport from '../../report/findingsReport';
 import summaryReport from '../../report/summaryReport';
 
 import validateFile from '../validateFile';
-
 import CommandOptions from './options';
 import { default as buildScanner } from './scanner';
 import scanArgs from '../scanArgs';
@@ -27,7 +26,7 @@ export default {
     scanArgs(args);
 
     args.option('appmap-file', {
-      describe: 'single file to scan',
+      describe: 'single file to scan, or repeat this option to scan multiple specific files',
       alias: 'f',
     });
     args.option('ide', {
@@ -43,8 +42,8 @@ export default {
     return args.strict();
   },
   async handler(options: Arguments): Promise<void> {
+    let { appmapDir } = options as unknown as CommandOptions;
     const {
-      appmapDir,
       appmapFile,
       config,
       verbose: isVerbose,
@@ -65,6 +64,9 @@ export default {
 
     if (appmapFile && appmapDir) {
       throw new ValidationError('Use --appmap-dir or --appmap-file, but not both');
+    }
+    if (!appmapFile && !appmapDir) {
+      appmapDir = await appmapDirFromConfig();
     }
     if (!appmapFile && !appmapDir) {
       throw new ValidationError('Either --appmap-dir or --appmap-file is required');

--- a/packages/scanner/src/cli/scan/command.ts
+++ b/packages/scanner/src/cli/scan/command.ts
@@ -84,8 +84,8 @@ export default {
       files = await glob(`${appmapDir}/**/*.appmap.json`);
     }
     if (appmapFile) {
-      await validateFile('file', appmapFile);
-      files = [appmapFile];
+      files = typeof appmapFile === 'string' ? [appmapFile] : appmapFile;
+      await Promise.all(files.map(async (file) => validateFile('file', file)));
     }
 
     const configData = await parseConfigFile(config);

--- a/packages/scanner/src/cli/scan/options.ts
+++ b/packages/scanner/src/cli/scan/options.ts
@@ -2,6 +2,6 @@ import ScanOptions from '../scanOptions';
 
 export default interface CommandOptions extends ScanOptions {
   all: boolean;
-  appmapFile?: string;
+  appmapFile?: string | string[];
   ide?: string;
 }

--- a/packages/scanner/src/cli/scanArgs.ts
+++ b/packages/scanner/src/cli/scanArgs.ts
@@ -1,4 +1,3 @@
-import { join } from 'path';
 import { Argv } from 'yargs';
 
 export default function (args: Argv): void {
@@ -9,12 +8,12 @@ export default function (args: Argv): void {
   args.option('config', {
     describe:
       'path to assertions config file (TypeScript or YAML, check docs for configuration format)',
-    default: join(__dirname, '../sampleConfig/default.yml'),
+    default: 'appmap-scanner.yml',
     alias: 'c',
   });
   args.option('report-file', {
     describe: 'file name for findings report',
-    default: 'appland-findings.json',
+    default: 'appmap-findings.json',
   });
   args.option('api-key', {
     describe:

--- a/packages/scanner/src/cli/upload/command.ts
+++ b/packages/scanner/src/cli/upload/command.ts
@@ -24,7 +24,7 @@ export default {
     });
     args.option('report-file', {
       describe: 'file containing the findings report',
-      default: 'appland-findings.json',
+      default: 'appmap-findings.json',
     });
     args.option('app', {
       describe:

--- a/packages/scanner/src/configuration/configurationProvider.ts
+++ b/packages/scanner/src/configuration/configurationProvider.ts
@@ -1,7 +1,7 @@
 import { ValidateFunction } from 'ajv';
 import Ajv from 'ajv';
 import yaml from 'js-yaml';
-import { promises as fs } from 'fs';
+import { exists, promises as fs } from 'fs';
 
 import { Rule, RuleLogic, ScopeName } from '../types';
 import Check from '../check';
@@ -16,6 +16,8 @@ import match_pattern_config_schema from './schema/match-pattern-config.json';
 import Configuration from './types/configuration';
 import CheckConfig from './types/checkConfig';
 import { URL } from 'url';
+import { promisify } from 'util';
+import { join } from 'path';
 
 const ajv = new Ajv();
 ajv.addSchema(match_pattern_config_schema);
@@ -192,6 +194,9 @@ export async function loadConfig(config: Configuration): Promise<Check[]> {
 }
 
 export async function parseConfigFile(configPath: string): Promise<Configuration> {
+  if (!(await promisify(exists)(configPath))) {
+    configPath = join(__dirname, '../sampleConfig/default.yml');
+  }
   console.log(`Using scanner configuration file ${configPath}`);
   const yamlConfig = await fs.readFile(configPath, 'utf-8');
   return yaml.load(yamlConfig, {

--- a/packages/scanner/src/rules/lib/util.ts
+++ b/packages/scanner/src/rules/lib/util.ts
@@ -1,5 +1,19 @@
 import { Event, ReturnValueObject } from '@appland/models';
+import { exists } from 'fs';
+import { readFile } from 'fs/promises';
+import { load } from 'js-yaml';
 import { isAbsolute } from 'path';
+import { promisify } from 'util';
+
+export async function appmapDirFromConfig(): Promise<string | undefined> {
+  const appMapConfigExists = await promisify(exists)('appmap.yml');
+  if (appMapConfigExists) {
+    const appMapConfigData = load((await readFile('appmap.yml')).toString());
+    if (appMapConfigData && typeof appMapConfigData === 'object') {
+      return (appMapConfigData as any)['appmap_dir'] as string;
+    }
+  }
+}
 
 let isVerbose = false;
 function verbose(v: boolean | null = null): boolean {

--- a/packages/scanner/test/cli/scan.spec.ts
+++ b/packages/scanner/test/cli/scan.spec.ts
@@ -7,7 +7,7 @@ import { fixtureAppMapFileName } from '../util';
 import { readFileSync, unlinkSync } from 'fs';
 import { ScanResults } from '../../src/report/scanResults';
 
-const ReportFile = 'appland-findings.json';
+const ReportFile = 'appmap-findings.json';
 const AppId = test.AppId;
 const StandardOptions = {
   appmapFile: fixtureAppMapFileName(


### PR DESCRIPTION
Default scanner config file becomes `appmap-scanner.yml` (was: no default besides the default sampleConfig). If `appmap-scanner.yml` is not available, the default sampleConfig is used, as before.

Default findings file becomes `appmap-findings.json` (was: `appland-findings.json`).

If `appmap.yml` contains *appmap_dir*, it will be used as the default dir for the `scan` and `ci` commands.
