### PR TITLE
fix: Have scanner prune AppMaps before uploading

### DIFF
--- a/packages/scanner/src/cli/upload/pruneAppMap.ts
+++ b/packages/scanner/src/cli/upload/pruneAppMap.ts
@@ -1,0 +1,13 @@
+import { AppMap as AppMapStruct, buildAppMap } from '@appland/models';
+
+const APPMAP_UPLOAD_MAX_SIZE = parseInt(process.env.APPMAP_UPLOAD_MAX_SIZE || '40960') * 1024;
+if (!APPMAP_UPLOAD_MAX_SIZE) {
+  throw Error(`Failed parsing APPMAP_UPLOAD_MAX_SIZE: "${process.env.APPMAP_UPLOAD_MAX_SIZE}"`);
+}
+export function maxAppMapSize(): number {
+  return APPMAP_UPLOAD_MAX_SIZE;
+}
+
+export function pruneAppMap(appMapJson: Record<string, unknown>, maxSize: number): AppMapStruct {
+  return buildAppMap().source(appMapJson).prune(maxSize).normalize().build();
+}


### PR DESCRIPTION
Limit the size of each uploaded AppMap to 40MB.