### PR TITLE
feat: Hash participating events and partial stack

### DIFF
--- a/packages/models/src/event.js
+++ b/packages/models/src/event.js
@@ -470,8 +470,11 @@ export default class Event {
     ) =>
       Object.assign(baseProperties, {
         route: this.route,
-        status_code: this.httpServerResponse.status,
-        content_type: this.responseContentType,
+        status_code:
+          this.httpServerResponse?.status ||
+          this.httpServerResponse?.status_code ||
+          this.httpClientResponse?.status ||
+          this.httpServerResponse?.status_code,
       });
 
     let properties;
@@ -493,12 +496,9 @@ export default class Event {
     } else {
       properties = {
         event_type: 'function',
-        name: this.qualifiedMethodId,
-        parameterNames: (this.parameters || [])
-          .map((p) => p.name)
-          .filter(Boolean)
-          .join(','),
-        returnValueType: this.returnValue?.class,
+        id: this.qualifiedMethodId,
+        raises_exception:
+          this.returnEvent.exceptions && this.returnEvent.exceptions.length > 0,
       };
     }
     return normalizeProperties(properties);

--- a/packages/models/tests/unit/event.spec.js
+++ b/packages/models/tests/unit/event.spec.js
@@ -37,9 +37,8 @@ describe('Event', () => {
     it('stableProperties', () => {
       verifyJSON(getTasksEvent.stableProperties, {
         event_type: 'function',
-        name: 'org/apache/zookeeper/book/recovery/RecoveredAssignments#getTasks',
-        parameterNames: '',
-        returnValueType: '',
+        raises_exception: false,
+        id: 'org/apache/zookeeper/book/recovery/RecoveredAssignments#getTasks',
       });
     });
 
@@ -168,7 +167,6 @@ describe('Event', () => {
       });
       it('stableProperties', () => {
         verifyJSON(event.stableProperties, {
-          content_type: '',
           event_type: 'http_server_request',
           route: 'GET /admin',
           status_code: 302,
@@ -183,7 +181,6 @@ describe('Event', () => {
         returnEventData.http_server_response.headers = headers;
         eventWithContentType.link(new Event(returnEventData));
         verifyJSON(eventWithContentType.stableProperties, {
-          content_type: 'text/plain',
           event_type: 'http_server_request',
           route: 'GET /admin',
           status_code: 302,

--- a/packages/scanner/src/algorithms/hash/hashV1.ts
+++ b/packages/scanner/src/algorithms/hash/hashV1.ts
@@ -1,0 +1,33 @@
+import { Event } from '@appland/models';
+import { createHash } from 'crypto';
+
+export default class HashV1 {
+  private hash;
+
+  constructor(ruleId: string, findingEvent: Event, relatedEvents: Event[]) {
+    this.hash = createHash('sha256');
+    this.hash.update(findingEvent.hash);
+    this.hash.update(ruleId);
+
+    // Admittedly odd, this implementation matches the original hash algorithm.
+    const uniqueEvents = new Set<number>();
+    const hashEvents: Event[] = [];
+    relatedEvents.unshift(findingEvent);
+    relatedEvents.forEach((event) => {
+      if (uniqueEvents.has(event.id)) return;
+
+      uniqueEvents.add(event.id);
+      hashEvents.push(event);
+    });
+
+    // This part where the hashes go into a Set, and there is some kind of ordering as a side-
+    // effect, is particularly weird.
+    new Set(hashEvents.map((e) => e.hash)).forEach((eventHash) => {
+      this.hash.update(eventHash);
+    });
+  }
+
+  digest(): string {
+    return this.hash.digest('hex');
+  }
+}

--- a/packages/scanner/src/algorithms/hash/hashV2.ts
+++ b/packages/scanner/src/algorithms/hash/hashV2.ts
@@ -1,0 +1,84 @@
+import { Event } from '@appland/models';
+import { createHash } from 'crypto';
+import { verbose } from '../../rules/lib/util';
+
+function hashEvent(entries: string[], prefix: string, event: Event): void {
+  Object.keys(event.stableProperties)
+    .sort()
+    .forEach((key) =>
+      entries.push([[prefix, key].join('.'), event.stableProperties[key].toString()].join('='))
+    );
+}
+
+/**
+ * Builds a hash (digest) of a finding. The digest is constructed by first building a canonical
+ * string of the finding, of the form:
+ *
+ * ```
+ * [
+ *   rule=<rule-id>
+ *   commandEvent.<property1>=value1
+ *   ...
+ *   commandEvent.<propertyN>=valueN
+ *   findingEvent.<property1>=value1
+ *   ...
+ *   findingEvent.<propertyN>=valueN
+ *   participatingEvent.<eventName1>=value1
+ *   ...
+ *   participatingEvent.<eventName1>=valueN
+ *   ...
+ *   participatingEvent.<eventNameN>=value1
+ *   ...
+ *   participatingEvent.<eventNameN>=valueN
+ * ]
+ * ```
+ *
+ * Participating events are sorted by the event name. Properties of each event are sorted by
+ * the property name. Event properties are provided by `Event#stableProperties`.
+ *
+ * If the finding event has no @command, @job, or http_server_request ancestor, then the
+ * commandEvent is replaced by rootEvent: the root ancestor of the finding event.
+ */
+export default class HashV2 {
+  private hashEntries: string[] = [];
+  private hash;
+
+  constructor(ruleId: string, findingEvent: Event, participatingEvents: Record<string, Event>) {
+    this.hash = createHash('sha256');
+
+    const hashEntries = [['rule', ruleId].join('=')];
+    this.hashEntries = hashEntries;
+
+    const commandEvent = (event: Event): { command?: Event; root?: Event } => {
+      if (event.labels.has('command') || event.labels.has('job') || event.httpServerRequest)
+        return { command: event };
+
+      if (!event.parent) return { root: event };
+
+      return commandEvent(event.parent);
+    };
+
+    const command = commandEvent(findingEvent);
+    if (command.command) hashEvent(hashEntries, 'commandEvent', command.command);
+    else if (command.root) hashEvent(hashEntries, 'rootEvent', command.root);
+    hashEvent(hashEntries, 'findingEvent', findingEvent);
+    Object.keys(participatingEvents)
+      .sort()
+      .forEach((key) => {
+        const event = participatingEvents[key];
+        hashEvent(hashEntries, `participatingEvent.${key}`, event);
+      });
+
+    if (verbose()) console.log(hashEntries);
+
+    hashEntries.forEach((e) => this.hash.update(e));
+  }
+
+  get canonicalString(): string {
+    return this.hashEntries.join('\n');
+  }
+
+  digest(): string {
+    return this.hash.digest('hex');
+  }
+}

--- a/packages/scanner/src/report/summaryReport.ts
+++ b/packages/scanner/src/report/summaryReport.ts
@@ -11,8 +11,8 @@ function summarizeFindings(findings: Finding[]): FindingSummary[] {
     let findingSummary = memo[finding.ruleId];
     if (findingSummary) {
       findingSummary.findingTotal += 1;
-      if (!findingSummary.findingHashes.has(finding.hash)) {
-        findingSummary.findingHashes.add(finding.hash);
+      if (!findingSummary.findingHashes.has(finding.hash_v2)) {
+        findingSummary.findingHashes.add(finding.hash_v2);
         findingSummary.messages.push(finding.message);
       }
     } else {
@@ -20,7 +20,7 @@ function summarizeFindings(findings: Finding[]): FindingSummary[] {
         ruleId: finding.ruleId,
         ruleTitle: finding.ruleTitle,
         findingTotal: 1,
-        findingHashes: new Set([finding.hash]),
+        findingHashes: new Set([finding.hash_v2]),
         messages: [finding.message],
       } as FindingSummary;
       memo[finding.ruleId] = findingSummary;
@@ -37,7 +37,7 @@ export default function (summary: ScanResults, colorize: boolean): void {
   const matchedStr = `${summary.summary.numFindings} ${pluralize(
     'finding',
     summary.summary.numFindings
-  )} (${new Set(summary.findings.map((finding) => finding.hash)).size} unique)`;
+  )} (${new Set(summary.findings.map((finding) => finding.hash_v2)).size} unique)`;
   const colouredMatchedStr = colorize ? chalk.stderr.magenta(matchedStr) : matchedStr;
 
   console.log();

--- a/packages/scanner/src/rules/authzBeforeAuthn.ts
+++ b/packages/scanner/src/rules/authzBeforeAuthn.ts
@@ -28,6 +28,7 @@ function build(): RuleLogic {
             {
               event: event.event,
               message: `${event.event} provides authorization, but the request is not authenticated`,
+              participatingEvents: { request: rootEvent },
             },
           ];
         }

--- a/packages/scanner/src/rules/lib/isCommand.ts
+++ b/packages/scanner/src/rules/lib/isCommand.ts
@@ -1,0 +1,11 @@
+import { Event } from '@appland/models';
+
+export default function isCommand(event: Event): string | undefined {
+  let label: string | undefined;
+
+  if (event.labels.has('command')) label = 'command';
+  else if (event.labels.has('job')) label = 'job';
+  else if (event.httpServerRequest) label = 'request';
+
+  return label;
+}

--- a/packages/scanner/src/rules/logoutWithoutSessionReset.ts
+++ b/packages/scanner/src/rules/logoutWithoutSessionReset.ts
@@ -25,6 +25,7 @@ function build(): RuleLogic {
             {
               event: event.event,
               message: `${event.event} logs out the user, but the HTTP session is not cleared`,
+              participatingEvents: { request: rootEvent },
             },
           ];
         }

--- a/packages/scanner/src/rules/missingContentType.ts
+++ b/packages/scanner/src/rules/missingContentType.ts
@@ -7,8 +7,10 @@ const isRedirect = (status: number) => [301, 302, 303, 307, 308].includes(status
 const hasContent = (status: number) => status !== 204;
 
 function build(): RuleLogic {
-  function matcher(e: Event) {
-    return rpcRequestForEvent(e)!.responseContentType === undefined;
+  function matcher(event: Event) {
+    if (rpcRequestForEvent(event)!.responseContentType === undefined) {
+      return `Missing HTTP content type in response to request: ${event.route}`;
+    }
   }
   function where(e: Event) {
     return (

--- a/packages/scanner/src/rules/nPlusOneQuery.ts
+++ b/packages/scanner/src/rules/nPlusOneQuery.ts
@@ -40,6 +40,7 @@ function build(options: Options): RuleLogic {
         const ancestor = eventsById[parseInt(ancestorId)]!;
         const occurranceCount = events.length;
         if (occurranceCount > options.warningLimit) {
+          const participatingEvents = { commonAncestor: ancestor } as Record<string, Event>;
           const buildMatchResult = (level: Level): MatchResult => {
             return {
               level: level,
@@ -50,7 +51,7 @@ function build(options: Options): RuleLogic {
               groupMessage: sql,
               occurranceCount: occurranceCount,
               relatedEvents: events.map((e) => e.event),
-              participatingEvents: { commonAncestor: ancestor },
+              participatingEvents,
             };
           };
 

--- a/packages/scanner/src/rules/secretInLog.ts
+++ b/packages/scanner/src/rules/secretInLog.ts
@@ -52,7 +52,7 @@ const findInLog = (event: Event): MatchResult[] | undefined => {
   if (matches.length > 0) {
     return matches.map((match) => {
       const { pattern, value } = match;
-      const participatingEvents: Record<string, Event> = { logEvent: event };
+      const participatingEvents: Record<string, Event> = {};
       if (match.generatorEvent) {
         participatingEvents.generatorEvent = match.generatorEvent;
       }

--- a/packages/scanner/src/rules/updateInGetRequest.ts
+++ b/packages/scanner/src/rules/updateInGetRequest.ts
@@ -2,6 +2,7 @@ import { Event } from '@appland/models';
 import { Rule, RuleLogic } from '../types';
 import { toRegExpArray } from './lib/util';
 import parseRuleDescription from './lib/parseRuleDescription';
+import assert from 'assert';
 
 class Options {
   private _queryInclude: RegExp[];
@@ -53,7 +54,14 @@ function build(options: Options = new Options()): RuleLogic {
         !e.ancestors().some((ancestor) => ancestor.codeObject.labels.has(Audit)) &&
         hasHttpServerRequest()
       ) {
-        return `Data update performed in ${httpServerRequest!.route}: ${e.sqlQuery}`;
+        assert(httpServerRequest, 'HTTP server request is undefined');
+        return [
+          {
+            event: e,
+            message: `Data update performed in HTTP request ${httpServerRequest.route}: ${e.sqlQuery}`,
+            participatingEvents: { request: httpServerRequest },
+          },
+        ];
       }
     },
     where: (e) => !!e.sqlQuery,

--- a/packages/scanner/src/types.d.ts
+++ b/packages/scanner/src/types.d.ts
@@ -105,7 +105,8 @@ interface Finding {
   ruleId: string;
   ruleTitle: string;
   event: Event;
-  hash: string;
+  hash: string; // Deprecated for local use. Still used to integrate local results with the server.
+  hash_v2: string;
   scope: Event;
   message: string;
   stack: string[];

--- a/packages/scanner/test/scanner/authzBeforeAuthn.spec.ts
+++ b/packages/scanner/test/scanner/authzBeforeAuthn.spec.ts
@@ -36,16 +36,27 @@ it('authorization before (or without) authentication', async () => {
   );
   expect(findings).toHaveLength(1);
   const finding = findings[0];
+  console.log(finding.stack);
   const findingEvent = appMap.events.find((e) => e.id === finding.event.id)!;
   expect(
     new HashV2(finding.ruleId, findingEvent, finding.participatingEvents || {}).canonicalString
-  ).toEqual(`rule=authz-before-authn
-commandEvent.event_type=http_server_request
-commandEvent.route=DELETE /microposts/{id}
-commandEvent.status_code=302
+  ).toEqual(`algorithmVersion=2
+rule=authz-before-authn
 findingEvent.event_type=function
 findingEvent.id=MicropostsController#correct_user
-findingEvent.raises_exception=false`);
+findingEvent.raises_exception=false
+participatingEvent.request.event_type=http_server_request
+participatingEvent.request.route=DELETE /microposts/{id}
+participatingEvent.request.status_code=302
+stack[1].event_type=function
+stack[1].id=ActiveSupport::Callbacks::CallbackSequence#invoke_before
+stack[1].raises_exception=false
+stack[2].event_type=function
+stack[2].id=ActionController::Instrumentation#process_action
+stack[2].raises_exception=false
+stack[3].event_type=http_server_request
+stack[3].route=DELETE /microposts/{id}
+stack[3].status_code=302`);
   expect(finding.ruleId).toEqual('authz-before-authn');
   expect(finding.event.id).toEqual(16);
   expect(finding.message).toEqual(

--- a/packages/scanner/test/scanner/authzBeforeAuthn.spec.ts
+++ b/packages/scanner/test/scanner/authzBeforeAuthn.spec.ts
@@ -1,11 +1,12 @@
 import { buildAppMap } from '@appland/models';
 import { readFile } from 'fs/promises';
+import HashV2 from '../../src/algorithms/hash/hashV2';
 import Check from '../../src/check';
 import rule from '../../src/rules/authzBeforeAuthn';
 import { fixtureAppMapFileName, scan } from '../util';
 
 it('authentication precedes authentication', async () => {
-  const findings = await scan(new Check(rule), 'Test_authz_before_authn.appmap.json');
+  const { findings } = await scan(new Check(rule), 'Test_authz_before_authn.appmap.json');
   expect(findings).toHaveLength(0);
 });
 
@@ -28,13 +29,23 @@ it('authorization before (or without) authentication', async () => {
   baseAppMap.classMap.forEach(removeAuthenticationLabel);
   const appMapData = buildAppMap(JSON.stringify(baseAppMap)).normalize().build();
 
-  const findings = await scan(
+  const { appMap, findings } = await scan(
     new Check(rule),
     fixtureAppMapFileName('Test_authz_before_authn.appmap.json'),
     appMapData
   );
   expect(findings).toHaveLength(1);
   const finding = findings[0];
+  const findingEvent = appMap.events.find((e) => e.id === finding.event.id)!;
+  expect(
+    new HashV2(finding.ruleId, findingEvent, finding.participatingEvents || {}).canonicalString
+  ).toEqual(`rule=authz-before-authn
+commandEvent.event_type=http_server_request
+commandEvent.route=DELETE /microposts/{id}
+commandEvent.status_code=302
+findingEvent.event_type=function
+findingEvent.id=MicropostsController#correct_user
+findingEvent.raises_exception=false`);
   expect(finding.ruleId).toEqual('authz-before-authn');
   expect(finding.event.id).toEqual(16);
   expect(finding.message).toEqual(

--- a/packages/scanner/test/scanner/circularDependency.spec.ts
+++ b/packages/scanner/test/scanner/circularDependency.spec.ts
@@ -11,7 +11,7 @@ describe('circular dependency', () => {
   it('finds a cycle', async () => {
     const check = new Check(rule);
     check.options.depth = 3;
-    const findings = await detectCycles(check);
+    const { findings } = await detectCycles(check);
     expect(findings).toHaveLength(1);
     const finding = findings[0];
 
@@ -26,7 +26,7 @@ describe('circular dependency', () => {
   it('ignores cycles below the threshold length', async () => {
     const check = new Check(rule);
     check.options.depth = 4;
-    const findings = await detectCycles(check);
+    const { findings } = await detectCycles(check);
     expect(findings).toHaveLength(0);
   });
 });

--- a/packages/scanner/test/scanner/deserializationOfUntrustedData.spec.ts
+++ b/packages/scanner/test/scanner/deserializationOfUntrustedData.spec.ts
@@ -14,13 +14,20 @@ test('unsafe deserialization', async () => {
   const findingEvent = appMap.events.find((e) => e.id === finding.event.id)!;
   expect(
     new HashV2(finding.ruleId, findingEvent, finding.participatingEvents || {}).canonicalString
-  ).toEqual(`rule=deserialization-of-untrusted-data
-commandEvent.event_type=http_server_request
-commandEvent.route=GET /users
-commandEvent.status_code=200
+  ).toEqual(`algorithmVersion=2
+rule=deserialization-of-untrusted-data
 findingEvent.event_type=function
 findingEvent.id=ActiveSupport::MarshalWithAutoloading.load
-findingEvent.raises_exception=false`);
+findingEvent.raises_exception=false
+stack[1].event_type=function
+stack[1].id=app_views_users_index_html_erb.render
+stack[1].raises_exception=false
+stack[2].event_type=function
+stack[2].id=ActionController::Instrumentation#process_action
+stack[2].raises_exception=false
+stack[3].event_type=http_server_request
+stack[3].route=GET /users
+stack[3].status_code=200`);
   expect(finding.event.codeObject.fqid).toEqual(
     'function:marshal/ActiveSupport::MarshalWithAutoloading.load'
   );

--- a/packages/scanner/test/scanner/deserializationOfUntrustedData.spec.ts
+++ b/packages/scanner/test/scanner/deserializationOfUntrustedData.spec.ts
@@ -1,15 +1,27 @@
+import HashV2 from '../../src/algorithms/hash/hashV2';
 import Check from '../../src/check';
 import rule from '../../src/rules/deserializationOfUntrustedData';
 import { scan } from '../util';
 
 test('unsafe deserialization', async () => {
   const check = new Check(rule);
-  const findings = await scan(
+  const { appMap, findings } = await scan(
     check,
     'appmaps/deserializationOfUntrustedData/Users_index_index_as_non-admin.appmap.json'
   );
   expect(findings).toHaveLength(1);
-  expect(findings[0].event.codeObject.fqid).toEqual(
+  const finding = findings[0];
+  const findingEvent = appMap.events.find((e) => e.id === finding.event.id)!;
+  expect(
+    new HashV2(finding.ruleId, findingEvent, finding.participatingEvents || {}).canonicalString
+  ).toEqual(`rule=deserialization-of-untrusted-data
+commandEvent.event_type=http_server_request
+commandEvent.route=GET /users
+commandEvent.status_code=200
+findingEvent.event_type=function
+findingEvent.id=ActiveSupport::MarshalWithAutoloading.load
+findingEvent.raises_exception=false`);
+  expect(finding.event.codeObject.fqid).toEqual(
     'function:marshal/ActiveSupport::MarshalWithAutoloading.load'
   );
 });

--- a/packages/scanner/test/scanner/http500.spec.ts
+++ b/packages/scanner/test/scanner/http500.spec.ts
@@ -4,7 +4,7 @@ import { scan } from '../util';
 
 it('http500', async () => {
   const rule = await loadRule('http500');
-  const findings = await scan(
+  const { findings } = await scan(
     new Check(rule),
     'Password_resets_password_resets_with_http500.appmap.json'
   );

--- a/packages/scanner/test/scanner/illegalPackageDependency.spec.ts
+++ b/packages/scanner/test/scanner/illegalPackageDependency.spec.ts
@@ -1,3 +1,4 @@
+import HashV2 from '../../src/algorithms/hash/hashV2';
 import Check from '../../src/check';
 import MatchPatternConfig from '../../src/configuration/types/matchPatternConfig';
 import rule from '../../src/rules/illegalPackageDependency';
@@ -10,12 +11,25 @@ it('illegal package dependency', async () => {
     { equal: 'lib/command' } as MatchPatternConfig,
   ];
   options.calleePackages = [{ equal: 'lib/pkg_b' } as MatchPatternConfig];
-  const findings = await scan(
+  const { appMap, findings } = await scan(
     new Check(rule, options),
     'ruby/circular_dependency/tmp/appmap/minitest/Command_command.appmap.json'
   );
   expect(findings).toHaveLength(1);
   const finding = findings[0];
+  const findingEvent = appMap.events.find((e) => e.id === finding.event.id)!;
+  expect(
+    new HashV2(finding.ruleId, findingEvent, finding.participatingEvents || {}).canonicalString
+  ).toEqual(`rule=illegal-package-dependency
+rootEvent.event_type=function
+rootEvent.id=Command.invoke
+rootEvent.raises_exception=false
+findingEvent.event_type=function
+findingEvent.id=PkgA::A#cycle
+findingEvent.raises_exception=false
+participatingEvent.parent.event_type=function
+participatingEvent.parent.id=PkgB::B#invoke
+participatingEvent.parent.raises_exception=false`);
   expect(finding.ruleId).toEqual('illegal-package-dependency');
   expect(finding.event.id).toEqual(4);
   expect(finding.message).toEqual(

--- a/packages/scanner/test/scanner/illegalPackageDependency.spec.ts
+++ b/packages/scanner/test/scanner/illegalPackageDependency.spec.ts
@@ -20,16 +20,23 @@ it('illegal package dependency', async () => {
   const findingEvent = appMap.events.find((e) => e.id === finding.event.id)!;
   expect(
     new HashV2(finding.ruleId, findingEvent, finding.participatingEvents || {}).canonicalString
-  ).toEqual(`rule=illegal-package-dependency
-rootEvent.event_type=function
-rootEvent.id=Command.invoke
-rootEvent.raises_exception=false
+  ).toEqual(`algorithmVersion=2
+rule=illegal-package-dependency
 findingEvent.event_type=function
 findingEvent.id=PkgA::A#cycle
 findingEvent.raises_exception=false
 participatingEvent.parent.event_type=function
 participatingEvent.parent.id=PkgB::B#invoke
-participatingEvent.parent.raises_exception=false`);
+participatingEvent.parent.raises_exception=false
+stack[1].event_type=function
+stack[1].id=PkgB::B#invoke
+stack[1].raises_exception=false
+stack[2].event_type=function
+stack[2].id=PkgA::A#invoke
+stack[2].raises_exception=false
+stack[3].event_type=function
+stack[3].id=Command.invoke
+stack[3].raises_exception=false`);
   expect(finding.ruleId).toEqual('illegal-package-dependency');
   expect(finding.event.id).toEqual(4);
   expect(finding.message).toEqual(

--- a/packages/scanner/test/scanner/impactDomainInFindings.spec.ts
+++ b/packages/scanner/test/scanner/impactDomainInFindings.spec.ts
@@ -9,7 +9,7 @@ import { loadRule } from '../../src/configuration/configurationProvider';
 
 it('Security Domain in Deserialization of untrusted data', async () => {
   const check = new Check(untrustedDeserializationRule);
-  const findings = await scan(
+  const { findings } = await scan(
     check,
     'appmaps/deserializationOfUntrustedData/Users_index_index_as_non-admin.appmap.json'
   );
@@ -19,14 +19,20 @@ it('Security Domain in Deserialization of untrusted data', async () => {
 
 it('Stability Domain in http500', async () => {
   const check = new Check(await loadRule('http-500'));
-  const findings = await scan(check, 'Password_resets_password_resets_with_http500.appmap.json');
+  const { findings } = await scan(
+    check,
+    'Password_resets_password_resets_with_http500.appmap.json'
+  );
   expect(findings).toHaveLength(1);
   expect(findings[0].impactDomain).toEqual('Stability');
 });
 
 it('Performance Domain in n+1 Query', async () => {
   const check = new Check(nPlusOneRule);
-  const findings = await scan(check, 'Users_profile_profile_display_while_anonyomus.appmap.json');
+  const { findings } = await scan(
+    check,
+    'Users_profile_profile_display_while_anonyomus.appmap.json'
+  );
   expect(findings).toHaveLength(1);
   expect(findings[0].impactDomain).toEqual('Performance');
 });
@@ -35,7 +41,7 @@ it('Maintainability Domain in Too Many Updates', async () => {
   const options = new rule.Options();
   options.warningLimit = 2;
   const check = new Check(tooManyUpdatesRule, options);
-  const findings = await scan(
+  const { findings } = await scan(
     check,
     'PaymentsController_create_no_user_email_on_file_makes_a_onetime_payment_with_no_user_but_associate_with_stripe.appmap.json'
   );

--- a/packages/scanner/test/scanner/incompatibleHTTPClientRequest.spec.ts
+++ b/packages/scanner/test/scanner/incompatibleHTTPClientRequest.spec.ts
@@ -10,7 +10,7 @@ it('incompatible http client requests', async () => {
   )}`;
   const check = new Check(rule);
   check.options.schemata = { 'api.stripe.com': railsSampleAppSchemaURL };
-  const findings = await scan(
+  const { findings } = await scan(
     check,
     'PaymentsController_create_no_user_email_on_file_makes_a_onetime_payment_with_no_user_but_associate_with_stripe.appmap.json'
   );

--- a/packages/scanner/test/scanner/insecureCompare.spec.ts
+++ b/packages/scanner/test/scanner/insecureCompare.spec.ts
@@ -3,7 +3,7 @@ import rule from '../../src/rules/insecureCompare';
 import { scan } from '../util';
 
 it('insecure compare', async () => {
-  const findings = await scan(
+  const { findings } = await scan(
     new Check(rule),
     'Password_resets_password_resets_with_insecure_compare.appmap.json'
   );

--- a/packages/scanner/test/scanner/jobNotCancelled.spec.ts
+++ b/packages/scanner/test/scanner/jobNotCancelled.spec.ts
@@ -4,7 +4,7 @@ import { scan } from '../util';
 
 test('job not cancelled', async () => {
   const check = new Check(rule);
-  const findings = await scan(
+  const { findings } = await scan(
     check,
     'Microposts_interface_micropost_interface_with_job.appmap.json'
   );

--- a/packages/scanner/test/scanner/logoutWithoutSessionReset.spec.ts
+++ b/packages/scanner/test/scanner/logoutWithoutSessionReset.spec.ts
@@ -4,7 +4,7 @@ import { scan } from '../util';
 
 test('logout without session reset', async () => {
   const check = new Check(rule);
-  const findings = await scan(
+  const { findings } = await scan(
     check,
     'Users_login_login_with_valid_information_followed_by_logout.appmap.json'
   );

--- a/packages/scanner/test/scanner/missingAuthentication.spec.ts
+++ b/packages/scanner/test/scanner/missingAuthentication.spec.ts
@@ -4,7 +4,10 @@ import { scan } from '../util';
 
 it('missing authentication', async () => {
   const check = new Check(rule);
-  const findings = await scan(check, 'Users_profile_profile_display_while_anonyomus.appmap.json');
+  const { findings } = await scan(
+    check,
+    'Users_profile_profile_display_while_anonyomus.appmap.json'
+  );
 
   expect(findings).toHaveLength(1);
   const finding = findings[0];

--- a/packages/scanner/test/scanner/nPlusOneQuery.spec.ts
+++ b/packages/scanner/test/scanner/nPlusOneQuery.spec.ts
@@ -19,15 +19,22 @@ it('n+1 query', async () => {
   const findingEvent = appMap.events.find((e) => e.id === finding.event.id)!;
   expect(
     new HashV2(finding.ruleId, findingEvent, finding.participatingEvents || {}).canonicalString
-  ).toEqual(`rule=n-plus-one-query
-commandEvent.event_type=http_server_request
-commandEvent.route=GET /users/{id}
-commandEvent.status_code=200
+  ).toEqual(`algorithmVersion=2
+rule=n-plus-one-query
 findingEvent.event_type=sql
 findingEvent.sql_normalized={"type":"statement","variant":"list","statement":[{"type":"statement","variant":"select","result":[{"type":"identifier","variant":"star","name":"active_storage_attachments.*"}],"from":{"type":"identifier","variant":"table","name":"active_storage_attachments"},"where":[{"type":"expression","format":"binary","variant":"operation","operation":"and","left":{"type":"expression","format":"binary","variant":"operation","operation":"and","left":{"type":"expression","format":"binary","variant":"operation","operation":"=","left":{"type":"identifier","variant":"column","name":"active_storage_attachments.record_id"},"right":{"type":"variable"}},"right":{"type":"expression","format":"binary","variant":"operation","operation":"=","left":{"type":"identifier","variant":"column","name":"active_storage_attachments.record_type"},"right":{"type":"variable"}}},"right":{"type":"expression","format":"binary","variant":"operation","operation":"=","left":{"type":"identifier","variant":"column","name":"active_storage_attachments.name"},"right":{"type":"variable"}}}],"limit":{"type":"expression","variant":"limit","start":{"type":"variable"}}}]}
 participatingEvent.commonAncestor.event_type=function
 participatingEvent.commonAncestor.id=app_views_microposts__micropost_html_erb.render
-participatingEvent.commonAncestor.raises_exception=false`);
+participatingEvent.commonAncestor.raises_exception=false
+stack[1].event_type=function
+stack[1].id=app_views_users_show_html_erb.render
+stack[1].raises_exception=false
+stack[2].event_type=function
+stack[2].id=ActionController::Instrumentation#process_action
+stack[2].raises_exception=false
+stack[3].event_type=http_server_request
+stack[3].route=GET /users/{id}
+stack[3].status_code=200`);
   expect(finding.ruleId).toEqual('n-plus-one-query');
   expect(finding.event.id).toEqual(133);
   expect(finding.relatedEvents!).toHaveLength(31);

--- a/packages/scanner/test/scanner/rpcWithoutCircuitBreaker.spec.ts
+++ b/packages/scanner/test/scanner/rpcWithoutCircuitBreaker.spec.ts
@@ -3,7 +3,7 @@ import rule from '../../src/rules/rpcWithoutCircuitBreaker';
 import { scan } from '../util';
 
 it('rpc without circuit breaker', async () => {
-  const findings = await scan(
+  const { findings } = await scan(
     new Check(rule),
     'PaymentsController_create_no_user_email_on_file_makes_a_onetime_payment_with_no_user_but_associate_with_stripe.appmap.json'
   );
@@ -14,7 +14,7 @@ it('rpc without circuit breaker', async () => {
 });
 
 it('all rpc have a circuit breaker ', async () => {
-  const findings = await scan(
+  const { findings } = await scan(
     new Check(rule),
     'Test_net_5xxs_trip_circuit_when_fatal_server_flag_enabled.appmap.json'
   );

--- a/packages/scanner/test/scanner/secretInLog.spec.ts
+++ b/packages/scanner/test/scanner/secretInLog.spec.ts
@@ -1,16 +1,30 @@
+import HashV2 from '../../src/algorithms/hash/hashV2';
 import Check from '../../src/check';
 import rule from '../../src/rules/secretInLog';
 import { scan } from '../util';
 
 it('secret in log file', async () => {
   const check = new Check(rule);
-  const findings = await scan(
+  const { appMap, findings } = await scan(
     check,
     'Users_signup_valid_signup_information_with_account_activation.appmap.json'
   );
   expect(findings).toHaveLength(2);
   {
     const finding = findings[0];
+    const findingEvent = appMap.events.find((e) => e.id === finding.event.id)!;
+    expect(
+      new HashV2(finding.ruleId, findingEvent, finding.participatingEvents || {}).canonicalString
+    ).toEqual(`rule=secret-in-log
+rootEvent.event_type=function
+rootEvent.id=Logger::LogDevice#write
+rootEvent.raises_exception=false
+findingEvent.event_type=function
+findingEvent.id=Logger::LogDevice#write
+findingEvent.raises_exception=false
+participatingEvent.generatorEvent.event_type=function
+participatingEvent.generatorEvent.id=User.new_token
+participatingEvent.generatorEvent.raises_exception=false`);
     expect(finding.ruleId).toEqual('secret-in-log');
     expect(finding.event.id).toEqual(695);
     expect(finding.message).toEqual(
@@ -26,7 +40,7 @@ it('secret in log file', async () => {
 
 it('parses out multiple secrets from function return value', async () => {
   const check = new Check(rule);
-  const findings = await scan(
+  const { findings } = await scan(
     check,
     'appmaps/secretInLog/Confirmation_already_confirmed_user_should_not_be_able_to_confirm_the_account_again.appmap.json'
   );

--- a/packages/scanner/test/scanner/secretInLog.spec.ts
+++ b/packages/scanner/test/scanner/secretInLog.spec.ts
@@ -15,10 +15,8 @@ it('secret in log file', async () => {
     const findingEvent = appMap.events.find((e) => e.id === finding.event.id)!;
     expect(
       new HashV2(finding.ruleId, findingEvent, finding.participatingEvents || {}).canonicalString
-    ).toEqual(`rule=secret-in-log
-rootEvent.event_type=function
-rootEvent.id=Logger::LogDevice#write
-rootEvent.raises_exception=false
+    ).toEqual(`algorithmVersion=2
+rule=secret-in-log
 findingEvent.event_type=function
 findingEvent.id=Logger::LogDevice#write
 findingEvent.raises_exception=false

--- a/packages/scanner/test/scanner/slowFunctionCall.spec.ts
+++ b/packages/scanner/test/scanner/slowFunctionCall.spec.ts
@@ -9,7 +9,7 @@ it('slow function call', async () => {
   const pattern = new RegExp(/Controller#create$/);
   check.includeEvent = [(event: Event) => pattern.test(event.codeObject.fqid)];
 
-  const findings = await scan(check, 'Microposts_interface_micropost_interface.appmap.json');
+  const { findings } = await scan(check, 'Microposts_interface_micropost_interface.appmap.json');
   expect(findings).toHaveLength(1);
   const finding = findings[0];
   expect(finding.ruleId).toEqual('slow-function-call');

--- a/packages/scanner/test/scanner/slowHttpServerRequest.spec.ts
+++ b/packages/scanner/test/scanner/slowHttpServerRequest.spec.ts
@@ -5,7 +5,7 @@ import { scan } from '../util';
 it('slow HTTP server request', async () => {
   const options = new rule.Options();
   options.timeAllowed = 0.5;
-  const findings = await scan(
+  const { findings } = await scan(
     new Check(rule, options),
     'Password_resets_password_resets.appmap.json'
   );

--- a/packages/scanner/test/scanner/tooManyJoins.spec.ts
+++ b/packages/scanner/test/scanner/tooManyJoins.spec.ts
@@ -5,7 +5,10 @@ import { scan } from '../util';
 it('too many joins', async () => {
   const check = new Check(rule);
   check.options.warningLimit = 1;
-  const findings = await scan(check, 'Users_profile_profile_display_while_anonyomus.appmap.json');
+  const { findings } = await scan(
+    check,
+    'Users_profile_profile_display_while_anonyomus.appmap.json'
+  );
   expect(findings).toHaveLength(2);
   const finding = findings[0];
   expect(finding.ruleId).toEqual('too-many-joins');

--- a/packages/scanner/test/scanner/tooManyUpdates.spec.ts
+++ b/packages/scanner/test/scanner/tooManyUpdates.spec.ts
@@ -5,7 +5,7 @@ import { scan } from '../util';
 it('too many updates', async () => {
   const options = new rule.Options();
   options.warningLimit = 2;
-  const findings = await scan(
+  const { findings } = await scan(
     new Check(rule, options),
     'PaymentsController_create_no_user_email_on_file_makes_a_onetime_payment_with_no_user_but_associate_with_stripe.appmap.json'
   );

--- a/packages/scanner/test/scanner/unbatchedMaterializedQuery.spec.ts
+++ b/packages/scanner/test/scanner/unbatchedMaterializedQuery.spec.ts
@@ -3,7 +3,7 @@ import rule from '../../src/rules/unbatchedMaterializedQuery';
 import { scan } from '../util';
 
 it('unbatched materialized query', async () => {
-  const findings = await scan(
+  const { findings } = await scan(
     new Check(rule),
     'Users_index_index_as_admin_including_pagination_and_delete_links.appmap.json'
   );

--- a/packages/scanner/test/util.ts
+++ b/packages/scanner/test/util.ts
@@ -24,7 +24,11 @@ const fixtureAppMap = async (file: string): Promise<AppMap> => {
   return buildAppMap(appMapBytes).normalize().build();
 };
 
-const scan = async (check: Check, appMapFile: string, appMap?: AppMap): Promise<Finding[]> => {
+const scan = async (
+  check: Check,
+  appMapFile: string,
+  appMap?: AppMap
+): Promise<{ appMap: AppMap; findings: Finding[] }> => {
   let appMapData: AppMap;
   if (appMap) {
     appMapData = appMap!;
@@ -40,7 +44,7 @@ const scan = async (check: Check, appMapFile: string, appMap?: AppMap): Promise<
     console.log(JSON.stringify(findings, null, 2));
   }
 
-  return findings;
+  return { appMap: appMapData, findings };
 };
 
 export { fixtureAppMap, fixtureAppMapFileName, scan };


### PR DESCRIPTION
Adds a new `v2` hash algorithm based in part on the new `Event#stableProperties`.

Hash v2 first builds a canonical string of the finding, and then hashes it. Details of the canonical string algorithm are commented on the HashV2 class. Here's an example:

```
rule=n-plus-one-query
findingEvent.event_type=sql
findingEvent.sql_normalized={"type":"statement","variant":"list","statement":[{"type":"statement","variant":"select","result":[{"type":"identifier","variant":"star","name":"active_storage_attachments.*"}],"from":{"type":"identifier","variant":"table","name":"active_storage_attachments"},"where":[{"type":"expression","format":"binary","variant":"operation","operation":"and","left":{"type":"expression","format":"binary","variant":"operation","operation":"and","left":{"type":"expression","format":"binary","variant":"operation","operation":"=","left":{"type":"identifier","variant":"column","name":"active_storage_attachments.record_id"},"right":{"type":"variable"}},"right":{"type":"expression","format":"binary","variant":"operation","operation":"=","left":{"type":"identifier","variant":"column","name":"active_storage_attachments.record_type"},"right":{"type":"variable"}}},"right":{"type":"expression","format":"binary","variant":"operation","operation":"=","left":{"type":"identifier","variant":"column","name":"active_storage_attachments.name"},"right":{"type":"variable"}}}],"limit":{"type":"expression","variant":"limit","start":{"type":"variable"}}}]}
participatingEvent.commonAncestor.event_type=function
participatingEvent.commonAncestor.id=app_views_microposts__micropost_html_erb.render
participatingEvent.commonAncestor.raises_exception=false
stack[1].event_type=function
stack[1].id=app_views_users_show_html_erb.render
stack[1].raises_exception=false
stack[2].event_type=function
stack[2].id=ActionController::Instrumentation#process_action
stack[2].raises_exception=false
stack[3].event_type=http_server_request
stack[3].route=GET /users/{id}
stack[3].status_code=200
```

Note the following features:

1) Starts with the rule id
2) Followed with `commandEvent` - this is the HTTP server request, @command or @job that encloses the finding
3) Followed with `findingEvent` - this is the primary event of the finding
4) Followed by named `participatingEvent`s - these are other events that are instrumental to the finding, and should be invariant across duplicate findings. 

In this example, the `findingEvent` is the canonicalized form of the SQL query that's repeated N times. There is a participating event called `commonAncestor` which is the code function that contains all the N occurrences of the query.  

If the same query is found a different number M times within the same command and common ancestor, then that finding will have the same hash.

If the query is structurally different, or it's in a different command, or the queries have a different common ancestor, then the finding hash will be different. 

Hash V2 is generally more specific than Hash V1. For example, Hash V1 does not include the common ancestor of an N+1 query, nor does it include the command event. 

However, Hash V2 does do a better job of canonicalizing the query, because it collapses repeated query literals and query parameters.

Because Hash V2 includes more data about the finding, it will de-duplicate less aggressively.