### PR TITLE
Map379 investigate findings content

### DIFF
--- a/packages/cli/smoketest.sh
+++ b/packages/cli/smoketest.sh
@@ -9,6 +9,8 @@ cp -r tests/unit/fixtures/ruby "$TESTDIR"
 
 cd "$TESTDIR"
 echo '{}' > package.json
+echo 'nodeLinker: node-modules' > .yarnrc.yml
+
 yarn add ./package.tgz
 
 

--- a/packages/components/src/components/install-guide/NavigationButtons.vue
+++ b/packages/components/src/components/install-guide/NavigationButtons.vue
@@ -9,6 +9,7 @@
     />
     <v-button
       c
+      kind="ghost"
       label="Next"
       data-cy="next-button"
       @click.native="$root.$emit('page-next')"

--- a/packages/components/src/pages/InstallGuide.vue
+++ b/packages/components/src/pages/InstallGuide.vue
@@ -18,6 +18,7 @@
       :scanned="hasFindings"
       :num-findings="numFindings"
       :project-path="path"
+      :findingsDomainCounts="findingsDomainCounts"
     />
     <v-open-api
       id="openapi"
@@ -99,6 +100,9 @@ export default {
     path() {
       return this.selectedProject && this.selectedProject.path;
     },
+    findingsDomainCounts() {
+      return this.selectedProject && this.selectedProject.findingsDomainCounts;
+    }
   },
 
   components: {

--- a/packages/components/src/pages/InstallGuide.vue
+++ b/packages/components/src/pages/InstallGuide.vue
@@ -102,7 +102,7 @@ export default {
     },
     findingsDomainCounts() {
       return this.selectedProject && this.selectedProject.findingsDomainCounts;
-    }
+    },
   },
 
   components: {

--- a/packages/components/src/pages/install-guide/InvestigateFindings.vue
+++ b/packages/components/src/pages/install-guide/InvestigateFindings.vue
@@ -2,7 +2,7 @@
   <v-quickstart-layout>
     <section>
       <header>
-        <h1>Investigate findings</h1>
+        <h1 data-cy="title">Investigate findings</h1>
       </header>
       <main>
         <article v-if="scanned">
@@ -28,6 +28,7 @@
             <p>
               For details
               <v-button
+                data-cy="investigate-findings-button"
                 label="Open the PROBLEMS tab"
                 @click.native="viewProblems"
               />
@@ -101,7 +102,7 @@ export default {
     numFindings: Number,
     projectPath: String,
     findingsDomainCounts: {
-      type: Array,
+      type: Object,
       default: () => {},
     },
   },

--- a/packages/components/src/pages/install-guide/InvestigateFindings.vue
+++ b/packages/components/src/pages/install-guide/InvestigateFindings.vue
@@ -8,19 +8,71 @@
         <article v-if="scanned">
           <template v-if="numFindings > 0">
             <p>
-              AppMap has identified {{ numFindings }} findings. You can locate
-              more details by opening the problems panel.
+              AppMap has identified
+              <badge
+                v-for="domain in [
+                  'security',
+                  'performance',
+                  'stability',
+                  'maintainability',
+                ]"
+                :key="domain"
+                :data-cy="domain"
+                :class="domain"
+              >
+                {{ findingsDomainCounts[domain] }} {{ domain }}
+              </badge>
+              findings.
             </p>
-            <div class="center">
-              <v-button label="View problems" @click.native="viewProblems" />
-            </div>
+            <br />
+            <p>
+              For details
+              <v-button
+                label="Open the PROBLEMS tab"
+                @click.native="viewProblems"
+              />
+            </p>
           </template>
           <p v-else>
             You're good to go! AppMap scanned your application and found no
             flaws. We'll continue scanning for flaws automatically.
           </p>
         </article>
-        <article v-else>Waiting on your first analysis results.</article>
+        <article v-else>
+          <p>
+            <strong>This project has not been scanned yet.</strong>
+          </p>
+          <p>
+            AppMap will scan your project and report findings automatically if
+            you have:
+          </p>
+
+          <ol>
+            <li>
+              <a
+                href="#"
+                @click.prevent="
+                  $root.$emit('open-instruction', 'project-picker')
+                "
+                >The AppMap Agent installed</a
+              >
+            </li>
+            <li>
+              <a
+                href="#"
+                @click.prevent="
+                  $root.$emit('open-instruction', 'record-appmaps')
+                "
+              >
+                AppMaps in your project</a
+              >
+            </li>
+          </ol>
+          <p>
+            If you need help getting set up, we are happy to help open a support
+            ticket.
+          </p>
+        </article>
       </main>
       <v-navigation-buttons :first="first" :last="last" />
     </section>
