### PR TITLE
fix: Openapi template is packaged correctly and the command works again

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,8 @@
     "access": "public"
   },
   "files": [
-    "built"
+    "built",
+    "resources"
   ],
   "scripts": {
     "lint": "eslint 'src/**/*.js' 'tests/**/*.js'",
@@ -35,7 +36,6 @@
     "@types/tmp": "^0.2.3",
     "@types/w3c-xmlserializer": "^2.0.2",
     "@types/write-file-atomic": "^4.0.0",
-    "copy-webpack-plugin": "^9.0.1",
     "crypto": "^1.0.1",
     "css-loader": "^6.2.0",
     "eslint": "^7.25.0",

--- a/packages/cli/webpack.config.js
+++ b/packages/cli/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const webpack = require('webpack');
-const CopyPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const HtmlInlineScriptPlugin = require('html-inline-script-webpack-plugin');
 
@@ -32,9 +31,6 @@ module.exports = {
     }),
     new webpack.ProvidePlugin({
       process: 'process/browser',
-    }),
-    new CopyPlugin({
-      patterns: [{ from: 'resources', to: 'resources' }],
     }),
   ],
   resolve: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -103,7 +103,6 @@ __metadata:
     cli-progress: ^3.9.0
     conf: ^10.0.2
     console-table-printer: ^2.9.0
-    copy-webpack-plugin: ^9.0.1
     crypto: ^1.0.1
     crypto-js: ^4.0.0
     css-loader: ^6.2.0
@@ -10728,22 +10727,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"copy-webpack-plugin@npm:^9.0.1":
-  version: 9.1.0
-  resolution: "copy-webpack-plugin@npm:9.1.0"
-  dependencies:
-    fast-glob: ^3.2.7
-    glob-parent: ^6.0.1
-    globby: ^11.0.3
-    normalize-path: ^3.0.0
-    schema-utils: ^3.1.1
-    serialize-javascript: ^6.0.0
-  peerDependencies:
-    webpack: ^5.1.0
-  checksum: 06cb4fb6fc99a95ccfd3169115ee57f64953e5b4075900fc8faab98b7e7d3fcd6915b125fdb98c919cfd55e581a8444f5c6b9dbb342cbd60b154d8fb3f79f2b9
-  languageName: node
-  linkType: hard
-
 "core-js-compat@npm:^3.20.2, core-js-compat@npm:^3.21.0, core-js-compat@npm:^3.6.5, core-js-compat@npm:^3.8.1":
   version: 3.21.0
   resolution: "core-js-compat@npm:3.21.0"
@@ -13702,7 +13685,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.7, fast-glob@npm:^3.2.9":
+"fast-glob@npm:^3.2.9":
   version: 3.2.11
   resolution: "fast-glob@npm:3.2.11"
   dependencies:


### PR DESCRIPTION
The compiled files have moved directly to `built` instead of `built/src`, but still referred to `resources` two directories up, ending up pointing at `packages/cli/resources` instead of `packages/cli/built/resources`. The solution was to include the `resources` directory when creating the package. Old code copying `resources` to `built/resources` could now be removed.