### PR TITLE
fix: Improve telemetry for "appmap record remote"

### DIFF
--- a/packages/cli/src/cmds/record/action/nameAppMap.ts
+++ b/packages/cli/src/cmds/record/action/nameAppMap.ts
@@ -1,0 +1,15 @@
+import UI from '../../userInteraction';
+
+export default async function nameAppMap(jsonData: any): Promise<string> {
+  const { appMapName } = await UI.prompt({
+    type: 'input',
+    name: 'appMapName',
+    message: 'Choose a name for your AppMap:',
+    default: 'My recording',
+  });
+
+  jsonData['metadata'] = jsonData['metadata'] || {};
+  jsonData['metadata']['name'] = appMapName;
+
+  return appMapName;
+}

--- a/packages/cli/src/cmds/record/action/saveAppMap.ts
+++ b/packages/cli/src/cmds/record/action/saveAppMap.ts
@@ -1,0 +1,24 @@
+import { mkdirp } from 'fs-extra';
+import { writeFile } from 'fs/promises';
+import { join } from 'path';
+import UI from '../../userInteraction';
+import { readConfigOption } from '../configuration';
+
+export default async function saveAppMap(jsonData: any, appMapName: string) {
+  const data = JSON.stringify(jsonData);
+
+  const fileName = `${appMapName}.appmap.json`;
+  const outputDir = join(
+    (await readConfigOption('appmap_dir', 'tmp/appmap')) as string,
+    'remote'
+  );
+  await mkdirp(outputDir);
+
+  UI.status = `Saving recording to ${fileName} in directory ${outputDir}`;
+
+  await writeFile(join(outputDir, fileName), data);
+
+  UI.success('AppMap saved');
+
+  return join(outputDir, fileName);
+}

--- a/packages/cli/tests/unit/record/record.remote.spec.ts
+++ b/packages/cli/tests/unit/record/record.remote.spec.ts
@@ -1,21 +1,25 @@
 import { RequestOptions } from 'http';
 import sinon from 'sinon';
-import UI from '../../../src/cmds/userInteraction';
-import { State } from '../../../src/cmds/record/types/state';
-import * as remote from '../../../src/cmds/record/state/record_remote';
+import { inspect } from 'util';
+import * as configureHostAndPort from '../../../src/cmds/record/action/configureHostAndPort';
+import * as configureRemainingRequestOptions from '../../../src/cmds/record/action/configureRemainingRequestOptions';
+import * as detectProcessCharacteristics from '../../../src/cmds/record/action/detectProcessCharacteristics';
+import * as nameAppMap from '../../../src/cmds/record/action/nameAppMap';
+import * as saveAppMap from '../../../src/cmds/record/action/saveAppMap';
 import * as configuration from '../../../src/cmds/record/configuration';
-import * as isAgentAvailable from '../../../src/cmds/record/test/isAgentAvailable';
-import * as isRecordingInProgress from '../../../src/cmds/record/test/isRecordingInProgress';
+import * as continueWithRequestOptionConfiguration from '../../../src/cmds/record/prompt/continueWithRequestOptionConfiguration';
+import * as recordingInProgress from '../../../src/cmds/record/prompt/recordingInProgress';
+import RecordContext from '../../../src/cmds/record/recordContext';
+import RemoteRecording from '../../../src/cmds/record/remoteRecording';
 import * as agentAvailableAndReady from '../../../src/cmds/record/state/agentAvailableAndReady';
 import * as agentIsRecording from '../../../src/cmds/record/state/agentIsRecording';
 import * as agentNotAvailable from '../../../src/cmds/record/state/agentNotAvailable';
-import * as detectProcessCharacteristics from '../../../src/cmds/record/action/detectProcessCharacteristics';
 import * as agentProcessNotRunning from '../../../src/cmds/record/state/agentProcessNotRunning';
-import * as configureHostAndPort from '../../../src/cmds/record/action/configureHostAndPort';
-import RecordContext from '../../../src/cmds/record/recordContext';
-import { inspect } from 'util';
-import * as continueWithRequestOptionConfiguration from '../../../src/cmds/record/prompt/continueWithRequestOptionConfiguration';
-import * as configureRemainingRequestOptions from '../../../src/cmds/record/action/configureRemainingRequestOptions';
+import * as remote from '../../../src/cmds/record/state/record_remote';
+import * as isAgentAvailable from '../../../src/cmds/record/test/isAgentAvailable';
+import * as isRecordingInProgress from '../../../src/cmds/record/test/isRecordingInProgress';
+import { State } from '../../../src/cmds/record/types/state';
+import UI from '../../../src/cmds/userInteraction';
 
 describe('record remote', () => {
   let prompt: sinon.SinonStub,
@@ -36,7 +40,7 @@ describe('record remote', () => {
     sinon.restore();
   });
 
-  describe('agent is not avaliable', () => {
+  describe('agent is not available', () => {
     beforeEach(() => sinon.stub(isAgentAvailable, 'default').resolves(false));
 
     it('begins the configuration process', async () => {
@@ -114,7 +118,7 @@ describe('record remote', () => {
     });
   });
 
-  describe('agent is avaliable', () => {
+  describe('agent is available', () => {
     beforeEach(() => sinon.stub(isAgentAvailable, 'default').resolves(true));
 
     describe('agent is not recording', () => {
@@ -130,7 +134,7 @@ describe('record remote', () => {
         expect(next).toEqual(agentAvailableAndReady.default);
       });
     });
-    describe('agent is recording', () => {
+    describe.only('agent is recording', () => {
       beforeEach(() =>
         sinon.stub(isRecordingInProgress, 'default').resolves(true)
       );
@@ -141,6 +145,56 @@ describe('record remote', () => {
           `RecordContext { appMapDir: '.', url: 'http://localhost:3000/' }`
         );
         expect(next).toEqual(agentIsRecording.default);
+      });
+
+      describe('recording is stopped', () => {
+        beforeEach(() => {
+          sinon
+            .stub(recordingInProgress, 'default')
+            .resolves(recordingInProgress.RecordingAction.Save);
+
+          const appMapName = 'myAppMap';
+          sinon.stub(nameAppMap, 'default').resolves(appMapName);
+          sinon
+            .stub(saveAppMap, 'default')
+            .resolves(`${nameAppMap}.appmap.json`);
+        });
+
+        const EXAMPLES = [
+          {
+            description: 'is empty',
+            stopResult: '',
+            appMapCount: 0,
+            appMapEventCount: 0,
+          },
+          {
+            description: 'has no events',
+            stopResult: JSON.stringify({ events: [] }),
+            appMapCount: 1,
+            appMapEventCount: 0,
+          },
+          {
+            description: 'has an event',
+            stopResult: JSON.stringify({ events: [{ id: 1 }] }),
+            appMapCount: 1,
+            appMapEventCount: 1,
+          },
+        ];
+
+        EXAMPLES.forEach((e) => {
+          it(e.description, async () => {
+            sinon
+              .stub(RemoteRecording.prototype, 'stop')
+              .resolves(e.stopResult);
+
+            let next: State | string | undefined = await remote.default(
+              recordContext
+            );
+            next = await next(recordContext);
+            expect(recordContext.appMapCount).toEqual(e.appMapCount);
+            expect(recordContext.appMapEventCount).toEqual(e.appMapEventCount);
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
Make sure the telemetry event sent by "appmap record remote" reflects
the number of AppMaps created: 1 if the response for the DELETE request
contains data, 0 otherwise.

Fixes applandinc/board#127 .