### PR TITLE
feat: Add `Open AppMaps` to install guide

### DIFF
--- a/packages/components/src/componentExports.js
+++ b/packages/components/src/componentExports.js
@@ -4,4 +4,4 @@ export { default as VTabs } from '@/components/Tabs.vue';
 export { default as VVsCodeExtension } from '@/pages/VsCodeExtension.vue';
 export { default as VDiff } from '@/pages/Diff.vue';
 export { default as VInstallGuide } from '@/pages/InstallGuide.vue';
-export { default as VOpenAppmaps } from '@/pages/OpenAppMaps.vue';
+export { default as VOpenAppmaps } from '@/pages/install-guide/OpenAppMaps.vue';

--- a/packages/components/src/components/CodeSnippet.vue
+++ b/packages/components/src/components/CodeSnippet.vue
@@ -47,7 +47,10 @@ export default {
   },
   data() {
     return {
-      hasClipboardAPI: false,
+      hasClipboardAPI:
+        navigator &&
+        navigator.clipboard &&
+        typeof navigator.clipboard.writeText === 'function',
     };
   },
   methods: {
@@ -67,16 +70,6 @@ export default {
       const text = this.clipboardText.trim();
       this.$root.$emit('clipboard', text);
     },
-  },
-
-  mounted() {
-    if (
-      navigator &&
-      navigator.clipboard &&
-      typeof navigator.clipboard.writeText === 'function'
-    ) {
-      this.hasClipboardAPI = true;
-    }
   },
 };
 </script>

--- a/packages/components/src/components/mixins/navigation.js
+++ b/packages/components/src/components/mixins/navigation.js
@@ -1,0 +1,9 @@
+// This mixin is intended to be used by components used in a MultiPage layout
+export default {
+  data() {
+    return {
+      first: false,
+      last: false,
+    };
+  },
+};

