### PR TITLE
feat: Hide disabled languages in RecordAppMaps

### DIFF
--- a/packages/components/src/pages/install-guide/RecordAppMaps.vue
+++ b/packages/components/src/pages/install-guide/RecordAppMaps.vue
@@ -95,6 +95,10 @@ export default {
       default: 'vscode',
       validator: (value) => ['vscode', 'jetbrains'].indexOf(value) !== -1,
     },
+    disabledLanguages: {
+      type: Array,
+      default: () => [],
+    },
   },
 
   computed: {
@@ -114,7 +118,13 @@ export default {
       return this.project.language.name;
     },
     editorSpecificUrls() {
-      return documentationUrls[this.editor];
+      const urls = { ...documentationUrls[this.editor] };
+      const disabledLanguages = Object.values(this.disabledLanguages);
+      disabledLanguages.forEach((l) => {
+        delete urls[l];
+      });
+
+      return urls;
     },
     documentationUrl() {
       if (

--- a/packages/components/tests/unit/RecordAppMaps.spec.js
+++ b/packages/components/tests/unit/RecordAppMaps.spec.js
@@ -1,0 +1,21 @@
+import { shallowMount } from '@vue/test-utils';
+import RecordAppMaps from '@/pages/install-guide/RecordAppMaps.vue';
+
+describe('RecordAppMaps.vue', () => {
+  it('shows all languages by default', () => {
+    const wrapper = shallowMount(RecordAppMaps, {
+      propsData: { editor: 'vscode' },
+    });
+    expect(wrapper.text()).toContain('Java');
+    expect(wrapper.text()).toContain('JavaScript');
+    expect(wrapper.text()).toContain('Python');
+    expect(wrapper.text()).toContain('Ruby');
+  });
+
+  it('hides props.disabledLanguages when passed', () => {
+    const wrapper = shallowMount(RecordAppMaps, {
+      propsData: { editor: 'vscode', disabledLanguages: ['Python'] },
+    });
+    expect(wrapper.text()).not.toContain('Python');
+  });
+});


### PR DESCRIPTION
Hide all disabled languages when rendering the RecordAppMaps view.

To support fixing applandinc/board#30.