### PR TITLE
Fix: update links to docs in project picker

### DIFF
--- a/packages/components/src/components/install-guide/ProjectPickerRequirements.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRequirements.vue
@@ -184,13 +184,17 @@ export default {
     link() {
       let url = 'https://appland.com/docs/install-appmap-agent';
       if (this.language === 'Ruby') {
-        url = 'https://appland.com/docs/reference/appmap-ruby.html';
+        url =
+          'https://appland.com/docs/install-appmap-agent/install-appmap-agent-for-ruby.html';
       } else if (this.language === 'Java') {
-        url = 'https://appland.com/docs/reference/appmap-java.html';
+        url =
+          'https://appland.com/docs/install-appmap-agent/install-appmap-agent-for-java.html';
       } else if (this.language === 'JavaScript') {
-        url = 'https://appland.com/docs/reference/appmap-js.html';
+        url =
+          'https://appland.com/docs/install-appmap-agent/install-appmap-agent-for-python.html';
       } else if (this.language === 'Python') {
-        url = 'https://appland.com/docs/reference/appmap-python.html';
+        url =
+          'https://appland.com/docs/install-appmap-agent/install-appmap-agent-for-javascript.html';
       }
       return url;
     },


### PR DESCRIPTION
Fixes applandinc/board#94

Changed the links in the project picker to go to the Agent Installation section instead of the Reference section, because the user needs to install the AppMap Agent at this stage. 

Also, this better highlights that Python and JS are in beta, because the Open Beta message appears near the top of the page in the Agent Installation section.