### PR TITLE
fix: `scan --watch` picks up mtime files which have been deleted and restored

### DIFF
--- a/packages/scanner/test/cli/scan.spec.ts
+++ b/packages/scanner/test/cli/scan.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join, relative } from 'path';
 import nock from 'nock';
 import sinon from 'sinon';
 import fsextra from 'fs-extra';
@@ -148,7 +148,10 @@ describe('scan', () => {
         )
       );
 
-      watcher = new Watcher({ appmapDir: tmpDir, configFile: scanConfigFilePath });
+      watcher = new Watcher({
+        appmapDir: relative(process.cwd(), tmpDir),
+        configFile: scanConfigFilePath,
+      });
       await watcher.watch();
     });
 


### PR DESCRIPTION
`scan --watch` was missing fs events for mtime files if the parent directory was removed and recreated. An automated test now verifies this case, however if you'd like to see it yourself, here are the steps:

1. Run `appmap index --watch` and `scanner scan --watch` together in the same directory
2. Touch an appmap file
3. Delete the new directory containing the indexed data for that appmap
4. Touch the same appmap file

Previously, the indexer would recreate the directory but the scan would fail to receive an event. This has something to do with Chokidar watching a relative path instead of an absolute path. There are a number of reports of similar issues on their GitHub.