### PR TITLE
feat: Handle -d working directory arg

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -31,6 +31,8 @@ const RecordCommand = require('./cmds/record/record');
 import InstallCommand from './cmds/agentInstaller/install-agent';
 import StatusCommand from './cmds/agentInstaller/status';
 import PruneCommand from './cmds/prune/prune';
+import { handleWorkingDirectory } from './lib/handleWorkingDirectory';
+import { locateAppMapDir } from './lib/locateAppMapDir';
 
 class DiffCommand {
   public appMapNames: any;
@@ -183,6 +185,11 @@ yargs(process.argv.slice(2))
     'diff',
     'Compute the difference between two mapsets',
     (args) => {
+      args.option('directory', {
+        describe: 'program working directory',
+        type: 'string',
+        alias: 'd',
+      });
       args.option('name', {
         describe: 'indicate a specific AppMap to of compare',
       });
@@ -200,6 +207,7 @@ yargs(process.argv.slice(2))
     },
     async function (argv) {
       verbose(argv.verbose);
+      handleWorkingDirectory(argv.directory);
 
       let baseDir;
       let workingDir;
@@ -550,6 +558,11 @@ yargs(process.argv.slice(2))
     'inventory',
     'Generate canonical lists of the application code object inventory',
     (args) => {
+      args.option('directory', {
+        describe: 'program working directory',
+        type: 'string',
+        alias: 'd',
+      });
       args.option('appmap-dir', {
         describe: 'directory to recursively inspect for AppMaps',
         default: 'tmp/appmap',
@@ -558,6 +571,8 @@ yargs(process.argv.slice(2))
     },
     async (argv) => {
       verbose(argv.verbose);
+      handleWorkingDirectory(argv.directory);
+      const appmapDir = await locateAppMapDir(argv.appmapDir);
 
       await new FingerprintDirectoryCommand(argv.appmapDir).execute();
 

--- a/packages/cli/src/lib/appmapDirFromConfig.ts
+++ b/packages/cli/src/lib/appmapDirFromConfig.ts
@@ -1,0 +1,23 @@
+import assert from 'assert';
+import { exists } from 'fs';
+import { readFile } from 'fs/promises';
+import { load } from 'js-yaml';
+import { promisify } from 'util';
+
+export async function appmapDirFromConfig(): Promise<string | undefined> {
+  const appMapConfigExists = await promisify(exists)('appmap.yml');
+  if (appMapConfigExists) {
+    const appMapConfigData = load((await readFile('appmap.yml')).toString());
+    if (appMapConfigData && typeof appMapConfigData === 'object') {
+      const configData: { appmap_dir?: string } = appMapConfigData;
+      return configData['appmap_dir'];
+    }
+  }
+}
+
+export function assertAppMapDir(appmapDir: string) {
+  assert(
+    appmapDir,
+    'appmapDir must be provided as a command option, or available in appmap.yml'
+  );
+}

--- a/packages/cli/src/lib/handleWorkingDirectory.ts
+++ b/packages/cli/src/lib/handleWorkingDirectory.ts
@@ -1,0 +1,5 @@
+const { promises: fsp } = require('fs');
+
+export function handleWorkingDirectory(directory?: string) {
+  if (directory) process.chdir(directory);
+}

--- a/packages/cli/src/lib/locateAppMapDir.ts
+++ b/packages/cli/src/lib/locateAppMapDir.ts
@@ -1,0 +1,12 @@
+import { appmapDirFromConfig } from './appmapDirFromConfig';
+
+export async function locateAppMapDir(appmapDir?: string): Promise<string> {
+  if (appmapDir) return appmapDir;
+
+  const result = await appmapDirFromConfig();
+  if (!result)
+    throw new Error(
+      'appmapDir must be provided as a command option, or available in appmap.yml'
+    );
+  return result;
+}


### PR DESCRIPTION
`diff` and `inventory` commands will use default `appmap_dir` from *appmap.yml*.

This is a start on adding this behavior to all the commands.