### PR TITLE
Give the user the option of creating a Zendesk ticket when install fails

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -78,6 +78,7 @@
     "ajv": "^8.6.3",
     "applicationinsights": "^2.1.4",
     "async": "^3.2.0",
+    "axios": "^0.27.2",
     "boxen": "^5.0.1",
     "chalk": "^4.1.2",
     "chokidar": "^3.5.1",
@@ -101,6 +102,7 @@
     "ps-node": "^0.1.6",
     "read-pkg-up": "^7.0.1",
     "semver": "^7.3.5",
+    "strip-ansi": "^6.0.0",
     "supports-hyperlinks": "^2.2.0",
     "w3c-xmlserializer": "^2.0.0",
     "yargs": "^17.1.1"

--- a/packages/cli/src/cmds/agentInstaller/install-agent.ts
+++ b/packages/cli/src/cmds/agentInstaller/install-agent.ts
@@ -16,6 +16,7 @@ import { getDirectoryProperty } from './telemetryUtil';
 import { getProjects, ProjectConfiguration } from './projectConfiguration';
 import AgentInstaller from './agentInstaller';
 import { ProcessLog } from './commandRunner';
+import { openTicket } from '../../lib/ticket/openTicket';
 interface InstallCommandOptions {
   verbose?: any;
   projectType?: string;
@@ -214,9 +215,10 @@ const _handler = async (
     errors.push(installerError);
   }
 
+  await openTicket(errors.map((e) => e.message));
+
   if (errors.length) {
     const reason = new Error(errors.map((e) => e.message).join('\n'));
-    console.log(reason.message);
     return { exitCode: 1, err: reason };
   }
 

--- a/packages/cli/src/cmds/errors.ts
+++ b/packages/cli/src/cmds/errors.ts
@@ -9,6 +9,20 @@ export class InvalidPathError extends Error {
 
 export class AbortError extends Error {}
 export class ValidationError extends Error {}
+
+export interface HttpErrorResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+  toString(): string;
+}
+
+export class HttpError extends Error {
+  constructor(message: string, readonly response?: HttpErrorResponse) {
+    super(message);
+  }
+}
+
 export class ChildProcessError extends Error {
   constructor(
     readonly command: string,

--- a/packages/cli/src/lib/ticket/openTicket.ts
+++ b/packages/cli/src/lib/ticket/openTicket.ts
@@ -1,0 +1,90 @@
+import chalk from 'chalk';
+import { HttpError } from '../../cmds/errors';
+import UI from '../../cmds/userInteraction';
+import Telemetry from '../../telemetry';
+import { createRequest as createZendeskRequest } from './zendesk';
+
+export async function openTicket(errors: string[]): Promise<void> {
+  const message = `
+Would you like to provide your name and email address to open a support ticket?
+The details of the error will be included automatically.
+`;
+  const { name, email, openTicket } = await UI.prompt({
+    type: 'confirm',
+    name: 'openTicket',
+    default: true,
+    message,
+    prefix: chalk.red('!'),
+  }).then(async (answers) => {
+    if (!answers.openTicket) {
+      Telemetry.sendEvent({
+        name: 'open-ticket:declined',
+      });
+
+      return { openTicket: false };
+    }
+
+    const { name, email } = await UI.prompt([
+      {
+        name: 'name',
+        message: 'Your name',
+        validate: (v) => {
+          return v.trim().length > 0 || 'Please enter your name';
+        },
+      },
+      {
+        name: 'email',
+        message: 'Your email address',
+        validate: (v) =>
+          v.trim().length > 0 || 'Please enter your email address',
+      },
+    ]);
+    return {
+      name,
+      email,
+      openTicket: true,
+    };
+  });
+
+  if (!openTicket) {
+    return;
+  }
+
+  try {
+    const id = await createZendeskRequest(errors, email, name);
+    Telemetry.sendEvent({
+      name: 'open-ticket:success',
+    });
+    UI.success(
+      `Ticket ${id} was successfully opened on your behalf.
+
+Thank you very much for reporting this error.
+Please check your email for next steps.`,
+      'left'
+    );
+  } catch (e) {
+    const he = e as HttpError;
+    const response = he.response;
+    let name: string;
+    let error: string | undefined = undefined;
+    if (response) {
+      name = `open-ticket:${
+        he.response?.status === 429 ? 'rate-limit' : 'error'
+      }`;
+      error = response.toString();
+    } else {
+      name = 'open-ticket:no-response';
+    }
+    Telemetry.sendEvent({
+      name,
+      properties: {
+        error,
+      },
+    });
+    UI.error(
+      `${chalk.red('!')} A failure occurred attempting to create a ticket.
+
+${chalk.red('!')} This failure has been reported to AppLand.`
+    );
+  }
+}

--- a/packages/cli/src/lib/ticket/zendesk.ts
+++ b/packages/cli/src/lib/ticket/zendesk.ts
@@ -1,0 +1,80 @@
+// There is a Zendesk API client: https://github.com/blakmatrix/node-zendesk . It appears to have
+// some issues, notably incomplete typing (https://github.com/blakmatrix/node-zendesk/issues/251).
+// We're only making a single API call here, so just use Axios instead.
+import axios, { AxiosError } from 'axios';
+import stripAnsi from 'strip-ansi';
+import { HttpError } from '../../cmds/errors';
+
+export const APPMAP_SUPPORT_URL =
+  process.env.APPMAP_SUPPORT_URL || 'https://appland.zendesk.com';
+
+export async function createRequest(
+  errors: string[],
+  email: any,
+  name: any
+): Promise<number> {
+  const body = JSON.stringify({
+    request: {
+      comment: {
+        body: `Messages:
+${errors.map((e) => `===\n${stripAnsi(e)}\n===`).join('\n')}`,
+      },
+      subject: `Agent install failure`,
+      requester: {
+        email,
+        name,
+      },
+    },
+  });
+
+  try {
+    const headers = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    };
+    // Authorization it not required to create a Zendesk request. Without it, though, the API
+
+    // endpoint is limited to 5 requests per hour, which is a nuisance when doing development.
+    //
+    // Per https://developer.zendesk.com/api-reference/ticketing/introduction/#api-token, the format
+    // for ZENDESK_AUTHZ is {email_address}msg, {ken:{api_token}.
+    const zendeskAuthz = process.env.ZENDESK_AUTHZ;
+    if (zendeskAuthz) {
+      body: headers['Authorization'] = `Basic ${Buffer.from(
+        zendeskAuthz
+      ).toString('base64')}`;
+    }
+
+    const {
+      status,
+      request,
+      data: res,
+    } = await axios
+      .create({
+        baseURL: APPMAP_SUPPORT_URL,
+        headers,
+      })
+      .post('/api/v2/requests.json', body);
+
+    return res.request.id;
+  } catch (e) {
+    const ae = e as AxiosError;
+    const msg = 'Failed to create a Zendesk Request';
+    if (!ae.response) {
+      throw new HttpError(msg);
+    }
+
+    const response = ae.response;
+    throw new HttpError(msg, {
+      status: response.status,
+      headers: response.headers,
+      body: JSON.stringify(response.data),
+      toString: () =>
+        JSON.stringify(
+          response,
+          (k, v) => (k !== 'request' ? v : undefined),
+          2
+        ),
+    });
+  }
+}

--- a/packages/cli/tests/helper.ts
+++ b/packages/cli/tests/helper.ts
@@ -1,0 +1,34 @@
+import sinon from 'sinon';
+import extend from 'sinon/lib/sinon/util/core/extend';
+import Telemetry from '../src/telemetry';
+
+export function withSandbox() {
+  // The sinon doc says the default export is a sandbox, but it actually isn't (which is what this
+  // issue is getting at https://github.com/sinonjs/sinon/issues/1795). It's really a sandbox with
+  // some more methods added in:
+  const api = sinon.createSandbox();
+  extend(api, sinon);
+
+  return api;
+}
+export function withStubbedTelemetry(sandbox: sinon.SinonSandbox) {
+  beforeEach(() => {
+    // Stub all Telemetry methods. flush still needs to work, though.
+    sandbox.stub(Telemetry);
+    const callCB = (cb) => {
+      return cb();
+    };
+    (Telemetry.flush as sinon.SinonStub).callsFake(callCB);
+  });
+
+  afterEach(() => {
+    // This bug https://github.com/sinonjs/sinon/issues/2384 acknowledges that
+    // sinon.restore doesn't restore static methods. It suggests
+    // sinon.restoreObject as a workaround, but restoreObject is currently
+    // missing from @types/sinon.
+    //
+    // This hacks around both problems:
+    sandbox['restoreObject'](Telemetry);
+    sandbox.restore();
+  });
+}

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -24,6 +24,7 @@ import 'jest-sinon';
 import GradleInstaller from '../../../src/cmds/agentInstaller/gradleInstaller';
 import MavenInstaller from '../../../src/cmds/agentInstaller/mavenInstaller';
 
+import { withStubbedTelemetry } from '../../helper';
 const fixtureDir = path.join(__dirname, '..', 'fixtures');
 tmp.setGracefulCleanup();
 
@@ -58,26 +59,11 @@ const invokeCommand = (
 };
 
 describe('install sub-command', () => {
+  withStubbedTelemetry(sinon);
+
   let projectDir: string;
   beforeEach(() => {
-    // Stub all Telemetry methods. flush still needs to work, though.
-    sinon.stub(Telemetry);
-    const callCB = (cb) => {
-      return cb();
-    };
-    (Telemetry.flush as sinon.SinonStub).callsFake(callCB);
-    projectDir = tmp.dirSync({} as any).name;
-  });
 
-  afterEach(() => {
-    // This bug https://github.com/sinonjs/sinon/issues/2384 acknowledges that
-    // sinon.restore doesn't restore static methods. It suggests
-    // sinon.restoreObject as a workaround, but restoreObject is currently
-    // missing from @types/sinon.
-    //
-    // This hacks around both problems:
-    sinon['restoreObject'](Telemetry);
-    sinon.restore();
   });
 
   describe('A Java project', () => {

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -24,7 +24,9 @@ import 'jest-sinon';
 import GradleInstaller from '../../../src/cmds/agentInstaller/gradleInstaller';
 import MavenInstaller from '../../../src/cmds/agentInstaller/mavenInstaller';
 
+import * as openTicket from '../../../src/lib/ticket/openTicket';
 import { withStubbedTelemetry } from '../../helper';
+
 const fixtureDir = path.join(__dirname, '..', 'fixtures');
 tmp.setGracefulCleanup();
 
@@ -63,7 +65,10 @@ describe('install sub-command', () => {
 
   let projectDir: string;
   beforeEach(() => {
+    // don't open any tickets
+    sinon.stub(openTicket, 'openTicket').resolves();
 
+    projectDir = tmp.dirSync({} as any).name;
   });
 
   describe('A Java project', () => {

--- a/packages/cli/tests/unit/lib/openTicket.spec.ts
+++ b/packages/cli/tests/unit/lib/openTicket.spec.ts
@@ -1,0 +1,161 @@
+import 'jest-sinon';
+import sinon from 'sinon';
+import { HttpError, HttpErrorResponse } from '../../../src/cmds/errors';
+
+import UI from '../../../src/cmds/userInteraction';
+import { openTicket } from '../../../src/lib/ticket/openTicket';
+import * as zendesk from '../../../src/lib/ticket/zendesk';
+
+import Telemetry from '../../../src/telemetry';
+import { withSandbox, withStubbedTelemetry } from '../../helper';
+
+// I'm sure there's a proper way to write a matcher that will check that a sinon stub was called
+// with a matching object, a la https://jestjs.io/docs/expect#tomatchobjectobject . This will do for
+// now.
+const getNthCallArgs = (stub, nth) =>
+  (stub as sinon.SinonStub).getCall(nth).args[0];
+
+class TestErrorResponse implements HttpErrorResponse {
+  headers: Record<string, string> = {};
+  body: string = '';
+  toString(): string {
+    return `${JSON.stringify(this)}`;
+  }
+  constructor(readonly status: number) {}
+}
+
+describe('openTicket', () => {
+  beforeAll(() => {
+    // ZENDESK_AUTHZ is only for testing, make sure we run properly without it.
+    delete process.env.ZENDESK_AUTHZ;
+  });
+
+  const sandbox = withSandbox();
+  withStubbedTelemetry(sandbox);
+
+  let zdRequest: sinon.SinonStub,
+    prompt: sinon.SinonStub,
+    uiError: sinon.SinonStub;
+
+  beforeEach(() => {
+    zdRequest = sandbox.stub(zendesk, 'createRequest');
+    prompt = sandbox.stub(UI, 'prompt');
+    uiError = sandbox.stub(UI, 'error');
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('prompting', () => {
+    beforeEach(() => {
+      zdRequest.resolves();
+    });
+
+    it('proceeds when the user allows', async () => {
+      prompt.resolves({ openTicket: true });
+      await openTicket(['error']);
+      expect(prompt).toBeCalledTwice();
+      expect(getNthCallArgs(prompt, 0)).toMatchObject({ name: 'openTicket' });
+      expect(getNthCallArgs(prompt, 1)).toMatchObject([
+        { name: 'name' },
+        { name: 'email' },
+      ]);
+    });
+
+    it("doesn't prompt when the user declines", async () => {
+      prompt.resolves({ openTicket: false });
+      await openTicket(['error']);
+      expect(prompt).toBeCalledOnce();
+    });
+  });
+
+  describe('using Zendesk', () => {
+    beforeEach(() => {
+      prompt.resolves({ openTicket: true });
+    });
+
+    it('creates a request', async () => {
+      const expected = ['error'];
+      zdRequest.resolves();
+      await openTicket(expected);
+      expect(zdRequest).toBeCalledOnce();
+      expect(getNthCallArgs(zdRequest, 0)).toMatchObject(expected);
+    });
+
+    it('handles an error', async () => {
+      zdRequest.throws('an error');
+      await openTicket(['error']);
+      expect(uiError).toBeCalledOnce();
+      expect(getNthCallArgs(uiError, 0)).toMatch(
+        'A failure occurred attempting to create a ticket'
+      );
+    });
+  });
+
+  describe('telemetry event', () => {
+    [
+      {
+        example: 'gets sent the user opens a ticket',
+        condition: { openTicket: true },
+        expectation: { name: 'open-ticket:success' },
+      },
+      {
+        example: 'gets sent when the user declines to open a ticket',
+        condition: { openTicket: false },
+        expectation: { name: 'open-ticket:declined' },
+      },
+    ].forEach((e) => {
+      const { example, condition, expectation } = e;
+
+      it(example, async () => {
+        prompt.resolves(condition);
+        await openTicket(['error']);
+        expect(Telemetry.sendEvent).toBeCalledOnce();
+        expect(getNthCallArgs(Telemetry.sendEvent, 0)).toMatchObject(
+          expectation
+        );
+      });
+    });
+
+    describe('when Zendesk request fails', () => {
+      beforeEach(() => {
+        prompt.resolves({ openTicket: true });
+      });
+
+      [
+        {
+          example: 'gets sent showing an error when possible',
+          error: new HttpError('error', new TestErrorResponse(422)),
+          expectation: {
+            name: 'open-ticket:error',
+          },
+        },
+        {
+          example: 'gets sent indicating when rate-limited',
+          error: new HttpError('error', new TestErrorResponse(429)),
+          expectation: {
+            name: 'open-ticket:rate-limit',
+          },
+        },
+        {
+          example: "gets sent even when there's no response",
+          error: new HttpError('error'),
+          expectation: {
+            name: 'open-ticket:no-response',
+          },
+        },
+      ].forEach((e) => {
+        const { example, error, expectation } = e;
+        it(example, async () => {
+          zdRequest.throws(error);
+
+          await openTicket(['error']);
+          expect(Telemetry.sendEvent).toBeCalledOnce();
+          expect(getNthCallArgs(Telemetry.sendEvent, 0)).toMatchObject(
+            expectation
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/cli/tests/unit/record/record.remote.spec.ts
+++ b/packages/cli/tests/unit/record/record.remote.spec.ts
@@ -134,7 +134,7 @@ describe('record remote', () => {
         expect(next).toEqual(agentAvailableAndReady.default);
       });
     });
-    describe.only('agent is recording', () => {
+    describe('agent is recording', () => {
       beforeEach(() =>
         sinon.stub(isRecordingInProgress, 'default').resolves(true)
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,6 +97,7 @@ __metadata:
     ajv: ^8.6.3
     applicationinsights: ^2.1.4
     async: ^3.2.0
+    axios: ^0.27.2
     boxen: ^5.0.1
     chalk: ^4.1.2
     chokidar: ^3.5.1
@@ -134,6 +135,7 @@ __metadata:
     read-pkg-up: ^7.0.1
     semver: ^7.3.5
     sinon: ^11.1.2
+    strip-ansi: ^6.0.0
     style-loader: ^3.2.1
     supports-hyperlinks: ^2.2.0
     tmp: ^0.2.1
@@ -5997,12 +5999,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/sinon@npm:*, @types/sinon@npm:^10.0.11, @types/sinon@npm:^10.0.2":
+"@types/sinon@npm:*, @types/sinon@npm:^10.0.11":
   version: 10.0.11
   resolution: "@types/sinon@npm:10.0.11"
   dependencies:
     "@types/sinonjs__fake-timers": "*"
   checksum: 196f3e26985dca5dfb593592e4b64463e536c047a9f43aa2b328b16024a3b0e3fb27b7a3f3972c6ef75749f55012737eb6c63a1c2e9782b7fe5cbbd25f75fd62
+  languageName: node
+  linkType: hard
+
+"@types/sinon@npm:^10.0.2":
+  version: 10.0.13
+  resolution: "@types/sinon@npm:10.0.13"
+  dependencies:
+    "@types/sinonjs__fake-timers": "*"
+  checksum: 46a14c888db50f0098ec53d451877e0111d878ec4a653b9e9ed7f8e54de386d6beb0e528ddc3e95cd3361a8ab9ad54e4cca33cd88d45b9227b83e9fc8fb6688a
   languageName: node
   linkType: hard
 
@@ -8399,6 +8410,16 @@ __metadata:
   dependencies:
     follow-redirects: ^1.14.0
   checksum: 44245f24ac971e7458f3120c92f9d66d1fc695e8b97019139de5b0cc65d9b8104647db01e5f46917728edfc0cfd88eb30fc4c55e6053eef4ace76768ce95ff3c
+  languageName: node
+  linkType: hard
+
+"axios@npm:^0.27.2":
+  version: 0.27.2
+  resolution: "axios@npm:0.27.2"
+  dependencies:
+    follow-redirects: ^1.14.9
+    form-data: ^4.0.0
+  checksum: 38cb7540465fe8c4102850c4368053c21683af85c5fdf0ea619f9628abbcb59415d1e22ebc8a6390d2bbc9b58a9806c874f139767389c862ec9b772235f06854
   languageName: node
   linkType: hard
 
@@ -14288,6 +14309,16 @@ __metadata:
     debug:
       optional: true
   checksum: 40c67899c2e3149a27e8b6498a338ff27f39fe138fde8d7f0756cb44b073ba0bfec3d52af28f20c5bdd67263d564d0d8d7b5efefd431de95c18c42f7b4aef457
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.14.9":
+  version: 1.15.1
+  resolution: "follow-redirects@npm:1.15.1"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 6aa4e3e3cdfa3b9314801a1cd192ba756a53479d9d8cca65bf4db3a3e8834e62139245cd2f9566147c8dfe2efff1700d3e6aefd103de4004a7b99985e71dd533
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes applandinc/board#118 .

Early Loom of the flow: https://www.loom.com/share/377a1350fab84bf5a23afb13e9b79038 .
Transcript with these changes:
```! Installation failed. View error details? Yes

An error occurred while running the command: pip install -r requirements.txt
The command exited with code 3
>  ERROR: Could not find an activated virtualenv (required).
! 
Would you like to provide your name and email address to open a support ticket?
The details of the error will be included automatically.
 Yes
? Your name ajp
? Your email address apotteri.appland@gmail.com
{
  "name": "@appland/telemetry/open-ticket:success",
  "measurements": {},
  "properties": {
    "common.source": "@appland/telemetry",
    "common.os": "darwin",
    "common.platformversion": "21.6.0",
    "common.arch": "x64",
    "appmap.cli.machineId": "a5627e4c62e3fbf37b5ca459d422e31652366197c3045dce238c85ea3b00ca44",
    "appmap.cli.sessionId": "26ec81fc5b70aa8147366c767a7fce496fda51697496a2d48fc1bc06a5ed123d",
    "appland.telemetry.version": "1.0.0",
    "appland.telemetry.args": "/Users/ajp/src/applandinc/appmap-js/packages/cli/src/cli.ts install -d /tmp/foo"
  }
}

   ╭───────────────────────────────────────────────────────╮
   │                                                       │
   │   Ticket 26 was successfully opened on your behalf.   │
   │                                                       │
   │   Thank you very much for reporting this error.       │
   │   Please check your email for next steps.             │
   │                                                       │
   ╰───────────────────────────────────────────────────────╯
```
The only real difference between these changes and what's in the Loom is that the user can now see the error before submitting the ticket, an there are Telemetry events getting generate.