### PR TITLE
Don't try to release @appland/telemetry

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -48,4 +48,5 @@ module.exports = {
     join(__dirname, 'ci/yarnPublish.js'),
     '@semantic-release/github',
   ],
+  extends: 'semantic-release-monorepo'
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,4 +44,4 @@ jobs:
       if: branch = main
       script: |
         yarn run chromatic --auto-accept-changes \
-        && yarn run semantic-release -e semantic-release-monorepo
+        && yarn run semantic-release

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ci": "yarn run build && yarn run lint && yarn run test",
     "chromatic": "yarn workspaces foreach --exclude root -v run chromatic",
     "watch": "yarn workspaces foreach -t --exclude root -v -p -i run watch",
-    "semantic-release": "yarn workspaces foreach -t --exclude root -v exec semantic-release"
+    "semantic-release": "yarn workspaces foreach -t --exclude '{root,@appland/telemetry}' -v exec semantic-release"
   },
   "devDependencies": {
     "@google/semantic-release-replace-plugin": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
     "ci": "yarn run build && yarn run lint && yarn run test",
     "chromatic": "yarn workspaces foreach --exclude root -v run chromatic",
     "watch": "yarn workspaces foreach -t --exclude root -v -p -i run watch",
-    "semantic-release:prepare": "yarn workspaces foreach -t --exclude root -v exec semantic-release -e semantic-release-monorepo",
-    "semantic-release:publish": "yarn workspaces foreach -t --exclude root -v exec semantic-release -e semantic-release-monorepo",
-    "semantic-release": "yarn run semantic-release:prepare && yarn run semantic-release:publish"
+    "semantic-release": "yarn workspaces foreach -t --exclude root -v exec semantic-release"
   },
   "devDependencies": {
     "@google/semantic-release-replace-plugin": "^1.0.2",


### PR DESCRIPTION
This is to avoid build errors like the one at https://app.travis-ci.com/github/applandinc/appmap-js/jobs/571098857

Also, simplify the semantic-release config a bit.