### PR TITLE
Project table is styled as a table not as a primary action text field

### DIFF
--- a/packages/components/src/components/Button.vue
+++ b/packages/components/src/components/Button.vue
@@ -59,6 +59,7 @@ export default {
 
   &--primary {
     background-color: $color-highlight;
+    color: $white;
 
     &:hover {
       background-color: rgba(255, 255, 255, 0.9);
@@ -73,9 +74,9 @@ export default {
   }
   &--ghost {
     background-color: inherit;
-    border: 1px solid $color-highlight;
+    border: 1px solid $gray3;
     border-style: solid;
-    color: $color-highlight;
+    color: $gray4;
 
     &:disabled {
       background-color: inherit;

--- a/packages/components/src/components/install-guide/NavigationButtons.vue
+++ b/packages/components/src/components/install-guide/NavigationButtons.vue
@@ -1,14 +1,14 @@
 <template>
   <div :class="classes">
-    <!-- <v-button
+    <v-button
       label="Back"
       kind="ghost"
       @click.native="$root.$emit('page-previous')"
       v-if="!first"
-    /> -->
+    />
     <v-button
       c
-      label="NEXT STEP"
+      label="Next step"
       @click.native="$root.$emit('page-next')"
       v-if="!last"
     />
@@ -49,7 +49,7 @@ export default {
 .buttons {
   display: flex;
   flex-direction: row;
-  justify-content: flex-end;
+  justify-content: space-between;
 
   &--right {
     justify-content: right;

--- a/packages/components/src/components/install-guide/NavigationButtons.vue
+++ b/packages/components/src/components/install-guide/NavigationButtons.vue
@@ -1,14 +1,14 @@
 <template>
   <div :class="classes">
-    <v-button
+    <!-- <v-button
       label="Back"
       kind="ghost"
       @click.native="$root.$emit('page-previous')"
       v-if="!first"
-    />
+    /> -->
     <v-button
       c
-      label="Next"
+      label="NEXT STEP"
       @click.native="$root.$emit('page-next')"
       v-if="!last"
     />
@@ -49,7 +49,7 @@ export default {
 .buttons {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: flex-end;
 
   &--right {
     justify-content: right;

--- a/packages/components/src/components/install-guide/ProjectPickerRow.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRow.vue
@@ -68,7 +68,7 @@ tr {
       text-align: center;
       vertical-align: middle;
       line-height: 1em;
-      margin-right: 1em;
+      margin: 0 1rem 0 0.25rem;
     }
   }
 

--- a/packages/components/src/components/install-guide/ProjectPickerTable.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerTable.vue
@@ -59,7 +59,11 @@ export default {
   border-spacing: 0;
   overflow: hidden;
   margin-top: 1rem;
-
+  thead th {
+    &:first-of-type {
+      padding-left: 3.1rem;
+    }
+  }
   th {
     border-bottom: 1px solid $gray3;
     padding: 1em 2ex;

--- a/packages/components/src/components/install-guide/ProjectPickerTable.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerTable.vue
@@ -58,6 +58,7 @@ export default {
   border-radius: $border-radius;
   border-spacing: 0;
   overflow: hidden;
+  margin-top: 1rem;
 
   th {
     border-bottom: 1px solid $gray3;

--- a/packages/components/src/components/install-guide/ProjectPickerTable.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerTable.vue
@@ -52,14 +52,15 @@ export default {
 
 <style lang="scss" scoped>
 .project-picker-table {
-  border: 2px solid $color-highlight;
+  border: 1px solid $gray3;
   width: 100%;
   text-align: right;
-  border-radius: 8px;
+  border-radius: $border-radius;
   border-spacing: 0;
+  overflow: hidden;
 
   th {
-    border-bottom: 2px solid $color-highlight;
+    border-bottom: 1px solid $gray3;
     padding: 1em 2ex;
 
     &:first-child {

--- a/packages/components/src/pages/install-guide/ProjectPicker.vue
+++ b/packages/components/src/pages/install-guide/ProjectPicker.vue
@@ -7,12 +7,12 @@
       <main>
         <article v-if="projects.length > 0">
           <h2>Select a suitable project</h2>
-          <p>
+          <!-- <p>
             To make sure that your projects are suitable for mapping, we make a
             couple of quick requirement checks on your workspace to help you
             find a project to start AppMapping. Select a suitable project from
             the table below.
-          </p>
+          </p> -->
           <v-project-picker-table
             :projects="projects"
             @select-project="selectProject($event)"
@@ -22,19 +22,19 @@
         <template v-if="quality == 'good' || quality == 'ok'">
           <article>
             <h2>Run AppMap installer</h2>
-            <p class="body-text">
+            <!-- <p class="body-text">
               AppMap agent records executing code. It creates JSON files as you
               execute test cases, run sample programs, or perform interactive
               sessions with your app. This script will guide you through the
               installation process. Run it in the project's environment so it
               can correctly detect runtimes and libraries.
-            </p>
-            <p class="note body-text" v-if="quality == 'ok'">
+            </p> -->
+            <!-- <p class="note body-text" v-if="quality == 'ok'">
               It appears this project might not be a good choice for your first
               AppMap. We recommend you pick another project; proceed at your own
               risk.
-            </p>
-            <p class="body-text">
+            </p> -->
+            <!-- <p class="body-text">
               If you do not have Node.js installed, or would prefer manual
               installion of the AppMap agent visit our
               <a
@@ -42,16 +42,16 @@
                 href="https://appland.com/docs/quickstart/vscode/step-2"
                 >installation documentation.</a
               >
-            </p>
+            </p> -->
             <v-code-snippet
               :clipboard-text="installCommand"
               :message-success="messageSuccess"
             />
           </article>
-          <article v-if="selectedProject.agentInstalled">
+          <!-- <article v-if="selectedProject.agentInstalled">
             It looks like the AppMap agent is installed. Continue on to the next
             step.
-          </article>
+          </article> -->
           <v-navigation-buttons :first="first" :last="last" />
         </template>
         <template v-if="quality == 'bad'">


### PR DESCRIPTION
Closes MAP-377

In the project picker the project table is styled to look like a text input. Remove the primary CTA blue border, align the project name column header with the project name, change check mark to a radio button (currently it is ambiguous what the check means (selected, appropriated, both?).

![image](https://user-images.githubusercontent.com/123787/173420208-c4564f23-2296-40d3-ab44-c745de223034.png)


![image](https://user-images.githubusercontent.com/123787/173420238-3f52d11c-0ea2-4785-bafb-72cd26214b58.png)
