### PR TITLE
feat: Command scope falls back on root events

### DIFF
--- a/packages/scanner/src/check.ts
+++ b/packages/scanner/src/check.ts
@@ -19,7 +19,7 @@ export default class Check {
 
     this.id = rule.id;
     this.options = options || makeOptions();
-    this.scope = rule.scope || 'root';
+    this.scope = rule.scope || 'command';
     this.includeScope = [];
     this.excludeScope = [];
     this.includeEvent = [];

--- a/packages/scanner/src/ruleChecker.ts
+++ b/packages/scanner/src/ruleChecker.ts
@@ -1,7 +1,7 @@
 import { Event } from '@appland/models';
 import Check from './check';
 import { AbortError } from './errors';
-import { AppMapIndex, Finding, ScopeName } from './types';
+import { AppMapIndex, Finding } from './types';
 import { verbose } from './rules/lib/util';
 import ScopeIterator from './scope/scopeIterator';
 import RootScope from './scope/rootScope';
@@ -29,25 +29,7 @@ export default class RuleChecker {
     check: Check,
     findings: Finding[]
   ): Promise<void> {
-    const numScopesChecked = await this.checkScope(
-      appMapFile,
-      appMapIndex,
-      check,
-      check.scope,
-      findings
-    );
-    if (numScopesChecked === 0 && check.scope === 'command') {
-      await this.checkScope(appMapFile, appMapIndex, check, 'root', findings);
-    }
-  }
-
-  async checkScope(
-    appMapFile: string,
-    appMapIndex: AppMapIndex,
-    check: Check,
-    scope: ScopeName,
-    findings: Finding[]
-  ): Promise<number> {
+    const scope = check.scope;
     if (verbose()) {
       console.warn(`Checking AppMap ${appMapIndex.appMap.name} with scope ${scope}`);
     }
@@ -63,9 +45,7 @@ export default class RuleChecker {
       }
     };
 
-    let numScopes = 0;
     for (const scope of scopeIterator.scopes(callEvents())) {
-      numScopes += 1;
       if (verbose()) {
         console.warn(`Scope ${scope.scope}`);
       }
@@ -95,7 +75,6 @@ export default class RuleChecker {
         );
       }
     }
-    return numScopes;
   }
 
   async checkEvent(

--- a/packages/scanner/src/rules/secretInLog.ts
+++ b/packages/scanner/src/rules/secretInLog.ts
@@ -90,6 +90,7 @@ export default {
   id: 'secret-in-log',
   title: 'Secret in log',
   labels: [Secret, Log],
+  scope: 'root',
   impactDomain: 'Security',
   enumerateScope: true,
   references: {

--- a/packages/scanner/src/rules/slowFunctionCall.ts
+++ b/packages/scanner/src/rules/slowFunctionCall.ts
@@ -31,7 +31,6 @@ function build(options: Options): RuleLogic {
 export default {
   id: 'slow-function-call',
   title: 'Slow function call',
-  scope: 'root',
   impactDomain: 'Performance',
   enumerateScope: true,
   description: parseRuleDescription('slowFunctionCall'),

--- a/packages/scanner/src/scope/commandScope.ts
+++ b/packages/scanner/src/scope/commandScope.ts
@@ -25,16 +25,30 @@ const Job = 'job.perform';
 
 export default class CommandScope extends ScopeIterator {
   *scopes(events: IterableIterator<Event>): Generator<Scope> {
+    let found = false;
+    const roots: Event[] = [];
     for (const event of events) {
+      if (event.isCall() && !event.parent) {
+        roots.push(event);
+      }
+
       if (
         event.isCall() &&
         (event.codeObject.labels.has(Command) ||
           event.codeObject.labels.has(Job) ||
           event.httpServerRequest)
       ) {
+        found = true;
         yield new ScopeImpl(event);
 
         this.advanceToReturnEvent(event, events);
+      }
+    }
+    // If no true command is found, yield all root events.
+    if (!found) {
+      for (let index = 0; index < roots.length; index++) {
+        const event = roots[index];
+        yield new ScopeImpl(event);
       }
     }
   }

--- a/packages/scanner/test/scanner/rpcWithoutCircuitBreaker.spec.ts
+++ b/packages/scanner/test/scanner/rpcWithoutCircuitBreaker.spec.ts
@@ -7,10 +7,10 @@ it('rpc without circuit breaker', async () => {
     new Check(rule),
     'PaymentsController_create_no_user_email_on_file_makes_a_onetime_payment_with_no_user_but_associate_with_stripe.appmap.json'
   );
-  expect(findings).toHaveLength(4);
+  expect(findings).toHaveLength(3);
   const finding = findings[0];
   expect(finding.ruleId).toEqual('rpc-without-circuit-breaker');
-  expect(finding.event.id).toEqual(19);
+  expect(finding.event.id).toEqual(76);
 });
 
 it('all rpc have a circuit breaker ', async () => {


### PR DESCRIPTION
If no events qualify as commands (@command, @job, or http_server_request), `command` scope will enumerate root events.

`command` scope also be comes the default.