### PR TITLE
Apply eventUpdates when building an AppMap

### DIFF
--- a/packages/models/src/appMapBuilder/index.js
+++ b/packages/models/src/appMapBuilder/index.js
@@ -53,11 +53,16 @@ class AppMapBuilder extends EventSource {
       );
     }
 
-    (this.data.events || [])
-      .map((e) => new Event(e))
-      .forEach((e) => this.sorter.add(e));
+    (this.data.events || []).forEach((e) => {
+      if (this.data.eventUpdates && this.data.eventUpdates[e.id]) {
+        // eslint-disable-next-line no-param-reassign
+        e = this.data.eventUpdates[e.id];
+      }
+      this.sorter.add(new Event(e));
+    });
 
     delete this.data.events;
+    delete this.data.eventUpdates;
 
     return this;
   }

--- a/packages/models/tests/unit/appMapBuilder.spec.js
+++ b/packages/models/tests/unit/appMapBuilder.spec.js
@@ -1,14 +1,25 @@
 import buildAppMap from '../../src/appMapBuilder';
 import scenario from './fixtures/large_scenario.json';
+import updatesScenario from './fixtures/event_updates.json';
 
-test('build', () => {
-  const appMap = buildAppMap().source(scenario).build();
+describe('build', () => {
+  it('creates an AppMap', () => {
+    const appMap = buildAppMap().source(scenario).build();
 
-  const numCodeObjects = appMap.classMap.codeObjects.length;
+    const numCodeObjects = appMap.classMap.codeObjects.length;
 
-  expect(numCodeObjects).toEqual(50);
-  expect(appMap.events.length).toEqual(815);
-  expect(Object.keys(appMap.metadata).length).toEqual(10);
+    expect(numCodeObjects).toEqual(50);
+    expect(appMap.events.length).toEqual(815);
+    expect(Object.keys(appMap.metadata).length).toEqual(10);
+  });
+  it('overrwrites event with update', () => {
+    const appMap = buildAppMap().source(updatesScenario).build();
+    expect(appMap.events[0].extra_attribute).toBeUndefined();
+    expect(appMap.events[0].http_server_request).not.toBeNull();
+    expect(appMap.events[0].http_server_request.normalized_path_info).toEqual(
+      '/owners/:ownerId/pets/:petId/edit'
+    );
+  });
 });
 
 test('build with data source in constructor', () => {

--- a/packages/models/tests/unit/fixtures/event_updates.json
+++ b/packages/models/tests/unit/fixtures/event_updates.json
@@ -1,0 +1,89 @@
+{
+  "events": [
+    {
+      "extra_attribute": "extra",
+      "event": "call",
+      "http_server_request": {
+        "headers": {
+          "host": "localhost:8080",
+          "user-agent": "curl/7.79.1",
+          "accept": "application/json"
+        },
+        "path_info": "/owners/1/pets/1/edit",
+        "protocol": "HTTP/1.1",
+        "request_method": "GET"
+      },
+      "id": 172,
+      "thread_id": 183
+    },
+    {
+      "elapsed": 0.0227362,
+      "event": "return",
+      "http_server_response": {
+        "headers": {
+          "Transfer-Encoding": "chunked",
+          "Content-Language": "en-US",
+          "Date": "Mon, 06 Jun 2022 13:39:36 GMT",
+          "Content-Type": "text/html;charset=UTF-8"
+        },
+        "status": 200
+      },
+      "id": 265,
+      "parent_id": 172,
+      "thread_id": 183
+    }
+  ],
+  "classMap": [],
+  "version": "1.2",
+  "metadata": {
+    "app": "Spring Pet Clinic",
+    "language": {
+      "name": "java",
+      "version": "11.0.15+10",
+      "engine": "OpenJDK 64-Bit Server VM"
+    },
+    "client": {
+      "name": "appmap-java",
+      "url": "https://github.com/appland/appmap-java"
+    },
+    "recorder": {
+      "name": "remote_recording"
+    },
+    "recording": {},
+    "framework": {}
+  },
+  "eventUpdates": {
+    "172": {
+      "event": "call",
+      "http_server_request": {
+        "headers": {
+          "host": "localhost:8080",
+          "user-agent": "curl/7.79.1",
+          "accept": "application/json"
+        },
+        "normalized_path_info": "/owners/:ownerId/pets/:petId/edit",
+        "path_info": "/owners/1/pets/1/edit",
+        "protocol": "HTTP/1.1",
+        "request_method": "GET"
+      },
+      "id": 172,
+      "message": [
+        {
+          "class": "java.lang.String",
+          "kind": "req",
+          "name": "petId",
+          "object_id": 266360068,
+          "value": "1"
+        },
+        {
+          "class": "java.lang.String",
+          "kind": "req",
+          "name": "ownerId",
+          "object_id": 377227594,
+          "value": "1"
+        }
+      ],
+      "thread_id": 183
+    }
+  }
+}

--- a/packages/scanner/src/cli/upload/pruneAppMap.ts
+++ b/packages/scanner/src/cli/upload/pruneAppMap.ts
@@ -1,4 +1,4 @@
-import { AppMap as AppMapStruct, buildAppMap } from '@appland/models';
+import { buildAppMap as buildAppMapModel, AppMapBuilder } from '@appland/models';
 
 const APPMAP_UPLOAD_MAX_SIZE = parseInt(process.env.APPMAP_UPLOAD_MAX_SIZE || '40960') * 1024;
 if (!APPMAP_UPLOAD_MAX_SIZE) {
@@ -8,6 +8,10 @@ export function maxAppMapSize(): number {
   return APPMAP_UPLOAD_MAX_SIZE;
 }
 
-export function pruneAppMap(appMapJson: Record<string, unknown>, maxSize: number): AppMapStruct {
-  return buildAppMap().source(appMapJson).prune(maxSize).normalize().build();
+export function pruneAppMap(builder: AppMapBuilder, maxSize: number): AppMapBuilder {
+  return builder.prune(maxSize);
+}
+
+export function buildAppMap(appMapJson: Record<string, unknown>): AppMapBuilder {
+  return buildAppMapModel().source(appMapJson);
 }

--- a/packages/scanner/test/cli/upload.spec.ts
+++ b/packages/scanner/test/cli/upload.spec.ts
@@ -119,12 +119,15 @@ describe('upload', () => {
     const appId = MapsetData.app_id.toString();
 
     // There are two fixture AppMaps. One is smaller than 500K, the other is larger. So, setting the
-    // max size to 500K will exercise both the pruning and non-pruning paths.
+    // max size to 500K will exercise both the pruning and non-pruning paths. buildAppMap will be
+    // called on both paths, pruneAppMap only on the pruning path.
     sinon.stub(appMapPruning, 'maxAppMapSize').returns(500 * 1024);
+    const buildAppMap = sinon.stub(appMapPruning, 'buildAppMap').callThrough();
     const pruneAppMap = sinon.stub(appMapPruning, 'pruneAppMap').callThrough();
 
     await upload(ScanResults, appId, FixtureDir);
 
+    expect(buildAppMap.callCount).toBe(2);
     expect(pruneAppMap.callCount).toBe(1);
 
     sinon.restore();


### PR DESCRIPTION
Have `AppMapBuilder.source` apply event updates for the events in an AppMap. Change the `upload` subcommand to ensure that always builds an AppMap before sending it to the server.