--- a/packages/components/src/components/quickstart/QuickstartLayout.vue
+++ b/packages/components/src/components/quickstart/QuickstartLayout.vue
@@ -88,6 +88,11 @@ body {
   a {
     color: $color-link;
     text-decoration: none;
+    transition: $transition;
+
+    &:hover {
+      color: $color-foreground-light;
+    }
   }
 
   code {

--- a/packages/components/src/pages/InstallGuide.vue
+++ b/packages/components/src/pages/InstallGuide.vue
@@ -1,18 +1,22 @@
 <template>
-  <v-multi-page ref="page">
+  <v-multi-page ref="page" :disabled-pages="disabledPages">
     <v-project-picker
+      id="project-picker"
       :projects="projects"
       :message-success="messageCopiedCommand"
     />
     <v-record-app-maps
+      id="record-appmaps"
       :editor="editor"
       :project="selectedProject"
-      :complete="selectedProject && selectedProject.appMapsRecorded"
+      :complete="hasRecorded"
     />
+    <v-open-app-maps id="open-appmaps" :app-maps="appMaps" />
     <v-investigate-findings
-      :scanned="selectedProject && selectedProject.analysisPerformed"
-      :num-findings="selectedProject && selectedProject.numFindings"
-      :project-path="selectedProject && selectedProject.path"
+      id="investigate-findings"
+      :scanned="hasFindings"
+      :num-findings="numFindings"
+      :project-path="path"
     />
   </v-multi-page>
 </template>
@@ -21,12 +25,17 @@
 import VMultiPage from '@/pages/MultiPage.vue';
 import VProjectPicker from '@/pages/install-guide/ProjectPicker.vue';
 import VRecordAppMaps from '@/pages/install-guide/RecordAppMaps.vue';
+import VOpenAppMaps from '@/pages/install-guide/OpenAppMaps.vue';
 import VInvestigateFindings from '@/pages/install-guide/InvestigateFindings.vue';
 
 export default {
   name: 'install-guide',
 
   props: {
+    disabledPages: {
+      type: Set,
+      default: () => new Set(),
+    },
     messageCopiedCommand: {
       type: String,
       default: '<b>Copied!</b><br/>Paste this command<br/>into your terminal.',
@@ -48,11 +57,30 @@ export default {
     };
   },
 
+  computed: {
+    hasRecorded() {
+      return this.selectedProject && this.selectedProject.appMapsRecorded;
+    },
+    hasFindings() {
+      return this.selectedProject && this.selectedProject.analysisPerformed;
+    },
+    appMaps() {
+      return (this.selectedProject && this.selectedProject.appMaps) || [];
+    },
+    numFindings() {
+      return this.selectedProject && this.selectedProject.numFindings;
+    },
+    path() {
+      return this.selectedProject && this.selectedProject.path;
+    },
+  },
+
   components: {
     VMultiPage,
     VProjectPicker,
     VRecordAppMaps,
     VInvestigateFindings,
+    VOpenAppMaps,
   },
 
   methods: {
@@ -63,7 +91,6 @@ export default {
 
   mounted() {
     this.$root.$on('select-project', (project) => {
-      console.log('root selecting', project);
       this.selectedProject = project;
     });
   },

--- a/packages/components/src/pages/install-guide/Analyze.vue
+++ b/packages/components/src/pages/install-guide/Analyze.vue
@@ -14,7 +14,7 @@
           </div>
         </article>
       </main>
-      <v-navigation-buttons />
+      <v-navigation-buttons :first="first" :last="last" />
     </section>
   </v-quickstart-layout>
 </template>
@@ -23,6 +23,7 @@
 import VNavigationButtons from '@/components/install-guide/NavigationButtons.vue';
 import VQuickstartLayout from '@/components/quickstart/QuickstartLayout.vue';
 import VCodeSnippet from '@/components/CodeSnippet.vue';
+import Navigation from '@/components/mixins/navigation';
 
 export default {
   name: 'Analyze',
@@ -32,6 +33,8 @@ export default {
     VNavigationButtons,
     VCodeSnippet,
   },
+
+  mixins: [Navigation],
 
   computed: {
     command() {

--- a/packages/components/src/pages/install-guide/Collaboration.vue
+++ b/packages/components/src/pages/install-guide/Collaboration.vue
@@ -4,7 +4,7 @@
       <header>
         <h1>Collaboration</h1>
       </header>
-      <v-navigation-buttons :last="true" />
+      <v-navigation-buttons :first="first" :last="last" />
     </section>
   </v-quickstart-layout>
 </template>
@@ -12,6 +12,7 @@
 <script>
 import VNavigationButtons from '@/components/install-guide/NavigationButtons.vue';
 import VQuickstartLayout from '@/components/quickstart/QuickstartLayout.vue';
+import Navigation from '@/components/mixins/navigation';
 
 export default {
   name: 'Collaboration',
@@ -20,5 +21,7 @@ export default {
     VQuickstartLayout,
     VNavigationButtons,
   },
+
+  mixins: [Navigation],
 };
 </script>

--- a/packages/components/src/pages/install-guide/InvestigateFindings.vue
+++ b/packages/components/src/pages/install-guide/InvestigateFindings.vue
@@ -19,7 +19,7 @@
         </article>
         <article v-else>Waiting on your first analysis results.</article>
       </main>
-      <v-navigation-buttons :last="true" />
+      <v-navigation-buttons :first="first" :last="last" />
     </section>
   </v-quickstart-layout>
 </template>
@@ -28,6 +28,7 @@
 import VNavigationButtons from '@/components/install-guide/NavigationButtons.vue';
 import VQuickstartLayout from '@/components/quickstart/QuickstartLayout.vue';
 import VButton from '@/components/Button.vue';
+import Navigation from '@/components/mixins/navigation';
 
 export default {
   name: 'InvestigateFindings',
@@ -37,6 +38,8 @@ export default {
     VNavigationButtons,
     VButton,
   },
+
+  mixins: [Navigation],
 
   props: {
     scanned: Boolean,

--- a/packages/components/src/pages/install-guide/OpenAppMaps.vue
+++ b/packages/components/src/pages/install-guide/OpenAppMaps.vue
@@ -1,0 +1,85 @@
+<template>
+  <v-quickstart-layout>
+    <section>
+      <header>
+        <h1 class="qs-title">Open AppMaps</h1>
+      </header>
+      <main>
+        <article class="qs-step__block" v-if="appMaps.length">
+          <p>You have AppMaps in this project!</p>
+          <p>
+            Here are some that look interesting that you may want to check
+            out...
+          </p>
+          <table class="qs-appmaps-table">
+            <colgroup>
+              <col width="70%" />
+              <col width="10%" />
+              <col width="10%" />
+              <col width="10%" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th>AppMap</th>
+                <th>Requests</th>
+                <th>SQL</th>
+                <th>Functions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="appMap in appMaps"
+                :key="appMap.path"
+                @click="openAppmap(appMap.path)"
+              >
+                <td>{{ appMap.name }}</td>
+                <td>{{ appMap.requests }}</td>
+                <td>{{ appMap.sqlQueries }}</td>
+                <td>{{ appMap.functions }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </article>
+        <article v-else>
+          No AppMaps have been found in your project. Try
+          <a
+            href="#"
+            @click.prevent="$root.$emit('open-instruction', 'record-appmaps')"
+          >
+            recording AppMaps
+          </a>
+          first.
+        </article>
+      </main>
+    </section>
+    <v-navigation-buttons :first="first" :last="last" />
+  </v-quickstart-layout>
+</template>
+
+<script>
+import VNavigationButtons from '@/components/install-guide/NavigationButtons.vue';
+import VQuickstartLayout from '@/components/quickstart/QuickstartLayout.vue';
+import Navigation from '@/components/mixins/navigation';
+
+export default {
+  name: 'OpenAppMaps',
+
+  components: {
+    VQuickstartLayout,
+    VNavigationButtons,
+  },
+
+  mixins: [Navigation],
+
+  props: {
+    appMaps: Array,
+    default: () => [],
+  },
+
+  methods: {
+    openAppmap(path) {
+      this.$root.$emit('openAppmap', path);
+    },
+  },
+};
+</script>

--- a/packages/components/src/pages/install-guide/ProjectPicker.vue
+++ b/packages/components/src/pages/install-guide/ProjectPicker.vue
@@ -112,9 +112,12 @@ export default {
       return 'good';
     },
     installCommand() {
-      return `npx @appland/appmap install ${
-        this.selectedProject ? this.selectedProject.path : ''
-      }`;
+      return [
+        'npx @appland/appmap install',
+        this.selectedProject && `-d ${this.selectedProject.path}`,
+      ]
+        .filter(Boolean)
+        .join(' ');
     },
   },
 

--- a/packages/components/src/pages/install-guide/ProjectPicker.vue
+++ b/packages/components/src/pages/install-guide/ProjectPicker.vue
@@ -52,7 +52,7 @@
             It looks like the AppMap agent is installed. Continue on to the next
             step.
           </article>
-          <v-navigation-buttons :first="true" />
+          <v-navigation-buttons :first="first" :last="last" />
         </template>
         <template v-if="quality == 'bad'">
           <article>
@@ -78,6 +78,7 @@ import QuickstartLayout from '@/components/quickstart/QuickstartLayout.vue';
 import VCodeSnippet from '@/components/CodeSnippet.vue';
 import VProjectPickerTable from '@/components/install-guide/ProjectPickerTable.vue';
 import VNavigationButtons from '@/components/install-guide/NavigationButtons.vue';
+import Navigation from '@/components/mixins/navigation';
 
 export default {
   name: 'ProjectPicker',
@@ -88,6 +89,8 @@ export default {
     VProjectPickerTable,
     VNavigationButtons,
   },
+
+  mixins: [Navigation],
 
   props: {
     messageSuccess: {

--- a/packages/components/src/pages/install-guide/RecordAppMaps.vue
+++ b/packages/components/src/pages/install-guide/RecordAppMaps.vue
@@ -45,7 +45,7 @@
           </p>
         </article>
       </main>
-      <v-navigation-buttons />
+      <v-navigation-buttons :first="first" :last="last" />
     </section>
   </QuickstartLayout>
 </template>
@@ -54,6 +54,7 @@
 import QuickstartLayout from '@/components/quickstart/QuickstartLayout.vue';
 import VNavigationButtons from '@/components/install-guide/NavigationButtons.vue';
 import VCodeSnippet from '@/components/CodeSnippet.vue';
+import Navigation from '@/components/mixins/navigation';
 
 const documentationUrls = {
   vscode: {
@@ -82,6 +83,8 @@ export default {
     VNavigationButtons,
     VCodeSnippet,
   },
+
+  mixins: [Navigation],
 
   props: {
     clipboardSuccess: {

--- a/packages/components/src/pages/install-guide/RecordAppMaps.vue
+++ b/packages/components/src/pages/install-guide/RecordAppMaps.vue
@@ -15,7 +15,7 @@
             </a>
             <div class="center fit">
               <v-code-snippet
-                clipboard-text="npx @appland/appmap record test"
+                :clipboard-text="command"
                 :message-success="clipboardSuccess"
               />
             </div>
@@ -38,10 +38,6 @@
                 &nbsp;&nbsp;|&nbsp;&nbsp;
               </template>
             </template>
-          </p>
-          <p class="mb20" v-if="completed">
-            Success! Continue on to the next step to learn how to investigate
-            one of the 19 findings identified.
           </p>
         </article>
       </main>
@@ -102,6 +98,14 @@ export default {
   },
 
   computed: {
+    command() {
+      return [
+        'npx @appland/appmap record test',
+        this.project && `-d ${this.project.path}`,
+      ]
+        .filter(Boolean)
+        .join(' ');
+    },
     completed() {
       return this.selectedProject && this.selectedProject.appMapsRecorded;
     },

--- a/packages/components/src/stories/InstallGuide.stories.js
+++ b/packages/components/src/stories/InstallGuide.stories.js
@@ -14,15 +14,15 @@ export default {
         score: 1,
         path: '/home/user/test_app',
         language: {
-          value: 'C#',
+          name: 'C#',
           score: 1,
         },
         testFramework: {
-          value: 'MSTest',
+          name: 'MSTest',
           score: 1,
         },
         webFramework: {
-          value: 'ASP.NET',
+          name: 'ASP.NET',
           score: 1,
         },
       },
@@ -33,15 +33,15 @@ export default {
         agentInstalled: true,
         appMapsRecorded: true,
         language: {
-          value: 'Python',
+          name: 'Python',
           score: 2,
         },
         testFramework: {
-          value: 'PyTest',
+          name: 'PyTest',
           score: 2,
         },
         webFramework: {
-          value: 'Django',
+          name: 'Django',
           score: 2,
         },
       },
@@ -50,15 +50,15 @@ export default {
         score: 3,
         path: '/home/user/my_other_project',
         language: {
-          value: 'Ruby',
+          name: 'Ruby',
           score: 3,
         },
         testFramework: {
-          value: 'RSpec',
+          name: 'RSpec',
           score: 3,
         },
         webFramework: {
-          value: 'Rails',
+          name: 'Rails',
           score: 3,
         },
       },


### PR DESCRIPTION
- [x] Install guide pages can now be disabled and will no longer be able to be navigated to
- [x] Page navigation is now dynamic (back/next button visibility) 
- [x] CLI commands are updated to include the `-d` argument when providing a path
- [x] When no AppMaps have been created, the `Open AppMaps` page will link the user to the record AppMaps page
- [x] Updated link styling  