### PR TITLE
Only load SQL language for highlight.js

### DIFF
--- a/packages/components/src/components/SqlCode.vue
+++ b/packages/components/src/components/SqlCode.vue
@@ -6,7 +6,7 @@
 
 <script>
 import { format as sqlFormatter } from 'sql-formatter';
-import hljs from 'highlight.js';
+import hljs from 'highlight.js/lib/core';
 import sql from 'highlight.js/lib/languages/sql';
 
 hljs.registerLanguage('sql', sql);


### PR DESCRIPTION
Even though we're only using highlight.js for SQL, we used to load support for all languages, which ended up being bundled with in our webpage and VS code extension. Loading only SQL significantly (>1 MiB) improves bundle footprint.

Here's the VS code extension webview bundle before this change:
```
asset app.js 2.98 MiB [emitted] [big] (name: main) 1 related asset
```
And after:
```
asset app.js 1.7 MiB [emitted] [big] (name: main) 1 related asset
```