### PR TITLE
feat: Add participating events to each finding

### DIFF
--- a/packages/scanner/src/analyzer/recordSecrets.ts
+++ b/packages/scanner/src/analyzer/recordSecrets.ts
@@ -1,7 +1,12 @@
 import { Event } from '@appland/models';
 import { emptyValue, parseValue, verbose } from '../rules/lib/util';
 
-export default function (secrets: Set<string>, e: Event): void {
+export type Secret = {
+  generatorEvent: Event;
+  value: string;
+};
+
+export default function (secrets: Secret[], e: Event): void {
   if (!e.returnValue) {
     return;
   }
@@ -14,6 +19,6 @@ export default function (secrets: Set<string>, e: Event): void {
     if (verbose()) {
       console.warn(`Secret generated: ${secret}`);
     }
-    secrets.add(secret);
+    secrets.push({ generatorEvent: e, value: secret });
   }
 }

--- a/packages/scanner/src/rules/circularDependency.ts
+++ b/packages/scanner/src/rules/circularDependency.ts
@@ -208,13 +208,16 @@ function build(options: Options): RuleLogic {
       .map((cycle) => searchForCycle(cycle, ignoredPackages))
       .filter((path) => path)
       .map((path) => {
+        path = path!;
         return {
-          event: path![0],
+          event: path[0],
           message: [
             'Cycle in package dependency graph',
-            path!.map((event) => event.codeObject.packageOf).join(' -> '),
+            path.map((event) => event.codeObject.packageOf).join(' -> '),
           ].join(': '),
-          relatedEvents: path!,
+          participatingEvents: Object.fromEntries(
+            path.map((event, index) => [`path[${index}]`, event])
+          ),
         } as MatchResult;
       });
   }

--- a/packages/scanner/src/rules/illegalPackageDependency.ts
+++ b/packages/scanner/src/rules/illegalPackageDependency.ts
@@ -20,12 +20,15 @@ function build(options: Options): RuleLogic {
   }
 
   function matcher(e: Event): MatchResult[] | undefined {
+    const parent = e.parent;
+    if (!parent) return;
+
     const packageNamesStr = options.callerPackages
       .map((config) => config.equal || config.include || config.match)
       .map(String)
       .join(' or ');
 
-    const parentPackage = e.parent!.codeObject.packageOf;
+    const parentPackage = parent.codeObject.packageOf;
     if (
       !(
         e.codeObject.packageOf === parentPackage ||
@@ -36,7 +39,7 @@ function build(options: Options): RuleLogic {
         {
           event: e,
           message: `Code object ${e.codeObject.id} was invoked from ${parentPackage}, not from ${packageNamesStr}`,
-          relatedEvents: [e.parent!],
+          participatingEvents: { parent },
         },
       ];
     }

--- a/packages/scanner/src/rules/jobNotCancelled.ts
+++ b/packages/scanner/src/rules/jobNotCancelled.ts
@@ -20,15 +20,11 @@ function build(): RuleLogic {
     const missing = creationEvents.length - cancellationEvents.length;
     if (missing === 0) return;
 
-    const result: MatchResult = {
-      event: event,
-      message: `${missing} jobs created but not cancelled in this rolled back transaction`,
-      // if there's a mismatch and there are cancellations we can't tell
-      // for sure which creations they match, so return everything
-      relatedEvents: [...creationEvents, ...cancellationEvents],
-    };
-
-    return [result];
+    return creationEvents.map((jobCreationEvent) => ({
+      event: jobCreationEvent,
+      message: `Job created by ${jobCreationEvent.codeObject.prettyName} was not cancelled when the enclosing transaction rolled back`,
+      participatingEvents: { beginTransaction: event },
+    }));
   }
 
   return {

--- a/packages/scanner/src/rules/nPlusOneQuery.ts
+++ b/packages/scanner/src/rules/nPlusOneQuery.ts
@@ -50,6 +50,7 @@ function build(options: Options): RuleLogic {
               groupMessage: sql,
               occurranceCount: occurranceCount,
               relatedEvents: events.map((e) => e.event),
+              participatingEvents: { commonAncestor: ancestor },
             };
           };
 

--- a/packages/scanner/src/rules/queryFromInvalidPackage.ts
+++ b/packages/scanner/src/rules/queryFromInvalidPackage.ts
@@ -21,14 +21,15 @@ function build(options: Options): RuleLogic {
   const allowedQueries = buildFilters(options.allowedQueries);
 
   function matcher(e: Event): MatchResult[] | undefined {
-    if (!allowedPackages.some((filter) => filter(e.parent!.codeObject.packageOf))) {
+    if (!e.parent) return;
+
+    const parent = e.parent;
+    if (!allowedPackages.some((filter) => filter(parent.codeObject.packageOf))) {
       return [
         {
           event: e,
-          message: `${e.codeObject.id} is invoked from illegal package ${
-            e.parent!.codeObject.packageOf
-          }`,
-          relatedEvents: [e.parent!],
+          message: `${e.codeObject.id} is invoked from illegal package ${parent.codeObject.packageOf}`,
+          participatingEvents: { parent: parent },
         },
       ];
     }

--- a/packages/scanner/src/types.d.ts
+++ b/packages/scanner/src/types.d.ts
@@ -62,6 +62,7 @@ export interface MatchResult {
   level?: Level;
   event: Event;
   message: string;
+  participatingEvents?: Record<string, Event>;
   groupMessage?: string;
   occurranceCount?: number;
   relatedEvents?: Event[];
@@ -112,6 +113,8 @@ interface Finding {
   occurranceCount?: number;
   relatedEvents?: Event[];
   impactDomain?: ImpactDomain;
+  // Map of events by functional role name; for example, logEvent, secret, scope, etc.
+  participatingEvents?: Record<string, Event>;
 }
 
 interface RuleLogic {

--- a/packages/scanner/test/scanner/jobNotCancelled.spec.ts
+++ b/packages/scanner/test/scanner/jobNotCancelled.spec.ts
@@ -8,5 +8,16 @@ test('job not cancelled', async () => {
     check,
     'Microposts_interface_micropost_interface_with_job.appmap.json'
   );
-  expect(findings).toHaveLength(1);
+  expect(findings).toHaveLength(6);
+  expect(findings.map((f) => f.event.id)).toEqual([1077, 1093, 1909, 1925, 2049, 2977]);
+
+  const finding = findings[0];
+  expect(finding.ruleId).toEqual('job-not-cancelled');
+  expect(finding.message).toEqual(
+    `Job created by ActiveJob::Enqueuing::ClassMethods.perform_later was not cancelled when the enclosing transaction rolled back`
+  );
+  expect(Object.keys(finding.participatingEvents!)).toEqual(['beginTransaction']);
+  expect(Object.values(finding.participatingEvents!).map((e) => e.sqlQuery)).toEqual([
+    'begin transaction',
+  ]);
 });

--- a/packages/scanner/test/scanner/nPlusOneQuery.spec.ts
+++ b/packages/scanner/test/scanner/nPlusOneQuery.spec.ts
@@ -14,11 +14,12 @@ it('n+1 query', async () => {
   const finding1 = findings[0];
   expect(finding1.ruleId).toEqual('n-plus-one-query');
   expect(finding1.event.id).toEqual(133);
-  expect(finding1.relatedEvents!).toHaveLength(30);
+  expect(finding1.relatedEvents!).toHaveLength(31);
   expect(finding1.hash).toEqual(EXPECTED_HASH);
   expect(finding1.message).toEqual(
     `app_views_microposts__micropost_html_erb.render[120] contains 30 occurrences of SQL: SELECT "active_storage_attachments".* FROM "active_storage_attachments" WHERE "active_storage_attachments"."record_id" = ? AND "active_storage_attachments"."record_type" = ? AND "active_storage_attachments"."name" = ? LIMIT ?`
   );
+  expect(Object.keys(finding1.participatingEvents!)).toEqual(['commonAncestor']);
 });
 
 it('takes into account only unique hashes of related events when computing hash', async () => {
@@ -29,6 +30,6 @@ it('takes into account only unique hashes of related events when computing hash'
   );
 
   const finding1 = findings[0];
-  expect(finding1.relatedEvents!).toHaveLength(29);
+  expect(finding1.relatedEvents!).toHaveLength(30);
   expect(finding1.hash).toEqual(EXPECTED_HASH);
 });

--- a/packages/scanner/test/scanner/secretInLog.spec.ts
+++ b/packages/scanner/test/scanner/secretInLog.spec.ts
@@ -14,7 +14,7 @@ it('secret in log file', async () => {
     expect(finding.ruleId).toEqual('secret-in-log');
     expect(finding.event.id).toEqual(695);
     expect(finding.message).toEqual(
-      `Log event contains secret data: [2f025606-b6f0-4b64-8595-006f32f4d5d0] Started GET "/account_activations/-6SputWUtvALn3TLCfoYvA/edit`
+      `Log message contains secret User.new_token "-6SputWUtvALn3TLCfoYvA": [2f025606-b6f0-4b64-8595-006f32f4d5d0] Started GET "/account_activations/-6SputWUtvALn3TLCfoYvA/edit`
     );
   }
   {
@@ -36,7 +36,7 @@ it('parses out multiple secrets from function return value', async () => {
     expect(finding.ruleId).toEqual('secret-in-log');
     expect(finding.event.id).toEqual(221);
     expect(finding.message).toEqual(
-      `Log event contains secret data: REQUESTING PAGE: GET /users/confirmation?confirmation_token=axzHC1xW-8DtxWrstsJd with {} and HTTP he (...9 more characters)`
+      `Log message contains secret Devise.friendly_token "axzHC1xW-8DtxWrstsJd": REQUESTING PAGE: GET /users/confirmation?confirmation_token=axzHC1xW-8DtxWrstsJd with {} and HTTP he (...9 more characters)`
     );
   }
 });


### PR DESCRIPTION
Currently, each finding has an `event` which is the event that the finding "occurs on". But in actuality, many findings have more than one event that are instrumental to the finding. For example, for the secrets in log finding, the two participating events are the event that generated the secret, and the event that wrote to the log.

This PR adds `participatingEvents` which should include all events that are instrumental to the finding. In a subsequent PR, the finding hash will be composed from all these events.

Participating events is distinct from `relatedEvents` in that `relatedEvents` may add context to the finding, but do not directly participate in it and should not be included in the finding hash.