### PR TITLE
fix: User can configure extended RR URL

### DIFF
--- a/packages/cli/src/cmds/record/action/configureRemainingRequestOptions.ts
+++ b/packages/cli/src/cmds/record/action/configureRemainingRequestOptions.ts
@@ -17,7 +17,11 @@ export default async function configureRemainingRequestOptions() {
   });
 
   if (path !== defaultPath) {
-    await writeConfigOption('remote_recording.path', path);
+    let basePath = path;
+    if (!basePath.endsWith('/')) basePath = [basePath, '/'].join('');
+    if (!basePath.startsWith('/')) basePath = ['/', basePath].join('');
+
+    await writeConfigOption('remote_recording.path', basePath);
   }
 
   const defaultProtocol = await readConfigOption(

--- a/packages/cli/src/cmds/record/action/detectProcessCharacteristics.ts
+++ b/packages/cli/src/cmds/record/action/detectProcessCharacteristics.ts
@@ -56,7 +56,7 @@ export default async function detectProcessCharacteristics(): Promise<boolean> {
     const { looksGood } = await UI.prompt({
       type: 'confirm',
       name: 'looksGood',
-      message: `Does this look like your application?`,
+      message: `Does this look like your application server process?`,
       default: 'y',
     });
     return looksGood;

--- a/packages/cli/src/cmds/record/configuration.ts
+++ b/packages/cli/src/cmds/record/configuration.ts
@@ -61,9 +61,18 @@ export async function readConfig(): Promise<AppMapConfig | undefined> {
   try {
     fileContents = await readFile(AppMapConfigFilePath);
   } catch {
-    return;
+    return {} as AppMapConfig;
   }
-  return load(fileContents.toString()) as AppMapConfig;
+  let config: AppMapConfig;
+  try {
+    config = load(fileContents.toString()) as AppMapConfig;
+  } catch (err) {
+    console.warn(
+      `Error parsing AppMap config file ${AppMapConfigFilePath}: ${err}`
+    );
+    config = {} as AppMapConfig;
+  }
+  return config;
 }
 
 function settingsKey(): string {

--- a/packages/cli/src/cmds/record/prompt/continueWithRequestOptionConfiguration.ts
+++ b/packages/cli/src/cmds/record/prompt/continueWithRequestOptionConfiguration.ts
@@ -16,7 +16,7 @@ export default async function continueWithRequestOptionConfiguration(): Promise<
   UI.progress(
     `If you're sure it's running on that port, we can continue with extra configuration ` +
       `options that may enable me to connect to the agent. ` +
-      `Otherwise you start over by reconfiguring the host and port.`
+      `Otherwise you can start over by reconfiguring the host and port.`
   );
   UI.progress('');
 

--- a/packages/cli/src/cmds/record/prompt/continueWithRequestOptionConfiguration.ts
+++ b/packages/cli/src/cmds/record/prompt/continueWithRequestOptionConfiguration.ts
@@ -1,0 +1,33 @@
+import UI from '../../userInteraction';
+import { requestOptions } from '../configuration';
+
+export enum ConfigurationAction {
+  HostAndPort = 'Reconfigure host and port',
+  RequestOptions = 'Keep the host and port, and configure additional connection options',
+}
+
+export default async function continueWithRequestOptionConfiguration(): Promise<ConfigurationAction> {
+  UI.progress(
+    `I can't find your AppMap server process on port ${
+      (await requestOptions()).port
+    }.`
+  );
+  UI.progress('');
+  UI.progress(
+    `If you're sure it's running on that port, we can continue with extra configuration ` +
+      `options that may enable me to connect to the agent. ` +
+      `Otherwise you start over by reconfiguring the host and port.`
+  );
+  UI.progress('');
+
+  const { configurationAction } = await UI.prompt({
+    type: 'list',
+    choices: [
+      ConfigurationAction.HostAndPort,
+      ConfigurationAction.RequestOptions,
+    ],
+    name: 'configurationAction',
+    message: 'What would you like to do?',
+  });
+  return configurationAction;
+}

--- a/packages/cli/src/cmds/record/state/agentNotAvailable.ts
+++ b/packages/cli/src/cmds/record/state/agentNotAvailable.ts
@@ -2,6 +2,9 @@ import UI from '../../userInteraction';
 import configureHostAndPort from '../action/configureHostAndPort';
 import configureRemainingRequestOptions from '../action/configureRemainingRequestOptions';
 import detectProcessCharacteristics from '../action/detectProcessCharacteristics';
+import continueWithRequestOptionConfiguration, {
+  ConfigurationAction,
+} from '../prompt/continueWithRequestOptionConfiguration';
 import RecordContext from '../recordContext';
 import isAgentAvailable from '../test/isAgentAvailable';
 import { State } from '../types/state';
@@ -17,11 +20,11 @@ export default async function agentNotAvailable(
   recordContext: RecordContext
 ): Promise<State> {
   if (!(await detectProcessCharacteristics())) {
-    return agentProcessNotRunning;
-  }
-
-  if (await isAgentAvailable()) {
-    return initial;
+    if (
+      (await continueWithRequestOptionConfiguration()) ===
+      ConfigurationAction.HostAndPort
+    )
+      return agentProcessNotRunning;
   }
 
   UI.progress(

--- a/packages/cli/src/cmds/record/state/record_remote.ts
+++ b/packages/cli/src/cmds/record/state/record_remote.ts
@@ -5,7 +5,6 @@ import agentIsRecording from './agentIsRecording';
 import agentNotAvailable from './agentNotAvailable';
 import { State } from '../types/state';
 import RecordContext from '../recordContext';
-import { locationString } from '../configuration';
 
 // This is the initial state of remote recording. From here, the connection to the AppMap
 // agent must be configured and verified, and then the recording will be run.


### PR DESCRIPTION
Even if the server process can't be found in the process table, the user can elect to continue with remote recording and specify extended options for the URL connection.