@@ -48,6 +100,10 @@ export default {
     scanned: Boolean,
     numFindings: Number,
     projectPath: String,
+    findingsDomainCounts: {
+      type: Array,
+      default: () => {},
+    },
   },
 
   methods: {
@@ -61,5 +117,26 @@ export default {
 h1 {
   margin-block-start: 0;
   font-size: 2em;
+}
+
+.security {
+  color: #ff4141;
+  padding: 5px;
+  font-weight: bold;
+}
+.performance {
+  color: orange;
+  padding: 5px;
+  font-weight: bold;
+}
+.stability {
+  color: yellow;
+  padding: 5px;
+  font-weight: bold;
+}
+.maintainability {
+  color: white;
+  padding: 5px;
+  font-weight: bold;
 }
 </style>

--- a/packages/components/src/stories/InvestigateFindings.stories.js
+++ b/packages/components/src/stories/InvestigateFindings.stories.js
@@ -6,6 +6,10 @@ export default {
   args: {
     scanned: true,
     numFindings: 16,
+    numSecurity: 5,
+    numPerformance: 5,
+    numStability: 5,
+    numMaintainability: 1,
     projectPath: '/home/dev/project',
   },
 };

--- a/packages/components/src/stories/InvestigateFindings.stories.js
+++ b/packages/components/src/stories/InvestigateFindings.stories.js
@@ -3,19 +3,36 @@ import VInvestigateFindings from '@/pages/install-guide/InvestigateFindings.vue'
 export default {
   title: 'Pages/VS Code/Install Guide Pages',
   component: VInvestigateFindings,
-  args: {
-    scanned: true,
-    numFindings: 16,
-    numSecurity: 5,
-    numPerformance: 5,
-    numStability: 5,
-    numMaintainability: 1,
-    projectPath: '/home/dev/project',
-  },
 };
 
-export const investigateFindings = (args, { argTypes }) => ({
+const Template = (args, { argTypes }) => ({
   props: Object.keys(argTypes),
   components: { VInvestigateFindings },
   template: '<v-investigate-findings v-bind="$props" />',
 });
+
+export const InvestigateFindings = Template.bind({});
+InvestigateFindings.args = {
+  scanned: true,
+  projectPath: '/home/dev/project',
+  numFindings: 10,
+  findingsDomainCounts: {
+    security: 1,
+    performance: 3,
+    stability: 4,
+    maintainability: 2,
+  },
+};
+
+export const InvestigateFindingsEmpty = Template.bind({});
+InvestigateFindingsEmpty.args = {
+  scanned: true,
+  projectPath: '/home/dev/project',
+  numFindings: 0,
+  findingsDomainCounts: {
+    security: 0,
+    performance: 0,
+    stability: 0,
+    maintainability: 0,
+  },
+};

--- a/packages/components/tests/e2e/specs/investigateFindings.spec.js
+++ b/packages/components/tests/e2e/specs/investigateFindings.spec.js
@@ -1,0 +1,30 @@
+context('Investigate Findings (10 findings)', () => {
+  beforeEach(() => {
+    cy.visit(
+      'http://localhost:6006/iframe.html?id=pages-vs-code-install-guide-pages--investigate-findings&viewMode=story'
+    );
+  });
+
+  it('displays a title', () => {
+    cy.get('[data-cy="title"]').should('contain.text', 'Investigate findings');
+  });
+
+  it('shows the correct number of each type of finding', () => {
+    cy.get('[data-cy="security"]').should('contain.text', '1');
+    cy.get('[data-cy="performance"]').should('contain.text', '3');
+    cy.get('[data-cy="stability"]').should('contain.text', '4');
+    cy.get('[data-cy="maintainability"]').should('contain.text', '2');
+  });
+
+  it('should display a button to investigate findings', () => {
+    cy.get('[data-cy="investigate-findings-button"]').should('be.visible');
+  });
+
+  it('shows next button', () => {
+    cy.get('[data-cy="next-button"]').should('be.visible');
+  });
+
+  it('shows back button', () => {
+    cy.get('[data-cy="back-button"]').should('be.visible');
+  });
+});

--- a/packages/components/tests/e2e/specs/investigateFindingsEmpty.spec.js
+++ b/packages/components/tests/e2e/specs/investigateFindingsEmpty.spec.js
@@ -1,0 +1,30 @@
+context('Investigate Findings (Empty)', () => {
+  beforeEach(() => {
+    cy.visit(
+      'http://localhost:6006/iframe.html?id=pages-vs-code-install-guide-pages--investigate-findings-empty&viewMode=story'
+    );
+  });
+
+  it('displays a title', () => {
+    cy.get('[data-cy="title"]').should('contain.text', 'Investigate findings');
+  });
+
+  it('does not show different types of findings', () => {
+    cy.get('[data-cy="security"]').should('not.exist');
+    cy.get('[data-cy="performance"]').should('not.exist');
+    cy.get('[data-cy="stability"]').should('not.exist');
+    cy.get('[data-cy="maintainability"]').should('not.exist');
+  });
+
+  it('should not display a button to investigate findings', () => {
+    cy.get('[data-cy="investigate-findings-button"]').should('not.exist');
+  });
+
+  it('shows next button', () => {
+    cy.get('[data-cy="next-button"]').should('be.visible');
+  });
+
+  it('shows back button', () => {
+    cy.get('[data-cy="back-button"]').should('be.visible');
+  });
+});


### PR DESCRIPTION
Closes https://github.com/applandinc/board/issues/28

Updates the Investigate findings message:
OLD
<img width="682" alt="image" src="https://user-images.githubusercontent.com/1229326/174880242-994697f1-b8dd-4dd7-b8c0-4c000b57e55b.png">
NEW
![image](https://user-images.githubusercontent.com/1229326/176968529-eb85901e-da78-4805-9d3a-16a84873c732.png)


Updates the project not scanned message:
OLD:
<img width="563" alt="image" src="https://user-images.githubusercontent.com/1229326/174879576-2a884b5a-22d3-49fd-8ace-82cda83c7875.png">
NEW:
<img width="1197" alt="image" src="https://user-images.githubusercontent.com/1229326/174879466-758e3e2f-4600-45f5-948a-c0ab37fe17ef.png">

Adds content for 'Investigate findings' view.
TODO:
- [x] Update no findings message
- [ ] Add counts for finding categories
- [ ] Add link to Zendesk