### PR TITLE
fix: Return proper result for job-not-cancelled

### DIFF
--- a/packages/scanner/src/rules/jobNotCancelled.ts
+++ b/packages/scanner/src/rules/jobNotCancelled.ts
@@ -20,11 +20,15 @@ function build(): RuleLogic {
     const missing = creationEvents.length - cancellationEvents.length;
     if (missing === 0) return;
 
-    return creationEvents.map((jobCreationEvent) => ({
-      event: jobCreationEvent,
-      message: `Job created by ${jobCreationEvent.codeObject.prettyName} was not cancelled when the enclosing transaction rolled back`,
-      participatingEvents: { beginTransaction: event },
-    }));
+    const result: MatchResult = {
+      event: event,
+      message: `${missing} jobs are scheduled but not cancelled in a rolled back transaction`,
+      // if there's a mismatch and there are cancellations we can't tell
+      // for sure which creations they match, so return everything
+      relatedEvents: [...creationEvents, ...cancellationEvents],
+    };
+
+    return [result];
   }
 
   return {

--- a/packages/scanner/test/scanner/jobNotCancelled.spec.ts
+++ b/packages/scanner/test/scanner/jobNotCancelled.spec.ts
@@ -8,16 +8,12 @@ test('job not cancelled', async () => {
     check,
     'Microposts_interface_micropost_interface_with_job.appmap.json'
   );
-  expect(findings).toHaveLength(6);
-  expect(findings.map((f) => f.event.id)).toEqual([1077, 1093, 1909, 1925, 2049, 2977]);
+  expect(findings).toHaveLength(1);
+  expect(findings.map((f) => f.event.id)).toEqual([131]);
 
   const finding = findings[0];
   expect(finding.ruleId).toEqual('job-not-cancelled');
   expect(finding.message).toEqual(
-    `Job created by ActiveJob::Enqueuing::ClassMethods.perform_later was not cancelled when the enclosing transaction rolled back`
+    `6 jobs are scheduled but not cancelled in a rolled back transaction`
   );
-  expect(Object.keys(finding.participatingEvents!)).toEqual(['beginTransaction']);
-  expect(Object.values(finding.participatingEvents!).map((e) => e.sqlQuery)).toEqual([
-    'begin transaction',
-  ]);
 });


### PR DESCRIPTION
It's not correct to return a separate finding for each creation event.