### PR TITLE
Fixes: consistent heading sizes for install-guide

### DIFF
--- a/packages/components/src/pages/install-guide/InvestigateFindings.vue
+++ b/packages/components/src/pages/install-guide/InvestigateFindings.vue
@@ -54,3 +54,9 @@ export default {
   },
 };
 </script>
+<style lang="scss" scoped>
+h1 {
+  margin-block-start: 0;
+  font-size: 2em;
+}
+</style>

--- a/packages/components/src/pages/install-guide/RecordAppMaps.vue
+++ b/packages/components/src/pages/install-guide/RecordAppMaps.vue
@@ -140,3 +140,9 @@ export default {
   },
 };
 </script>
+<style lang="scss" scoped>
+h1 {
+  margin-block-start: 0;
+  font-size: 2em;
+}
+</style>


### PR DESCRIPTION
Heading sizes should match the size used in Project-picker (2rem).
Fixes https://github.com/applandinc/board/issues/97

Project-picker (reference):
![Screen Shot 2022-06-30 at 10 11 46 AM](https://user-images.githubusercontent.com/123787/176730954-2e04fa03-9949-4c04-815f-9246e90b8e0d.png)

Before: 
![Screen Shot 2022-06-30 at 10 11 41 AM](https://user-images.githubusercontent.com/123787/176731046-41ee5cdd-f6b7-4501-aa63-effafec180b4.png)
![Screen Shot 2022-06-30 at 10 11 54 AM](https://user-images.githubusercontent.com/123787/176731047-e33e09f1-9511-4286-b73a-c1e4d1b3a63b.png)
![Screen Shot 2022-06-30 at 10 12 16 AM](https://user-images.githubusercontent.com/123787/176731048-01c42835-1511-4849-b773-dab33e33656b.png)

After: 
![Screen Shot 2022-06-30 at 12 37 06 PM](https://user-images.githubusercontent.com/123787/176731221-80b15bf5-b791-426b-8eaf-1c6227084f8f.png)
![Screen Shot 2022-06-30 at 12 36 40 PM](https://user-images.githubusercontent.com/123787/176731268-a59284a1-8e6b-4632-bb0b-114ffac381bf.png)
![Screen Shot 2022-06-30 at 12 36 46 PM](https://user-images.githubusercontent.com/123787/176731272-a13570a1-a210-4844-8b6a-30912b1c18e2.png)
![Screen Shot 2022-06-30 at 12 36 54 PM](https://user-images.githubusercontent.com/123787/176731274-9b5c4c52-5855-438e-a4c7-1480c41d70ad.png)


