### PR TITLE
fix: Recording metrics report 0 initial AppMaps

### DIFF
--- a/packages/cli/src/cmds/record/recordContext.ts
+++ b/packages/cli/src/cmds/record/recordContext.ts
@@ -35,10 +35,15 @@ export default class RecordContext {
   metrics(): Record<string, number> {
     const result = {} as Record<string, number>;
     if (this.maxTime) result.maxTime = this.maxTime;
-    if (this.initialAppMapCount)
+    if (this.initialAppMapCount !== undefined) {
       result.initialAppMapCount = this.initialAppMapCount;
-    if (this.appMapCount) result.appMapCount = this.appMapCount;
-    if (this.appMapEventCount) result.appMapEventCount = this.appMapEventCount;
+    }
+    if (this.appMapCount !== undefined) {
+      result.appMapCount = this.appMapCount;
+    }
+    if (this.appMapEventCount !== undefined) {
+      result.appMapEventCount = this.appMapEventCount;
+    }
     return result;
   }
 

--- a/packages/cli/tests/unit/record/test/recordContext.spec.ts
+++ b/packages/cli/tests/unit/record/test/recordContext.spec.ts
@@ -1,0 +1,27 @@
+import * as sinon from 'sinon';
+import { inspect } from 'util';
+import * as countAppMaps from '../../../../src/cmds/record/action/countAppMaps';
+import RecordContext from '../../../../src/cmds/record/recordContext';
+
+describe('RecordContext', function () {
+  afterEach(sinon.restore);
+
+  describe('when generating metrics', () => {
+    it('correctly reports counts of 0 items', async () => {
+      sinon
+        .stub(countAppMaps, 'default')
+        .onCall(0)
+        .resolves(0)
+        .onCall(1)
+        .resolves(0);
+
+      const rc = new RecordContext('.');
+      await rc.initialize();
+      await rc.populateAppMapCount();
+      rc.appMapEventCount = 0;
+      expect(inspect(rc.metrics())).toEqual(
+        '{ initialAppMapCount: 0, appMapCount: 0, appMapEventCount: 0 }'
+      );
+    });
+  });
+});


### PR DESCRIPTION
Telemetry events for the "record" subcommands will now correctly report
an AppMap count of 0. Previously, 0 AppMaps would cause the count to be
missing from the events.