### PR TITLE
fix: Don't prompt to create ticket on success

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/install-agent.ts
+++ b/packages/cli/src/cmds/agentInstaller/install-agent.ts
@@ -215,9 +215,9 @@ const _handler = async (
     errors.push(installerError);
   }
 
-  await openTicket(errors.map((e) => e.message));
-
   if (errors.length) {
+    await openTicket(errors.map((e) => e.message));
+
     const reason = new Error(errors.map((e) => e.message).join('\n'));
     return { exitCode: 1, err: reason };
   }


### PR DESCRIPTION
Don't prompt the user to create a ticket if install is successful.