### PR TITLE
Create a ticket when "record test" fails

### DIFF
--- a/packages/cli/jest-setup.js
+++ b/packages/cli/jest-setup.js
@@ -1,0 +1,11 @@
+const sinon = require('sinon');
+
+beforeEach(() => {
+  try {
+    if (!('calls' in console.log)) sinon.stub(console, 'log').returns();
+    if (!('calls' in console.warn)) sinon.stub(console, 'warn').returns();
+    if (!('calls' in console.error)) sinon.stub(console, 'error').returns();
+  } catch (e) {
+    console.error(e);
+  }
+});

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -1,5 +1,6 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
+  setupFilesAfterEnv: ['./jest-setup'],
   preset: 'ts-jest',
   testEnvironment: 'node',
   testTimeout: parseInt(process.env.TEST_TIMEOUT, 10) || 5000,

--- a/packages/cli/src/cmds/record/state/testCasesComplete.ts
+++ b/packages/cli/src/cmds/record/state/testCasesComplete.ts
@@ -1,10 +1,26 @@
+import chalk from 'chalk';
+import { openTicket } from '../../../lib/ticket/openTicket';
+import UI from '../../userInteraction';
 import printAppMapCount from '../action/printAppMapCount';
 import RecordContext from '../recordContext';
 
 export default async function testCasesComplete(
   recordContext: RecordContext
 ): Promise<undefined> {
-  await recordContext.populateAppMapCount();
+  // Handle command failures here, rather than in a separate state, so we maintain compatibility
+  // with the Azure Function that processes telemetry events.
+  if (recordContext.failures > 0 || recordContext.appMapsCreated === 0) {
+    UI.warn(
+      `\n${chalk.yellow('!')} The test commands failed to create AppMaps\n`
+    );
+
+    const errors: string[] = recordContext.output || [
+      'Test command failed with no output',
+    ];
+    await openTicket(errors);
+
+    return;
+  }
 
   await printAppMapCount(recordContext.appMapDir);
 

--- a/packages/cli/src/cmds/record/state/testCasesComplete.ts
+++ b/packages/cli/src/cmds/record/state/testCasesComplete.ts
@@ -15,7 +15,8 @@ export default async function testCasesComplete(
     );
 
     const errors: string[] = recordContext.output || [
-      'Test command failed with no output',
+      `
+Test command failed with no output`,
     ];
     await openTicket(errors);
 

--- a/packages/cli/src/cmds/record/state/testCasesRunning.ts
+++ b/packages/cli/src/cmds/record/state/testCasesRunning.ts
@@ -1,5 +1,3 @@
-import chalk from 'chalk';
-import UI from '../../userInteraction';
 import RecordContext from '../recordContext';
 import TestCaseRecording from '../testCaseRecording';
 import { State } from '../types/state';
@@ -8,13 +6,9 @@ import testCasesComplete from './testCasesComplete';
 export default async function testCasesRunning(
   recordContext: RecordContext
 ): Promise<State> {
-  const exitCodes = await TestCaseRecording.waitFor();
+  await TestCaseRecording.waitFor(recordContext);
 
-  recordContext.exitCodes = exitCodes;
-  if (!exitCodes.every((code) => code === 0)) {
-    UI.warn(`\n${chalk.yellow('!')} Some test commands failed\n`);
-    await UI.continue('Press enter to continue');
-  }
+  await recordContext.populateAppMapCount();
 
   return testCasesComplete;
 }

--- a/packages/cli/src/cmds/record/testCaseRecording.ts
+++ b/packages/cli/src/cmds/record/testCaseRecording.ts
@@ -102,7 +102,8 @@ export default class TestCaseRecording {
           if (interruptTimeout) clearTimeout(interruptTimeout);
           if (exitCode && exitCode !== 0) {
             UI.progress(
-              `Test command failed with status code ${exitCode}: ${commandStr}`
+              `
+Test command failed with status code ${exitCode}: ${commandStr}`
             );
           }
           resolve({ exitCode, output: output.join() });

--- a/packages/cli/src/cmds/record/testCaseRecording.ts
+++ b/packages/cli/src/cmds/record/testCaseRecording.ts
@@ -8,6 +8,7 @@ import {
   readSetting,
   TestCommand,
 } from './configuration';
+import RecordContext, { RecordProcessResult } from './recordContext';
 
 let TestCommands: TestCommand[] = [];
 
@@ -60,7 +61,7 @@ export default class TestCaseRecording {
     TestCommands = testCommands;
   }
 
-  static async waitFor(): Promise<number[]> {
+  static async waitFor(ctx: RecordContext): Promise<void> {
     let maxTime: number | undefined = (await readSetting(
       'test_recording.max_time',
       -1
@@ -71,7 +72,9 @@ export default class TestCaseRecording {
     if (maxTime) UI.progress(`Running tests for up to ${maxTime} seconds`);
 
     let waitTime = maxTime;
-    async function waitForProcess(process: ChildProcess): Promise<number> {
+    async function waitForProcess(
+      process: ChildProcess
+    ): Promise<{ exitCode: number; output: string }> {
       const commandStr = process.spawnargs.join(' ');
       const startTime = Date.now();
       return new Promise((resolve) => {
@@ -87,6 +90,7 @@ export default class TestCaseRecording {
           }
         }
 
+        const output: string[] = [];
         function report(exitCode: number) {
           if (reported) return;
 
@@ -101,10 +105,16 @@ export default class TestCaseRecording {
               `Test command failed with status code ${exitCode}: ${commandStr}`
             );
           }
-          resolve(exitCode);
+          resolve({ exitCode, output: output.join() });
         }
 
         if (process.exitCode) return report(process.exitCode);
+
+        const onData = (data) => {
+          output.push(data.toString());
+        };
+        process.stdout?.on('data', onData);
+        process.stderr?.on('data', onData);
 
         process.on('exit', report);
         if (waitTime) {
@@ -113,7 +123,6 @@ export default class TestCaseRecording {
       });
     }
 
-    const exitCodes: number[] = [];
     for (const cmd of TestCommands) {
       cmd.env ||= {};
       UI.progress(
@@ -122,15 +131,17 @@ export default class TestCaseRecording {
         }`
       );
       const args = cmd.command.split(' ');
+      const env = Object.assign(process.env, cmd.env);
       const proc = spawn(args[0], args.slice(1), {
-        env: Object.assign(process.env, cmd.env),
+        env,
         shell: true,
-        stdio: ['ignore', 'inherit', 'inherit'],
+        stdio: ['ignore'],
       });
-      const exitCode = await waitForProcess(proc);
-      exitCodes.push(exitCode);
+      const { exitCode, output } = await waitForProcess(proc);
+      ctx.addResult(
+        new RecordProcessResult(env, cmd.command, exitCode, output)
+      );
     }
-    return exitCodes;
   }
 
   static envString(env: Record<string, string>) {

--- a/packages/cli/src/cmds/userInteraction.ts
+++ b/packages/cli/src/cmds/userInteraction.ts
@@ -42,10 +42,17 @@ export class UserInteraction {
     return confirm;
   }
 
+  /**
+   * Prints a message to STDOUT.
+   */
   progress(msg: string) {
     console.log(msg);
   }
 
+  /**
+   * Finishes an in-progress command, showing a success indicator at the beginning of the line.
+   * Prints an optional message inside of a box.
+   */
   success(msg?: string, align: 'center' | 'left' | 'right' = 'center') {
     if (this.spinner.isSpinning) {
       this.spinner.succeed();
@@ -63,6 +70,10 @@ export class UserInteraction {
     }
   }
 
+  /**
+   * Halts an in-progress command, showing a failure indicator at the beginning of the line.
+   * Prints an optional error message to
+   */
   error(msg?: any) {
     if (this.spinner.isSpinning) {
       this.spinner.fail();
@@ -74,6 +85,9 @@ export class UserInteraction {
     }
   }
 
+  /**
+   * Prints a message to STDERR.
+   */
   warn(msg?: string) {
     console.error(msg);
   }

--- a/packages/cli/src/lib/ticket/openTicket.ts
+++ b/packages/cli/src/lib/ticket/openTicket.ts
@@ -6,8 +6,7 @@ import { createRequest as createZendeskRequest } from './zendesk';
 
 export async function openTicket(errors: string[]): Promise<void> {
   const message = `
-Would you like to provide your name and email address to open a support ticket?
-The details of the error will be included automatically.
+Would you like to submit a support request to the AppMap team to get help with this problem?
 `;
   const { name, email, openTicket } = await UI.prompt({
     type: 'confirm',

--- a/packages/cli/src/lib/ticket/openTicket.ts
+++ b/packages/cli/src/lib/ticket/openTicket.ts
@@ -5,10 +5,17 @@ import Telemetry from '../../telemetry';
 import { createRequest as createZendeskRequest } from './zendesk';
 
 export async function openTicket(errors: string[]): Promise<void> {
-  const message = `
-Would you like to submit a support request to the AppMap team to get help with this problem?
-`;
-  const { name, email, openTicket } = await UI.prompt({
+  UI.progress(
+    [
+      `Help is available from the AppMap support team! If you want assistance, the test command,
+error message, exit code, and APPMAP environment variables can be uploaded securely to the
+AppMap ZenDesk support portal. The AppMap team will respond to you by email, so we'll need your
+email address to open the support request.
+`,
+    ].join('\n')
+  );
+  const message = `Would you like to open a support request?`;
+  const { email, openTicket } = await UI.prompt({
     type: 'confirm',
     name: 'openTicket',
     default: true,
@@ -16,6 +23,16 @@ Would you like to submit a support request to the AppMap team to get help with t
     prefix: chalk.red('!'),
   }).then(async (answers) => {
     if (!answers.openTicket) {
+      UI.progress(
+        [
+          `
+You've elected not to open a support request for this problem.
+
+If you change your mind, you can always reach us by email: support@appmap.io
+`,
+        ].join('\n')
+      );
+
       Telemetry.sendEvent({
         name: 'open-ticket:declined',
       });
@@ -23,23 +40,16 @@ Would you like to submit a support request to the AppMap team to get help with t
       return { openTicket: false };
     }
 
-    const { name, email } = await UI.prompt([
-      {
-        name: 'name',
-        message: 'Your name',
-        validate: (v) => {
-          return v.trim().length > 0 || 'Please enter your name';
-        },
-      },
+    const { email } = await UI.prompt([
       {
         name: 'email',
-        message: 'Your email address',
+        message:
+          'Please provide your email address, so that we can contact you with a response:',
         validate: (v) =>
           v.trim().length > 0 || 'Please enter your email address',
       },
     ]);
     return {
-      name,
       email,
       openTicket: true,
     };
@@ -50,32 +60,33 @@ Would you like to submit a support request to the AppMap team to get help with t
   }
 
   try {
-    const id = await createZendeskRequest(errors, email, name);
+    const id = await createZendeskRequest(errors, email);
     Telemetry.sendEvent({
       name: 'open-ticket:success',
     });
     UI.success(
-      `Ticket ${id} was successfully opened on your behalf.
+      `Thank you very much for reporting this problem.
 
-Thank you very much for reporting this error.
-Please check your email for next steps.`,
+Ticket ${id} has been successfully created on your behalf.
+
+Please monitor your email for updates. Thank you for using AppMap!`,
       'left'
     );
   } catch (e) {
     const he = e as HttpError;
     const response = he.response;
-    let name: string;
+    let eventName: string;
     let error: string | undefined = undefined;
     if (response) {
-      name = `open-ticket:${
+      eventName = `open-ticket:${
         he.response?.status === 429 ? 'rate-limit' : 'error'
       }`;
       error = response.toString();
     } else {
-      name = 'open-ticket:no-response';
+      eventName = 'open-ticket:no-response';
     }
     Telemetry.sendEvent({
-      name,
+      name: eventName,
       properties: {
         error,
       },
@@ -83,7 +94,7 @@ Please check your email for next steps.`,
     UI.error(
       `${chalk.red('!')} A failure occurred attempting to create a ticket.
 
-${chalk.red('!')} This failure has been reported to AppLand.`
+${chalk.red('!')} This problem has been reported to the AppMap team.`
     );
   }
 }

--- a/packages/cli/src/lib/ticket/zendesk.ts
+++ b/packages/cli/src/lib/ticket/zendesk.ts
@@ -32,8 +32,7 @@ const debugAdapter = async (config: AxiosRequestConfig): Promise<any> => {
 
 export async function createRequest(
   errors: string[],
-  email: any,
-  name: any
+  email: any
 ): Promise<number> {
   const body = JSON.stringify({
     request: {
@@ -44,7 +43,6 @@ ${errors.map((e) => `===\n${stripAnsi(e)}\n===`).join('\n')}`,
       subject: `CLI command failure`,
       requester: {
         email,
-        name,
       },
     },
   });

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -38,9 +38,6 @@ const invokeCommand = (
 
   if (debugSwitch !== '-v') {
     // Don't scribble on the console unless we're debugging.
-    sinon.stub(console, 'log');
-    sinon.stub(console, 'warn');
-    sinon.stub(console, 'error');
     sinon.stub(UI, 'status').set(() => {});
   }
 

--- a/packages/cli/tests/unit/agentInstall/statusCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/statusCommand.spec.ts
@@ -15,9 +15,6 @@ const invokeCommand = (
   projectDir: string,
   evalResults: (err: Error | undefined, argv: any, output: string) => void
 ) => {
-  sinon.stub(console, 'log');
-  sinon.stub(console, 'warn');
-  sinon.stub(console, 'error');
   return yargs
     .command(require('../../../src/cmds/agentInstaller/status').default)
     .parse(`status ${projectDir}`, {}, (err, argv, output) => {
@@ -38,7 +35,9 @@ describe('status sub-command', () => {
       .stub(AgentStatusProcedure.prototype, 'getEnvironmentForDisplay')
       .resolves(['env']);
 
-    const installer = stubInterface<AgentInstaller>({verifyCommand: undefined});
+    const installer = stubInterface<AgentInstaller>({
+      verifyCommand: undefined,
+    });
 
     getInstallersForProject = sinon
       .stub(ProjectConfiguration, 'getProjects')

--- a/packages/cli/tests/unit/fingerprint/fingerprintQueue.spec.ts
+++ b/packages/cli/tests/unit/fingerprint/fingerprintQueue.spec.ts
@@ -1,5 +1,5 @@
 import FingerprintQueue from '../../../src/fingerprint/fingerprintQueue';
-import sinon from 'sinon';
+import sinon, { SinonStub } from 'sinon';
 import { verbose } from '../../../src/utils';
 
 describe(FingerprintQueue, () => {
@@ -9,13 +9,13 @@ describe(FingerprintQueue, () => {
   });
 
   it('gracefully handles files which cannot be read', async () => {
-    const consoleLog = sinon.stub(console, 'log');
-
     const queue = new FingerprintQueue();
     queue.push('missing-file.appmap.json');
     await queue.process();
 
-    expect(consoleLog.callCount).toBe(1);
-    expect(consoleLog.getCall(0).args[0]).toMatch(/does not exist/);
+    expect((console.log as SinonStub).callCount).toBe(1);
+    expect((console.log as SinonStub).getCall(0).args[0]).toMatch(
+      /does not exist/
+    );
   });
 });

--- a/packages/cli/tests/unit/lib/openTicket.spec.ts
+++ b/packages/cli/tests/unit/lib/openTicket.spec.ts
@@ -57,7 +57,6 @@ describe('openTicket', () => {
       expect(prompt).toBeCalledTwice();
       expect(getNthCallArgs(prompt, 0)).toMatchObject({ name: 'openTicket' });
       expect(getNthCallArgs(prompt, 1)).toMatchObject([
-        { name: 'name' },
         { name: 'email' },
       ]);
     });

--- a/packages/cli/tests/unit/record/recordContext.spec.ts
+++ b/packages/cli/tests/unit/record/recordContext.spec.ts
@@ -1,0 +1,68 @@
+import RecordContext, {
+  RecordProcessResult,
+} from '../../../src/cmds/record/recordContext';
+import * as countAppMaps from '../../../src/cmds/record/action/countAppMaps';
+import sinon from 'sinon';
+
+describe('RecordContext', () => {
+  let resultsStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sinon.stub(countAppMaps, 'default').resolves();
+    resultsStub = sinon.stub(RecordContext.prototype, 'results');
+  });
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('RecordProcessResult', () => {
+    it('filters the environment variables in results', () => {
+      const rpr = new RecordProcessResult(
+        {
+          APPMAP: 'true',
+          APPMAP_API_KEY: 'deadbeef',
+          MY_APPMAP_ENV_VAR: 'not one we recognize',
+          COLUMNS: '128',
+        },
+        '/bin/true',
+        0,
+        ''
+      );
+
+      const actual = Object.keys(rpr.env);
+
+      const expected = ['APPMAP'];
+      for (const k of expected) {
+        expect(actual).toContain(k);
+      }
+
+      const filteredKeys = ['APPMAP_API_KEY', 'MY_APPMAP_ENV_VAR', 'COLUMNS'];
+      for (const k of filteredKeys) {
+        expect(actual).not.toContain(k);
+      }
+    });
+  });
+
+  describe('counting failures', () => {
+    beforeEach(() => {
+      // Turn off RecordContext's precondition check that results are present, to make it easier to
+      // test exitCodes.
+      resultsStub.value([]);
+    });
+
+    [
+      { codes: [], expectation: 0 },
+      { codes: [0], expectation: 0 },
+      { codes: [2], expectation: 1 },
+      { codes: [0, 0], expectation: 0 },
+      { codes: [0, 1], expectation: 1 },
+    ].forEach((e) => {
+      const { codes, expectation } = e;
+      (e['fn'] || it)(`has exit codes ${JSON.stringify(codes)}`, () => {
+        const ctx = new RecordContext('.');
+        sinon.stub(ctx, 'exitCodes').value(codes);
+        expect(ctx.failures).toEqual(expectation);
+      });
+    });
+  });
+});

--- a/packages/cli/tests/unit/record/testCaseRecording.spec.ts
+++ b/packages/cli/tests/unit/record/testCaseRecording.spec.ts
@@ -1,6 +1,7 @@
 import sinon from 'sinon';
 
 import * as configuration from '../../../src/cmds/record/configuration';
+import RecordContext from '../../../src/cmds/record/recordContext';
 import TestCaseRecording from '../../../src/cmds/record/testCaseRecording';
 import UI from '../../../src/cmds/userInteraction';
 
@@ -23,7 +24,7 @@ describe('record.testCaseRecording', () => {
       const stubUI = sinon.stub(UI, 'progress');
 
       await TestCaseRecording.start();
-      await TestCaseRecording.waitFor();
+      await TestCaseRecording.waitFor(new RecordContext('.'));
 
       expect(stubUI.getCalls().map((c) => c.firstArg)).toEqual([
         'Running test command: sleep 0.01',
@@ -53,7 +54,7 @@ describe('record.testCaseRecording', () => {
       const stubUI = sinon.stub(UI, 'progress');
 
       await TestCaseRecording.start();
-      await TestCaseRecording.waitFor();
+      await TestCaseRecording.waitFor(new RecordContext('.'));
 
       expect(stubUI.getCalls().map((c) => c.firstArg)).toEqual([
         'Running tests for up to 0.01 seconds',
@@ -79,7 +80,7 @@ describe('record.testCaseRecording', () => {
       const stubUI = sinon.stub(UI, 'progress');
 
       await TestCaseRecording.start();
-      await TestCaseRecording.waitFor();
+      await TestCaseRecording.waitFor(new RecordContext('.'));
 
       expect(stubUI.getCalls().map((c) => c.firstArg)).toEqual([
         'Running test command: foobar',

--- a/packages/cli/tests/unit/record/testCaseRecording.spec.ts
+++ b/packages/cli/tests/unit/record/testCaseRecording.spec.ts
@@ -84,7 +84,8 @@ describe('record.testCaseRecording', () => {
 
       expect(stubUI.getCalls().map((c) => c.firstArg)).toEqual([
         'Running test command: foobar',
-        'Test command failed with status code 127: /bin/sh -c foobar',
+        `
+Test command failed with status code 127: /bin/sh -c foobar`,
       ]);
     });
   });

--- a/packages/cli/tests/unit/record/testCasesComplete.spec.ts
+++ b/packages/cli/tests/unit/record/testCasesComplete.spec.ts
@@ -1,0 +1,51 @@
+import sinon from 'sinon';
+import 'jest-sinon';
+import RecordContext from '../../../src/cmds/record/recordContext';
+import testCasesComplete from '../../../src/cmds/record/state/testCasesComplete';
+import * as openTicket from '../../../src/lib/ticket/openTicket';
+
+describe('testCasesComplete', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('opening tickets', () => {
+    let rc: RecordContext, openTicketStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      rc = new RecordContext('.');
+      sinon.stub(rc, 'output').value(['']);
+      openTicketStub = sinon.stub(openTicket, 'openTicket').resolves();
+    });
+
+    it('opens a ticket when test commands fail', async () => {
+      sinon.stub(rc, 'failures').value(1);
+
+      await testCasesComplete(rc);
+
+      expect(openTicketStub).toBeCalledOnce();
+    });
+
+    describe('when test commands succeed', () => {
+      beforeEach(() => {
+        sinon.stub(rc, 'failures').value(0);
+      });
+
+      it('opens a ticket when no AppMaps are created', async () => {
+        sinon.stub(rc, 'appMapsCreated').value(0);
+
+        await testCasesComplete(rc);
+
+        expect(openTicketStub).toBeCalledOnce();
+      });
+
+      it('does not open a ticket when AppMaps are created', async () => {
+        sinon.stub(rc, 'appMapsCreated').value(1);
+
+        await testCasesComplete(rc);
+
+        expect(openTicketStub).not.toBeCalled();
+      });
+    });
+  });
+});

--- a/packages/telemetry/telemetry.spec.ts
+++ b/packages/telemetry/telemetry.spec.ts
@@ -4,19 +4,20 @@ import * as os from 'os';
 import Telemetry from './telemetry';
 import { name as appName, version } from './package.json';
 
-const sandbox = sinon.createSandbox();
 const invalidExpiration = () => Date.now() - 1000 * 60 * 60;
 
 describe('telemetry', () => {
-  beforeAll(() => {
+  const sandbox = sinon.createSandbox();
+  let trackEvent: sinon.SinonStub;
+  beforeEach(() => {
     // Don't accidentally send data
-    sinon.stub(Telemetry, 'client').value({
-      trackEvent: sinon.stub(),
-      flush: sinon.stub(),
+    sandbox.stub(Telemetry, 'client').value({
+      trackEvent: (trackEvent = sandbox.stub()),
+      flush: sandbox.stub(),
     });
 
     // Don't persist data locally
-    sinon.stub(Conf.prototype, 'set');
+    sandbox.stub(Conf.prototype, 'set');
   });
 
   afterEach(() => {
@@ -87,7 +88,6 @@ describe('telemetry', () => {
     });
 
     it('sends the expected telemetry data', () => {
-      const trackEvent = Telemetry.client.trackEvent as sinon.SinonStub;
       Telemetry.sendEvent({
         name: 'test',
         properties: { prop: 'value' },
@@ -118,7 +118,6 @@ describe('telemetry', () => {
     });
 
     it('does not send undefined properties', () => {
-      const trackEvent = Telemetry.client.trackEvent as sinon.SinonStub;
       Telemetry.sendEvent({
         name: 'test',
         properties: { prop: undefined },


### PR DESCRIPTION
**Please don't merge this, it needs a rebase.**

Offer the user the chance to create a ticket when `record test` has test command failures, or fails to create AppMaps.

Fixes applandinc/board#128. Fixes applandinc/board#106.