### PR TITLE
feat: Stable properties

### DIFF
--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -34,6 +34,7 @@
     "@rollup/plugin-commonjs": "^18.0.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-replace": "^2.4.2",
+    "@types/crypto-js": "^4.1.1",
     "cross-env": "^7.0.3",
     "eslint": "^7.25.0",
     "eslint-config-airbnb-base": "^14.2.1",

--- a/packages/models/src/event/hash.js
+++ b/packages/models/src/event/hash.js
@@ -5,7 +5,7 @@ import parse from '../sql/parse';
 // returns a JSON of SQL query AST
 // with all literals replaced by variables
 // and all variable names removed
-function abstractSqlAstJSON(query, databaseType) {
+export function abstractSqlAstJSON(query, databaseType) {
   const ast = parse(query);
   if (!ast) return normalize(query, databaseType);
 
@@ -25,6 +25,7 @@ function abstractSqlAstJSON(query, databaseType) {
 // For SQL queries, it's a JSON of abstract query AST.
 // For HTTP queries, it's the method plus normalized path info.
 // For function calls it's the qualified function id.
+// TODO: This can be removed/deprecated when the current hash algorithm is removed.
 function callEventToString(event) {
   const { sqlQuery, route } = event;
   if (sqlQuery) return abstractSqlAstJSON(sqlQuery, event.sql.database_type);

--- a/packages/models/types/index.d.ts
+++ b/packages/models/types/index.d.ts
@@ -170,6 +170,7 @@ declare module '@appland/models' {
     readonly nextSibling?: Event | null;
     readonly callEvent: Event;
     readonly returnEvent: Event;
+    readonly stableProperties: Record<string, string | number>;
     readonly hash: string;
     readonly identityHash: string;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,6 +289,7 @@ __metadata:
     "@rollup/plugin-commonjs": ^18.0.0
     "@rollup/plugin-node-resolve": ^11.2.1
     "@rollup/plugin-replace": ^2.4.2
+    "@types/crypto-js": ^4.1.1
     cross-env: ^7.0.3
     crypto-js: ^4.0.0
     eslint: ^7.25.0
@@ -5402,6 +5403,13 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: fe81351470f2d3165e8b12ce33542eef89ea893e36dd62e8f7d72566dfb7e448376ae962f9f3ea888547ce8b55a40020ca0e01d637fab5d99567673084542641
+  languageName: node
+  linkType: hard
+
+"@types/crypto-js@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@types/crypto-js@npm:4.1.1"
+  checksum: ea3d6a67b69f88baeb6af96004395903d2367a41bd5cd86306da23a44dd96589749495da50974a9b01bb5163c500764c8a33706831eade036bddae016417e3ea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add `Event.stableProperties`, which is meant to be a better foundation for an improved event/finding hash.

The concept is that all the data that identifies this event and is stable across AppMaps should be present here, and can be included in the hash. Volatile information such as SQL literals, parameter and return value literals, ... should be omitted.