### PR TITLE
fix: Make EventNavigator.preceding() actually work

### DIFF
--- a/packages/models/src/eventNavigator.js
+++ b/packages/models/src/eventNavigator.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-syntax */
 export default class EventNavigator {
   constructor(event) {
     this.event = event;
@@ -32,22 +33,13 @@ export default class EventNavigator {
    * Generates all events which precede this event in the scenario.
    */
   *preceding() {
-    const ancestors = this.ancestors();
-    let ancestor = ancestors.next();
-    while (!ancestor.done) {
-      yield new EventNavigator(ancestor.value);
-      let precedingSibling = this.precedingSiblings.next();
-      while (!precedingSibling.done) {
-        yield new EventNavigator(precedingSibling.value);
-        const descendants = precedingSibling.value.descendants();
-        let descendant = descendants.next();
-        while (!descendant.done) {
-          yield new EventNavigator(descendant.value);
-          descendant = descendants.next();
-        }
-        precedingSibling = this.precedingSiblings.next();
+    for (const node of [this, ...this.ancestors()]) {
+      if (node !== this) yield node;
+      for (const sibling of node.precedingSiblings()) {
+        for (const descendant of [...sibling.descendants()].reverse())
+          yield descendant;
+        yield sibling;
       }
-      ancestor = ancestors.next();
     }
   }
 

--- a/packages/models/tests/unit/eventNavigator.spec.js
+++ b/packages/models/tests/unit/eventNavigator.spec.js
@@ -59,6 +59,16 @@ describe('EventNavigator', () => {
     expect(ancestors.next().done).toEqual(true);
   });
 
+  test('preceding', () => {
+    const event = apiKeyAppMap.events.find(({ id }) => id === 32);
+    const precedingSiblings = new EventNavigator(event).preceding();
+
+    expect(
+      // eslint-disable-next-line no-shadow
+      Array.from(precedingSiblings).map(({ event }) => event.id)
+    ).toEqual([30, 29, 28, 25, 23, 21, 19, 17, 14, 13, 11, 9, 8, 7]);
+  });
+
   test('precedingSiblings', () => {
     const event = apiKeyAppMap.events.find(
       (e) => e.isCall() && e.methodId === 'touch'


### PR DESCRIPTION
I'm not entirely sure what the previous code tried to do, but it yielded duplicate nodes in no particular order.