### PR TITLE
fix: Record command

### DIFF
--- a/packages/cli/src/cmds/record/action/startTestCases.ts
+++ b/packages/cli/src/cmds/record/action/startTestCases.ts
@@ -5,13 +5,19 @@ import { readSetting, writeSetting } from '../configuration';
 export default async function startTestCases() {
   if (Boolean(process.stdout.isTTY)) {
     const defaultMaxTime = await readSetting('test_recording.max_time', 30);
-    const { maxTime } = await UI.prompt({
-      type: 'input',
-      name: 'maxTime',
-      message:
-        'Enter the maximum time (in seconds) to allow test cases to run (-1 to run forever):',
-      default: defaultMaxTime,
-    });
+    let maxTime: number | undefined;
+    do {
+      maxTime = (
+        await UI.prompt({
+          type: 'input',
+          name: 'maxTime',
+          message:
+            'Enter the maximum time (in seconds) to allow test cases to run (-1 to run forever):',
+          default: defaultMaxTime,
+        })
+      )['maxTime'];
+      maxTime = Number(maxTime);
+    } while (Number.isNaN(maxTime));
     if (maxTime !== defaultMaxTime)
       await writeSetting('test_recording.max_time', maxTime);
   }

--- a/packages/cli/src/cmds/record/record.ts
+++ b/packages/cli/src/cmds/record/record.ts
@@ -2,7 +2,6 @@ import { endTime, verbose } from '../../utils';
 import runCommand from '../runCommand';
 import showAppMap from '../open/showAppMap';
 import yargs from 'yargs';
-import { setAppMapConfigFilePath } from './configuration';
 import { State } from './types/state';
 import { FileName } from './types/fileName';
 import { chdir } from 'process';
@@ -10,6 +9,7 @@ import { chdir } from 'process';
 import initial from './state/initial';
 import Telemetry from '../../telemetry';
 import RecordContext from './recordContext';
+import { readConfigOption, setAppMapConfigFilePath } from './configuration';
 
 export const command = 'record [mode]';
 export const describe =
@@ -48,7 +48,9 @@ export async function handler(argv: any) {
 
     if (appmapConfig) setAppMapConfigFilePath(appmapConfig);
 
-    const recordContext = new RecordContext(directory || '.');
+    const appmapDir = (await readConfigOption('appmap_dir', '.')) as string;
+
+    const recordContext = new RecordContext(appmapDir);
     await recordContext.initialize();
 
     const { mode } = argv;

--- a/packages/cli/src/utils.js
+++ b/packages/cli/src/utils.js
@@ -2,8 +2,8 @@
 const { constants: fsConstants, promises: fsp } = require('fs');
 const { queue } = require('async');
 const glob = require('glob');
-const { join: joinPath } = require('path');
 const { buildAppMap } = require('@appland/models');
+const { promisify } = require('util');
 
 const StartTime = Date.now();
 
@@ -88,24 +88,8 @@ async function listAppMapFiles(directory, fn) {
   if (verbose()) {
     console.warn(`Scanning ${directory} for AppMaps`);
   }
-  const files = await fsp.readdir(directory);
   await Promise.all(
-    files
-      .filter((file) => file !== '.' && file !== '..')
-      // eslint-disable-next-line prefer-arrow-callback
-      .map(async function (file) {
-        const path = joinPath(directory, file);
-        const stat = await fsp.stat(path);
-        if (stat.isDirectory()) {
-          await listAppMapFiles(path, fn);
-        }
-
-        if (file.endsWith('.appmap.json')) {
-          await fn(path);
-        }
-
-        return null;
-      })
+    (await promisify(glob)(`${directory}/**/*.appmap.json`)).map(fn)
   );
 }
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [@appland/components-v2.3.1](https://github.com/applandinc/appmap-js/compare/@appland/components-v2.3.0...@appland/components-v2.3.1) (2022-06-02)
+
+
+### Bug Fixes
+
+* "Limit root events to HTTP" filter is now disabled when searching for a hidden root event ([#593](https://github.com/applandinc/appmap-js/issues/593)) ([8962b4a](https://github.com/applandinc/appmap-js/commit/8962b4ad34f7117b159540c69e90bfb90c75fd26))
+
 # [@appland/components-v2.3.0](https://github.com/applandinc/appmap-js/compare/@appland/components-v2.2.0...@appland/components-v2.3.0) (2022-06-02)
 
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appland/components",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Fix two bugs in the record command:

* listAppMapFiles blows up with a `stat` error when the indexer is writing temp files into the index directory
* maxTime may be non-numeric, in which case it's not properly enforced