### PR TITLE
fix: disable "Limit root events to HTTP" filter when searching for hidden root event

### DIFF
--- a/packages/components/src/pages/VsCodeExtension.vue
+++ b/packages/components/src/pages/VsCodeExtension.vue
@@ -644,6 +644,14 @@ export default {
                 const event = this.eventsById[eventId];
                 if (event) {
                   nodes.add(event);
+                } else if (this.filters.declutter.limitRootEvents.on) {
+                  // when event is not present in filtered AppMap, but it's a root event - disable "Limit root events to HTTP" filter
+                  const rootEvents = this.$store.state.appMap.rootEvents();
+                  if (rootEvents.some((e) => e.id === eventId)) {
+                    this.$nextTick(() => {
+                      this.filters.declutter.limitRootEvents.on = false;
+                    });
+                  }
                 }
 
                 break;
@@ -949,6 +957,10 @@ export default {
 
         if (state.traceFilter) {
           this.$nextTick(() => {
+            if (!state.traceFilter.endsWith(' ')) {
+              state.traceFilter += ' ';
+            }
+
             this.$refs.traceFilter.setValue(state.traceFilter);
           });
         }

--- a/packages/components/tests/e2e/specs/vsCodeExtension.spec.js
+++ b/packages/components/tests/e2e/specs/vsCodeExtension.spec.js
@@ -832,6 +832,31 @@ context('VS Code Extension', () => {
       cy.get('.trace-filter__arrows-text').should('be.visible');
     });
 
+    it('disables "Limit root events to HTTP" filter when searching for root event which is hidden', () => {
+      cy.get('.tabs .tab-btn').last().click();
+
+      cy.get('.trace .trace-node').should('have.length', 4);
+
+      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.filters__checkbox input[type="checkbox"]')
+        .first()
+        .should('be.checked');
+      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.trace-node[data-event-id="7"]').should('not.exist');
+
+      cy.get('.trace-filter__input').type('id:7').type('{enter}');
+
+      cy.get('.trace .trace-node').should('have.length', 12);
+      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.filters__checkbox input[type="checkbox"]')
+        .first()
+        .should('not.be.checked');
+      cy.get('.tabs__controls .popper__button').click();
+      cy.get('.trace-node[data-event-id="7"]')
+        .should('exist')
+        .should('have.class', 'highlight');
+    });
+
     it('moves the active event filter selection as expected', () => {
       cy.get('.tabs .tab-btn').last().click();
       cy.get('.trace-filter__input').type('label:json').type('{enter}');


### PR DESCRIPTION
Fixes: https://linear.app/appland/issue/MAP-300/limit-root-events-to-http-filter-is-unselected-when-needed-to-make-an