### PR TITLE
fix typos, and consistent wording & punctuation

### DIFF
--- a/packages/components/src/stories/ProjectPicker.stories.js
+++ b/packages/components/src/stories/ProjectPicker.stories.js
@@ -44,7 +44,7 @@ export default {
         webFramework: {
           name: 'Rails',
           score: 3,
-          text: 'This project uses Rails. AppMap enables recording web requests and remote recording.',
+          text: 'This project uses Rails. AppMap will automatically recognize web requests during recording.',
         },
       },
       {
@@ -54,7 +54,7 @@ export default {
         language: {
           name: 'Ruby',
           score: 3,
-          text: "This project looks like Ruby. It's one of languages supported by AppMap!",
+          text: "This project looks like Ruby. It's one of the languages supported by AppMap.",
         },
         testFramework: {
           name: 'minitest',
@@ -64,7 +64,7 @@ export default {
         webFramework: {
           name: 'Rails',
           score: 3,
-          text: 'This project uses Rails. AppMap enables recording web requests and remote recording.',
+          text: 'This project uses Rails. AppMap will automatically recognize web requests during recording.',
         },
       },
     ],

--- a/packages/components/src/stories/ProjectPicker.stories.js
+++ b/packages/components/src/stories/ProjectPicker.stories.js
@@ -44,7 +44,7 @@ export default {
         webFramework: {
           name: 'Rails',
           score: 3,
-          text: 'This project uses Rails. AppMap will automatically recognize web requests during recording.',
+          text: 'This project uses Rails. AppMap will automatically recognize web requests, SQL queries, and key framework functions during recording.',
         },
       },
       {
@@ -64,7 +64,7 @@ export default {
         webFramework: {
           name: 'Rails',
           score: 3,
-          text: 'This project uses Rails. AppMap will automatically recognize web requests during recording.',
+          text: 'This project uses Rails. AppMap will automatically recognize web requests, SQL queries, and key framework functions during recording.',
         },
       },
     ],


### PR DESCRIPTION
Closes https://github.com/applandinc/board/issues/81

Fix typos, use consistent language for Install steps. 

Existing:
- `This project looks like Ruby. It's one of languages supported by AppMap!`
- `This project uses Rails. AppMap enables recording web requests and remote recording.`

New:
- `This project looks like Ruby. It's one of the languages supported by AppMap.`
- `This project uses Rails. AppMap will automatically recognize web requests, SQL queries, and key framework functions during recording.`

