### PR TITLE
fix: Index no longer panics on missing files

### DIFF
--- a/packages/cli/src/fingerprint/fingerprintQueue.js
+++ b/packages/cli/src/fingerprint/fingerprintQueue.js
@@ -26,6 +26,8 @@ class FingerprintQueue {
               'Tip: consider recording a shorter interaction or removing some classes from appmap.yml.',
             ].join('\n')
           );
+        } else if (error.code === 'ENOENT') {
+          console.warn(`Skipped: ${error.path}\nThe file does not exist.`);
         } else reject(error);
       });
       this.queue.resume();

--- a/packages/cli/src/fingerprint/fingerprinter.js
+++ b/packages/cli/src/fingerprint/fingerprinter.js
@@ -46,7 +46,7 @@ class Fingerprinter {
 
   // eslint-disable-next-line class-methods-use-this
   async fingerprint(appMapFileName) {
-    const appMapCreatedAt = await ctime(appMapFileName);
+    const appMapCreatedAt = await ctime(appMapFileName, false);
     if (!appMapCreatedAt) {
       return;
     }

--- a/packages/cli/src/utils.js
+++ b/packages/cli/src/utils.js
@@ -23,12 +23,13 @@ function baseName(/** @type string */ fileName) {
   return fileName.substring(0, fileName.length - '.appmap.json'.length);
 }
 
-async function ctime(filePath) {
+async function ctime(filePath, suppressExceptions = true) {
   let fileStat;
   try {
     fileStat = await fsp.stat(filePath);
   } catch (e) {
-    return null;
+    if (suppressExceptions) return null;
+    throw e;
   }
   if (!fileStat.isFile()) {
     return null;

--- a/packages/cli/tests/unit/fingerprint/fingerprintQueue.spec.ts
+++ b/packages/cli/tests/unit/fingerprint/fingerprintQueue.spec.ts
@@ -1,0 +1,19 @@
+import FingerprintQueue from '../../../src/fingerprint/fingerprintQueue';
+import sinon from 'sinon';
+
+describe(FingerprintQueue, () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('gracefully handles files which cannot be read', async () => {
+    const logWarn = sinon.stub(console, 'warn');
+
+    const queue = new FingerprintQueue();
+    queue.push('missing-file.appmap.json');
+    await queue.process();
+
+    expect(logWarn.callCount).toBe(1);
+    expect(logWarn.getCall(0).args[0]).toMatch(/The file does not exist/);
+  });
+});


### PR DESCRIPTION
A race condition existed where an AppMap may be deleted during the fingerprinting process. If this were to occur the command would panic and exit, even in `--watch` mode. This commit changes the behavior to instead log a warning and continue.

This is was most often observed in automated testing where files are quickly written and removed.

Resolves MAP-368