### PR TITLE
ci: Build and release pre-built binaries to GitHub Releases

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -46,7 +46,12 @@ module.exports = {
     ],
     '@semantic-release/git',
     join(__dirname, 'ci/yarnPublish.js'),
-    '@semantic-release/github',
+    [
+      '@semantic-release/github',
+      {
+        assets: 'release/*.tar.gz',
+      },
+    ],
   ],
-  extends: 'semantic-release-monorepo'
+  extends: 'semantic-release-monorepo',
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,5 @@ jobs:
       if: branch = main
       script: |
         yarn run chromatic --auto-accept-changes \
+        && yarn run build-native \
         && yarn run semantic-release

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "yarn workspaces foreach --exclude root -v run lint",
     "test": "yarn workspaces foreach --exclude root -v run test",
     "build": "yarn workspaces foreach -t --exclude root -v run build",
+    "build-native": "yarn workspaces foreach -t --exclude root -v run build-native",
     "ci": "yarn run build && yarn run lint && yarn run test",
     "chromatic": "yarn workspaces foreach --exclude root -v run chromatic",
     "watch": "yarn workspaces foreach -t --exclude root -v -p -i run watch",

--- a/packages/cli/bin/build-native
+++ b/packages/cli/bin/build-native
@@ -1,15 +1,24 @@
 #!/bin/bash
+set -e
 
 echo "Building native binaries..."
-
-cp built/appmap.html appmap.html
-
 yarn pkg \
   --config package.json \
   --compress GZip \
-  -o dist/cli \
+  -o release/appmap \
   built/cli.js
 
-rm appmap.html
+echo "Archiving..."
+pushd release>/dev/null
+  rm -rf *.tar.gz
+  for i in appmap-*; do
+    archive_name="$(echo ${i} | sed 's/\..*//').tar.gz"
+    tar \
+      --transform 's|-\w*||' \
+      -czf "${archive_name}" \
+      "${i}"
+    echo "  + ${archive_name}"
+  done
+popd>/dev/null
 
 echo "Success!"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -118,7 +118,7 @@
     "assets": [
       "package.json",
       "**/openapi-template.yaml",
-      "appmap.html"
+      "built/appmap.html"
     ],
     "outputPath": "dist"
   }

--- a/packages/cli/src/cmds/open/serveAndOpenAppMap.ts
+++ b/packages/cli/src/cmds/open/serveAndOpenAppMap.ts
@@ -13,7 +13,7 @@ export default async function serveAndOpenAppMap(appMapFile: string) {
   const builtDir = join(__dirname, '../../../built');
   const baseDir = (await exists(builtDir))
     ? builtDir
-    : join(__dirname, '../../..');
+    : join(__dirname, '..', '..');
 
   const server = createServer(async (req, res) => {
     // Once a request is received, the server can be closed.

--- a/packages/scanner/bin/build-native
+++ b/packages/scanner/bin/build-native
@@ -5,14 +5,14 @@ echo "Building native binaries..."
 yarn pkg \
   --config package.json \
   --compress GZip \
-  -o dist/scanner \
+  -o release/scanner \
   built/cli.js
 
 echo "Archiving..."
-pushd dist>/dev/null
-  rm -rf *.tgz
+pushd release>/dev/null
+  rm -rf *.tar.gz
   for i in scanner-*; do
-    archive_name="$(echo ${i} | sed 's/\..*//').tgz"
+    archive_name="$(echo ${i} | sed 's/\..*//').tar.gz"
     tar \
       --transform 's|-\w*||' \
       -czf "${archive_name}" \


### PR DESCRIPTION
Build and release `scanner` and `appmap` binaries to GitHub Releases during semantic release.

Resolves #702