### PR TITLE
Fix: switch links for python and js

### DIFF
--- a/packages/components/src/components/install-guide/ProjectPickerRequirements.vue
+++ b/packages/components/src/components/install-guide/ProjectPickerRequirements.vue
@@ -207,10 +207,10 @@ export default {
       } else if (this.language === 'Java') {
         url =
           'https://appland.com/docs/install-appmap-agent/install-appmap-agent-for-java.html';
-      } else if (this.language === 'JavaScript') {
+      } else if (this.language === 'Python') {
         url =
           'https://appland.com/docs/install-appmap-agent/install-appmap-agent-for-python.html';
-      } else if (this.language === 'Python') {
+      } else if (this.language === 'JavaScript') {
         url =
           'https://appland.com/docs/install-appmap-agent/install-appmap-agent-for-javascript.html';
       }


### PR DESCRIPTION
The links to the docs for Python and JavaScript were mistakenly switched. I fixed them so that now they go to the correct page.