### PR TITLE
fix: Correct packages/cli bin script location

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@appland/appmap",
   "version": "3.27.0",
   "description": "",
-  "bin": "built/src/cli.js",
+  "bin": "built/cli.js",
   "publishConfig": {
     "access": "public"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -145,7 +145,7 @@ __metadata:
     webpack-cli: ^4.8.0
     yargs: ^17.1.1
   bin:
-    appmap: built/src/cli.js
+    appmap: built/cli.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
I can confirm that the build is now building the cli.js to `built/cli.js`, and that running that script seems to work:

```
➜  cli git:(main) ls built/cli.js
built/cli.js
➜  cli git:(main) node built/cli.js 
cli.js <command>

Commands:
  cli.js diff                   Compute the difference between two mapsets
  cli.js depends [files]        Compute a list of AppMaps that are out of date
  cli.js inspect <code-object>  Search AppMaps for references to a code object
                                (package, function, class, query, route, etc)
                                and print available event info
```