### PR TITLE
fix: Merge succeeds when examples are missing 'items'

### DIFF
--- a/packages/openapi/src/schemaInferrer.ts
+++ b/packages/openapi/src/schemaInferrer.ts
@@ -18,24 +18,29 @@ function mergeProperties(props1?: Properties, props2?: Properties): Properties {
   return result;
 }
 
-
 // Merge type, items and properties of schema objects.
 function mergeType(
   a?: OpenAPIV3.SchemaObject,
   b?: OpenAPIV3.SchemaObject
 ): OpenAPIV3.SchemaObject | undefined {
-  if (!b || !a) return a;
-  if (b.type !== a.type) return a;
+  if (!b) return a;
+  else if (!a) return b;
+  else if (b.type !== a.type) return a;
 
   if (a.type === 'array' && b.type === 'array') {
-    if ('type' in a.items && 'type' in b.items) {
+    if (!b.items) return a;
+    else if (!a.items && b.items) return b;
+    else if ('type' in a.items && 'type' in b.items) {
       const merged = mergeType(a.items, b.items);
       if (merged) return { ...a, items: merged };
     }
   }
 
   if ('properties' in a && 'properties' in b) {
-    return { ...a, properties: mergeProperties(a.properties as Properties, b.properties as Properties) };
+    return {
+      ...a,
+      properties: mergeProperties(a.properties as Properties, b.properties as Properties),
+    };
   }
 
   return a;

--- a/packages/openapi/test/schemaInferrer.spec.ts
+++ b/packages/openapi/test/schemaInferrer.spec.ts
@@ -1,4 +1,4 @@
-import SchemaInferrer from "../src/schemaInferrer";
+import SchemaInferrer from '../src/schemaInferrer';
 
 describe(SchemaInferrer, () => {
   it('returns undefined when no examples', () => {
@@ -9,8 +9,44 @@ describe(SchemaInferrer, () => {
     const inferrer = new SchemaInferrer();
     inferrer.addExample({
       class: 'nilclass',
-      value: 'nil'
+      value: 'nil',
     });
     expect(inferrer.openapi()).toBeUndefined();
+  });
+
+  it(`can merge arrays that don't have items`, () => {
+    const inferrer = new SchemaInferrer();
+    inferrer.addExample({
+      class: 'Hash',
+      value: '{products=>[]}',
+      object_id: 70132031886120,
+      size: 1,
+      properties: [
+        {
+          name: 'products',
+          class: 'Array',
+        },
+      ],
+    });
+    inferrer.addExample({
+      class: 'Hash',
+      value: '{products=>[]}',
+      object_id: 70131584403400,
+      size: 1,
+      properties: [
+        {
+          name: 'products',
+          class: 'Array',
+        },
+      ],
+    });
+    expect(inferrer.openapi()).toEqual({
+      properties: {
+        products: {
+          type: 'array',
+        },
+      },
+      type: 'object',
+    });
   });
 });


### PR DESCRIPTION
Without this code change, the new test case fails as follows:

```
 FAIL  test/schemaInferrer.spec.ts (7.358 s)
  ● SchemaInferrer › can merge arrays that don't have items

    TypeError: Cannot use 'in' operator to search for 'type' in undefined

    > 36 |     if ('type' in a.items && 'type' in b.items) {
         |               ^
      37 |       const merged = mergeType(a.items, b.items);
      38 |       if (merged) return { ...a, items: merged };
      39 |     }

      at mergeType (src/schemaInferrer.ts:36:15)
      at mergeProperties (src/schemaInferrer.ts:14:20)
      at mergeType (src/schemaInferrer.ts:45:19)
          at Array.reduce (<anonymous>)
      at SchemaInferrer.openapi (src/schemaInferrer.ts:63:20)
      at Object.<anonymous> (test/schemaInferrer.spec.ts:43:21)
```

## Reporter

Reported in community Slack (advise this user when the fix is released):

<img width="1097" alt="Screen Shot 2022-06-15 at 11 14 28 AM" src="https://user-images.githubusercontent.com/86395/173863191-31f17311-380b-4a45-acbd-594c1ad2d968.png">

## Tags

Fixes #624