### PR TITLE
fix: Emit missing data fields to JSON

### DIFF
--- a/packages/cli/tests/unit/inspect.spec.js
+++ b/packages/cli/tests/unit/inspect.spec.js
@@ -43,6 +43,7 @@ describe('Inspect', () => {
             codeObject: {
               name: 'issue',
               type: 'function',
+              labels: ['security'],
               static: true,
               location: 'app/models/api_key.rb:28',
             },

--- a/packages/models/src/classMap.js
+++ b/packages/models/src/classMap.js
@@ -176,7 +176,6 @@ export default class ClassMap {
   }
 
   toJSON() {
-    // Don't write out code objects that were created during runtime
-    return this.roots.filter((obj) => !obj.dynamic);
+    return this.roots;
   }
 }

--- a/packages/models/src/event.js
+++ b/packages/models/src/event.js
@@ -1,4 +1,9 @@
-import { addHiddenProperty, hasProp, identityHashEvent } from './util';
+import {
+  addHiddenProperty,
+  hasProp,
+  identityHashEvent,
+  transformToJSON,
+} from './util';
 import hashEvent from './event/hash';
 
 // This class supercedes `CallTree` and `CallNode`. Events are stored in a flat
@@ -37,6 +42,8 @@ export default class Event {
         data.exceptions = [...obj.$hidden.exceptions];
       }
     }
+
+    this.dataKeys = Object.keys(data);
 
     // Cyclic references shall not be enumerable
     if (data.event === 'call') {
@@ -414,6 +421,10 @@ export default class Event {
     const { definedClass, isStatic, methodId } = this;
     if (!definedClass) return undefined;
     return `${definedClass}${isStatic ? '.' : '#'}${methodId}`;
+  }
+
+  toJSON() {
+    return transformToJSON(this.dataKeys, this);
   }
 
   toString() {

--- a/packages/models/src/util.js
+++ b/packages/models/src/util.js
@@ -425,3 +425,25 @@ export function resolveDifferences(arr1, arr2) {
 export function getRootEvents(eventArray) {
   return eventArray.filter((e) => e.isCall() && !e.parent);
 }
+
+export function transformToJSON(dataKeys, obj) {
+  const emptyLength = (value) => 'length' in value && value.length === 0;
+  const emptySize = (value) => 'size' in value && value.size === 0;
+  const empty = (value) =>
+    value === undefined ||
+    value === null ||
+    (typeof value === 'object' &&
+      [emptyLength, emptySize].find((fn) => fn(value)));
+
+  return dataKeys.reduce((memo, key) => {
+    const value = obj[key];
+    if (empty(value)) {
+      // nop
+    } else if (value.constructor === Set) {
+      memo[key] = [...value];
+    } else {
+      memo[key] = value;
+    }
+    return memo;
+  }, {});
+}


### PR DESCRIPTION
`CodeObject#toJSON` was omitting some fields from the source data. This PR ensures that all the expected fields are emitted. It does the same for `Event` as well, although this problem is not known to be occurring with Event (not to say it wasn't...). 

As a result, printing an AppMap object to JSON will result in a valid and complete AppMap. So, for example, raw AppMap data can be loaded, normalized, and then printed without loss of data.

Fixes https://github.com/applandinc/appmap-js/issues/637
