### PR TITLE
fix: Project state is reactive

### DIFF
--- a/packages/components/src/pages/InstallGuide.vue
+++ b/packages/components/src/pages/InstallGuide.vue
@@ -51,6 +51,15 @@ export default {
     },
   },
 
+  watch: {
+    projects(newVal) {
+      if (!this.selectedProject || !this.selectedProject.name) return;
+      this.selectedProject = newVal.find(
+        (p) => p.name === this.selectedProject.name
+      );
+    },
+  },
+
   data() {
     return {
       selectedProject: null,


### PR DESCRIPTION
This change fixes a bug which causes the project state not to be reactive. A reference to an existing project would not be updated as project states change.

Fixes MAP-341