### PR TITLE
Offer to open a ticket when a remote recording request fails

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -23,7 +23,7 @@ import * as OpenAPICommand from './cmds/openapi';
 const InventoryCommand = require('./inventoryCommand');
 const OpenCommand = require('./cmds/open/open');
 const InspectCommand = require('./cmds/inspect/inspect');
-const RecordCommand = require('./cmds/record/record');
+import RecordCommand from './cmds/record/record';
 import InstallCommand from './cmds/agentInstaller/install-agent';
 import StatusCommand from './cmds/agentInstaller/status';
 import PruneCommand from './cmds/prune/prune';

--- a/packages/cli/src/cmds/agentInstaller/install-agent.ts
+++ b/packages/cli/src/cmds/agentInstaller/install-agent.ts
@@ -16,7 +16,7 @@ import { getDirectoryProperty } from './telemetryUtil';
 import { getProjects, ProjectConfiguration } from './projectConfiguration';
 import AgentInstaller from './agentInstaller';
 import { ProcessLog } from './commandRunner';
-import { openTicket } from '../../lib/ticket/openTicket';
+import openTicket from '../../lib/ticket/openTicket';
 interface InstallCommandOptions {
   verbose?: any;
   projectType?: string;

--- a/packages/cli/src/cmds/record/makeRequest.ts
+++ b/packages/cli/src/cmds/record/makeRequest.ts
@@ -1,0 +1,62 @@
+import axios, { AxiosAdapter } from 'axios';
+import RemoteRecording from './remoteRecording';
+
+export class RemoteRecordingError extends Error {
+  constructor(
+    public description: string,
+    public statusCode: number,
+    public method: string,
+    public path: string,
+    msg: string
+  ) {
+    super(msg);
+  }
+
+  toString(): string {
+    return `description: ${this.description}
+status: ${this.statusCode}
+error: ${this.message}`;
+  }
+}
+
+export default async function makeRequest(
+  rr: RemoteRecording,
+  path: string,
+  method: string,
+  description: string,
+  statusCodes: number[] = [200, 201, 204],
+  adapter?: AxiosAdapter
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const { hostname: host, protocol, port } = rr.requestOptions;
+    const url = `${protocol}//${host}:${port}${path}`;
+    axios({
+      method,
+      url,
+      responseType: 'arraybuffer',
+      validateStatus: () => true, // status is checked below
+      adapter,
+    })
+      .then((response) => {
+        const statusCode = response.status;
+        const data = response.data.toString();
+
+        if (statusCodes.includes(statusCode)) {
+          resolve({ statusCode, data });
+        } else {
+          reject(
+            new RemoteRecordingError(
+              description,
+              statusCode,
+              method,
+              path,
+              data
+            )
+          );
+        }
+      })
+      .catch((e) => {
+        reject(e);
+      });
+  });
+}

--- a/packages/cli/src/cmds/record/makeRequest.ts
+++ b/packages/cli/src/cmds/record/makeRequest.ts
@@ -15,7 +15,7 @@ export class RemoteRecordingError extends Error {
   toString(): string {
     return `description: ${this.description}
 status: ${this.statusCode}
-error: ${this.message}`;
+response text: ${this.message}`;
   }
 }
 

--- a/packages/cli/src/cmds/record/record.ts
+++ b/packages/cli/src/cmds/record/record.ts
@@ -125,8 +125,8 @@ export default {
 
 async function handleRemoteError(err: RemoteRecordingError) {
   UI.error(`Something went wrong when ${err.description}:
-status: ${err.statusCode}
-request: ${err.method} ${err.path}
+HTTP status: ${err.statusCode}
+HTTP request: ${err.method} ${err.path}
 `);
 
   const message = `Would you like to see the server's response?`;

--- a/packages/cli/src/cmds/record/recordContext.ts
+++ b/packages/cli/src/cmds/record/recordContext.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import countAppMaps from './action/countAppMaps';
 import Configuration, { TestCommand } from './configuration';
+import { RemoteRecordingError } from './makeRequest';
 export class RecordProcessResult {
   constructor(
     private _env: Record<string, string>,
@@ -26,6 +27,7 @@ export default class RecordContext {
   public initialAppMapCount?: number;
   public appMapCount?: number;
   public appMapEventCount?: number;
+  public remoteError?: RemoteRecordingError;
   private _results?: RecordProcessResult[];
   public appMapDir?: string;
 

--- a/packages/cli/src/cmds/record/remoteRecording.ts
+++ b/packages/cli/src/cmds/record/remoteRecording.ts
@@ -1,48 +1,6 @@
-import { request as httpsRequest } from 'https';
-import { IncomingMessage, request as httpRequest, RequestOptions } from 'http';
+import { RequestOptions } from 'http';
+import makeRequest from './makeRequest';
 import { RemoteRecordingStatus } from './types/remoteRecordingStatus';
-import { appendFileSync } from 'fs';
-
-const HTTP = {
-  'http:': httpRequest,
-  'https:': httpsRequest,
-};
-
-const makeRequest = async (
-  rr: RemoteRecording,
-  path: string,
-  method: string,
-  statusCodes: number[] = [200, 201, 204]
-): Promise<any> => {
-  const options = Object.assign({}, rr.requestOptions, {
-    path,
-    method,
-  });
-
-  const requestFn = HTTP[rr.requestOptions.protocol!];
-  return new Promise((resolve, reject) => {
-    const req = requestFn(options, (res: IncomingMessage) => {
-      if (!statusCodes.includes(res.statusCode!)) {
-        return reject(`HTTP status code ${res.statusCode}`);
-      }
-
-      let data = '';
-      res.setEncoding('utf8');
-      res.on('data', (chunk: string) => {
-        data += chunk;
-      });
-      res.on('end', () => {
-        resolve({ statusCode: res.statusCode, data });
-      });
-    });
-
-    req.on('error', (e: Error) => {
-      reject(e.message);
-    });
-
-    req.end();
-  });
-};
 
 export default class RemoteRecording {
   constructor(public requestOptions: RequestOptions) {}
@@ -53,6 +11,7 @@ export default class RemoteRecording {
         this,
         `${this.requestOptions.path}_appmap/record`,
         'POST',
+        'starting recording',
         [200, 201, 409]
       )
     ).statusCode;
@@ -70,7 +29,8 @@ export default class RemoteRecording {
         await makeRequest(
           this,
           `${this.requestOptions.path}_appmap/record`,
-          'GET'
+          'GET',
+          'checking recording status'
         )
       ).data
     );
@@ -81,6 +41,7 @@ export default class RemoteRecording {
       this,
       `${this.requestOptions.path}_appmap/record`,
       'DELETE',
+      'stopping recording',
       [200, 404]
     );
 

--- a/packages/cli/src/cmds/record/state/initial.ts
+++ b/packages/cli/src/cmds/record/state/initial.ts
@@ -2,6 +2,10 @@ import UI from '../../userInteraction';
 import RecordContext from '../recordContext';
 import { State } from '../types/state';
 
+export async function createState(method: string): Promise<State> {
+  return (await import(`./record_${method}`)).default;
+}
+
 export default async function initial(
   recordContext: RecordContext
 ): Promise<State> {
@@ -19,5 +23,5 @@ export default async function initial(
   const method = choices[methodName];
 
   recordContext.recordMethod = method;
-  return (await import(`./record_${method}`)).default;
+  return createState.bind(null, method);
 }

--- a/packages/cli/src/cmds/record/state/testCasesComplete.ts
+++ b/packages/cli/src/cmds/record/state/testCasesComplete.ts
@@ -19,7 +19,8 @@ export default async function testCasesComplete(
       `
 Test command failed with no output`,
     ];
-    await openTicket(errors);
+    const helpMsg = ` If you want assistance, the test command, error message, exit code, and APPMAP environment variables can be uploaded securely to the AppMap ZenDesk support portal.`;
+    await openTicket(errors, helpMsg);
 
     return;
   }

--- a/packages/cli/src/cmds/record/state/testCasesComplete.ts
+++ b/packages/cli/src/cmds/record/state/testCasesComplete.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import chalk from 'chalk';
-import { openTicket } from '../../../lib/ticket/openTicket';
+import openTicket from '../../../lib/ticket/openTicket';
 import UI from '../../userInteraction';
 import printAppMapCount from '../action/printAppMapCount';
 import RecordContext from '../recordContext';

--- a/packages/cli/src/cmds/record/state/testCasesComplete.ts
+++ b/packages/cli/src/cmds/record/state/testCasesComplete.ts
@@ -15,10 +15,10 @@ export default async function testCasesComplete(
       `\n${chalk.yellow('!')} The test commands failed to create AppMaps\n`
     );
 
-    const errors: string[] = recordContext.output || [
-      `
-Test command failed with no output`,
-    ];
+    const errors: string | string[] =
+      recordContext.output?.join('\n').length > 0
+        ? recordContext.output
+        : `[Test command failed with no output]`;
     const helpMsg = ` If you want assistance, the test command, error message, exit code, and APPMAP environment variables can be uploaded securely to the AppMap ZenDesk support portal.`;
     await openTicket(errors, helpMsg);
 

--- a/packages/cli/src/cmds/record/test/isAgentAvailable.ts
+++ b/packages/cli/src/cmds/record/test/isAgentAvailable.ts
@@ -13,7 +13,7 @@ export default async function isAgentAvailable({
     UI.success(`AppMap agent is available at ${location}`);
     return true;
   } catch (e: any) {
-    UI.error(`AppMap agent is not avaliable at ${location}: ${e.toString()}`);
+    UI.error(`AppMap agent is not available at ${location}: ${e.toString()}`);
     return false;
   }
 }

--- a/packages/cli/src/cmds/record/test/isAgentAvailable.ts
+++ b/packages/cli/src/cmds/record/test/isAgentAvailable.ts
@@ -1,10 +1,12 @@
 import UI from '../../userInteraction';
+import { RemoteRecordingError } from '../makeRequest';
 import RecordContext from '../recordContext';
 import RemoteRecording from '../remoteRecording';
 
-export default async function isAgentAvailable({
-  configuration,
-}: RecordContext): Promise<boolean> {
+export default async function isAgentAvailable(
+  recordContext: RecordContext
+): Promise<boolean> {
+  const { configuration } = recordContext;
   const ro = configuration.requestOptions();
   const location = configuration.locationString();
   UI.status = `Checking if the AppMap agent is available at ${location}`;
@@ -13,7 +15,13 @@ export default async function isAgentAvailable({
     UI.success(`AppMap agent is available at ${location}`);
     return true;
   } catch (e: any) {
-    UI.error(`AppMap agent is not available at ${location}: ${e.toString()}`);
+    if (e instanceof RemoteRecordingError) {
+      recordContext.remoteError = e;
+    }
+    UI.error(`AppMap agent is not available at ${location}.`);
+    if (await UI.confirm(`Would you like to see the server's response?`)) {
+      UI.error(e.toString());
+    }
     return false;
   }
 }

--- a/packages/cli/src/cmds/runCommand.ts
+++ b/packages/cli/src/cmds/runCommand.ts
@@ -71,7 +71,9 @@ export default async function runCommand(
       }
       flushTelemetry(ExitCode.Error, err);
     } else {
-      // idk why this wouldn't be an Error ^^
+      // You'll wind up here if the object thrown wasn't an instance of Error. An obvious way this
+      // can happen is `throw 'Fail'`. A less obvious way is rejecting a Promise with something
+      // other than an error, e.g. `reject('Fail')`.
       throw err;
     }
   }

--- a/packages/cli/src/lib/ticket/openTicket.ts
+++ b/packages/cli/src/lib/ticket/openTicket.ts
@@ -4,12 +4,13 @@ import UI from '../../cmds/userInteraction';
 import Telemetry from '../../telemetry';
 import { createRequest as createZendeskRequest } from './zendesk';
 
-export async function openTicket(errors: string[]): Promise<void> {
+export async function openTicket(
+  errors: string | string[],
+  helpMsg: string = ''
+): Promise<void> {
   UI.progress(
     [
-      `Help is available from the AppMap support team! If you want assistance, the test command,
-error message, exit code, and APPMAP environment variables can be uploaded securely to the
-AppMap ZenDesk support portal. The AppMap team will respond to you by email, so we'll need your
+      `Help is available from the AppMap support team!${helpMsg} The AppMap team will respond to you by email, so we'll need your
 email address to open the support request.
 `,
     ].join('\n')

--- a/packages/cli/src/lib/ticket/openTicket.ts
+++ b/packages/cli/src/lib/ticket/openTicket.ts
@@ -2,9 +2,9 @@ import chalk from 'chalk';
 import { HttpError } from '../../cmds/errors';
 import UI from '../../cmds/userInteraction';
 import Telemetry from '../../telemetry';
-import { createRequest as createZendeskRequest } from './zendesk';
+import createZendeskRequest from './zendesk';
 
-export async function openTicket(
+export default async function openTicket(
   errors: string | string[],
   helpMsg: string = ''
 ): Promise<void> {

--- a/packages/cli/src/lib/ticket/openTicket.ts
+++ b/packages/cli/src/lib/ticket/openTicket.ts
@@ -6,24 +6,32 @@ import createZendeskRequest from './zendesk';
 
 export default async function openTicket(
   errors: string | string[],
-  helpMsg: string = ''
+  helpMsg: string = ' ',
+  prompt: boolean = true
 ): Promise<void> {
-  UI.progress(
-    [
-      `Help is available from the AppMap support team!${helpMsg} The AppMap team will respond to you by email, so we'll need your
-email address to open the support request.
-`,
-    ].join('\n')
-  );
-  const message = `Would you like to open a support request?`;
-  const { email, openTicket } = await UI.prompt({
-    type: 'confirm',
-    name: 'openTicket',
-    default: true,
-    message,
-    prefix: chalk.red('!'),
-  }).then(async (answers) => {
-    if (!answers.openTicket) {
+  errors = !Array.isArray(errors) ? [errors] : errors;
+
+  UI.progress(`
+Help is available from the AppMap support team!${helpMsg}
+`);
+
+  if (
+    await UI.confirm(`Details of the error will be provided to the support team.
+  Would you like to see them?`)
+  ) {
+    UI.error(errors.join('\n'));
+  }
+
+  if (prompt) {
+    const message = `Would you like to open a support request?`;
+    const { openTicket } = await UI.prompt({
+      type: 'confirm',
+      name: 'openTicket',
+      default: true,
+      message,
+    });
+
+    if (!openTicket) {
       UI.progress(
         [
           `
@@ -38,27 +46,18 @@ If you change your mind, you can always reach us by email: support@appmap.io
         name: 'open-ticket:declined',
       });
 
-      return { openTicket: false };
+      return;
     }
-
-    const { email } = await UI.prompt([
-      {
-        name: 'email',
-        message:
-          'Please provide your email address, so that we can contact you with a response:',
-        validate: (v) =>
-          v.trim().length > 0 || 'Please enter your email address',
-      },
-    ]);
-    return {
-      email,
-      openTicket: true,
-    };
-  });
-
-  if (!openTicket) {
-    return;
   }
+
+  const { email } = await UI.prompt([
+    {
+      name: 'email',
+      message: `The AppMap team will respond to you by email. 
+Please provide your email address to open the support request:`,
+      validate: (v) => v.trim().length > 0 || 'Please enter your email address',
+    },
+  ]);
 
   try {
     const id = await createZendeskRequest(errors, email);

--- a/packages/cli/src/lib/ticket/zendesk.ts
+++ b/packages/cli/src/lib/ticket/zendesk.ts
@@ -30,10 +30,11 @@ const debugAdapter = async (config: AxiosRequestConfig): Promise<any> => {
   });
 };
 
-export async function createRequest(
-  errors: string[],
+export default async function createRequest(
+  errors: string | string[],
   email: any
 ): Promise<number> {
+  errors = !Array.isArray(errors) ? [errors] : errors;
   const body = JSON.stringify({
     request: {
       comment: {

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -66,7 +66,7 @@ describe('install sub-command', () => {
     projectDir = tmp.dirSync({} as any).name;
 
     // don't open any tickets
-    openTicketStub = sinon.stub(openTicket, 'openTicket');
+    openTicketStub = sinon.stub(openTicket, 'default');
     openTicketStub.resolves();
   });
 

--- a/packages/cli/tests/unit/lib/openTicket.spec.ts
+++ b/packages/cli/tests/unit/lib/openTicket.spec.ts
@@ -3,8 +3,8 @@ import sinon from 'sinon';
 import { HttpError, HttpErrorResponse } from '../../../src/cmds/errors';
 
 import UI from '../../../src/cmds/userInteraction';
-import { openTicket } from '../../../src/lib/ticket/openTicket';
-import * as zendesk from '../../../src/lib/ticket/zendesk';
+import openTicket from '../../../src/lib/ticket/openTicket';
+import * as createRequest from '../../../src/lib/ticket/zendesk';
 
 import Telemetry from '../../../src/telemetry';
 import { withSandbox, withStubbedTelemetry } from '../../helper';
@@ -38,7 +38,7 @@ describe('openTicket', () => {
     uiError: sinon.SinonStub;
 
   beforeEach(() => {
-    zdRequest = sandbox.stub(zendesk, 'createRequest');
+    zdRequest = sandbox.stub(createRequest, 'default');
     prompt = sandbox.stub(UI, 'prompt');
     uiError = sandbox.stub(UI, 'error');
   });
@@ -53,17 +53,15 @@ describe('openTicket', () => {
 
     it('proceeds when the user allows', async () => {
       prompt.resolves({ openTicket: true });
-      await openTicket(['error']);
+      await openTicket('error');
       expect(prompt).toBeCalledTwice();
       expect(getNthCallArgs(prompt, 0)).toMatchObject({ name: 'openTicket' });
-      expect(getNthCallArgs(prompt, 1)).toMatchObject([
-        { name: 'email' },
-      ]);
+      expect(getNthCallArgs(prompt, 1)).toMatchObject([{ name: 'email' }]);
     });
 
     it("doesn't prompt when the user declines", async () => {
       prompt.resolves({ openTicket: false });
-      await openTicket(['error']);
+      await openTicket('error');
       expect(prompt).toBeCalledOnce();
     });
   });
@@ -83,7 +81,7 @@ describe('openTicket', () => {
 
     it('handles an error', async () => {
       zdRequest.throws('an error');
-      await openTicket(['error']);
+      await openTicket('error');
       expect(uiError).toBeCalledOnce();
       expect(getNthCallArgs(uiError, 0)).toMatch(
         'A failure occurred attempting to create a ticket'
@@ -108,7 +106,7 @@ describe('openTicket', () => {
 
       it(example, async () => {
         prompt.resolves(condition);
-        await openTicket(['error']);
+        await openTicket('error');
         expect(Telemetry.sendEvent).toBeCalledOnce();
         expect(getNthCallArgs(Telemetry.sendEvent, 0)).toMatchObject(
           expectation
@@ -148,7 +146,7 @@ describe('openTicket', () => {
         it(example, async () => {
           zdRequest.throws(error);
 
-          await openTicket(['error']);
+          await openTicket('error');
           expect(Telemetry.sendEvent).toBeCalledOnce();
           expect(getNthCallArgs(Telemetry.sendEvent, 0)).toMatchObject(
             expectation

--- a/packages/cli/tests/unit/lib/openTicket.spec.ts
+++ b/packages/cli/tests/unit/lib/openTicket.spec.ts
@@ -35,10 +35,12 @@ describe('openTicket', () => {
 
   let zdRequest: sinon.SinonStub,
     prompt: sinon.SinonStub,
+    confirm: sinon.SinonStub,
     uiError: sinon.SinonStub;
 
   beforeEach(() => {
     zdRequest = sandbox.stub(createRequest, 'default');
+    confirm = sandbox.stub(UI, 'confirm');
     prompt = sandbox.stub(UI, 'prompt');
     uiError = sandbox.stub(UI, 'error');
   });
@@ -52,6 +54,7 @@ describe('openTicket', () => {
     });
 
     it('proceeds when the user allows', async () => {
+      confirm.resolves(false);
       prompt.resolves({ openTicket: true });
       await openTicket('error');
       expect(prompt).toBeCalledTwice();

--- a/packages/cli/tests/unit/record/makeRequest.spec.ts
+++ b/packages/cli/tests/unit/record/makeRequest.spec.ts
@@ -1,0 +1,51 @@
+import { AxiosAdapter } from 'axios';
+import makeRequest, {
+  RemoteRecordingError,
+} from '../../../src/cmds/record/makeRequest';
+import RemoteRecording from '../../../src/cmds/record/remoteRecording';
+
+describe('makeRequest', () => {
+  let rr: RemoteRecording;
+  beforeEach(() => {
+    rr = new RemoteRecording({});
+  });
+
+  it('resolves when the status code matches', async () => {
+    const expected = {
+      data: 'data',
+      statusCode: 200,
+    };
+
+    const adapter: AxiosAdapter = async (config) => {
+      return new Promise((resolve) => {
+        resolve({
+          status: expected.statusCode,
+          data: expected.data,
+          headers: {},
+          statusText: '',
+          config,
+        });
+      });
+    };
+    await expect(
+      makeRequest(rr, '/', 'GET', 'testing', [200], adapter)
+    ).resolves.toEqual(expected);
+  });
+
+  it("rejects when the status code doesn't match", async () => {
+    const adapter: AxiosAdapter = async (config) => {
+      return new Promise((resolve) => {
+        resolve({
+          status: 500,
+          data: '',
+          statusText: 'Server Error',
+          headers: {},
+          config,
+        });
+      });
+    };
+    await expect(
+      makeRequest(rr, '/', 'GET', 'testing', [200], adapter)
+    ).rejects.toThrow(RemoteRecordingError);
+  });
+});

--- a/packages/cli/tests/unit/record/record.remote.spec.ts
+++ b/packages/cli/tests/unit/record/record.remote.spec.ts
@@ -1,10 +1,11 @@
+import 'jest-sinon';
 import sinon from 'sinon';
 import * as configureHostAndPort from '../../../src/cmds/record/action/configureHostAndPort';
 import * as configureRemainingRequestOptions from '../../../src/cmds/record/action/configureRemainingRequestOptions';
 import * as detectProcessCharacteristics from '../../../src/cmds/record/action/detectProcessCharacteristics';
 import * as nameAppMap from '../../../src/cmds/record/action/nameAppMap';
 import * as saveAppMap from '../../../src/cmds/record/action/saveAppMap';
-import Configuration, * as configuration from '../../../src/cmds/record/configuration';
+import Configuration from '../../../src/cmds/record/configuration';
 import * as continueWithRequestOptionConfiguration from '../../../src/cmds/record/prompt/continueWithRequestOptionConfiguration';
 import * as recordingInProgress from '../../../src/cmds/record/prompt/recordingInProgress';
 import RecordContext from '../../../src/cmds/record/recordContext';
@@ -18,7 +19,6 @@ import * as isAgentAvailable from '../../../src/cmds/record/test/isAgentAvailabl
 import * as isRecordingInProgress from '../../../src/cmds/record/test/isRecordingInProgress';
 import { State } from '../../../src/cmds/record/types/state';
 import UI from '../../../src/cmds/userInteraction';
-
 
 function checkContext(
   context: RecordContext,

--- a/packages/cli/tests/unit/record/record.remote.spec.ts
+++ b/packages/cli/tests/unit/record/record.remote.spec.ts
@@ -78,6 +78,9 @@ describe('record remote', () => {
           );
           expect(next).toEqual(agentNotAvailable.default);
 
+          prompt.resolves({
+            option: agentNotAvailable.NextStepChoices.CONFIGURE.value,
+          });
           sinon.stub(configureRemainingRequestOptions, 'default').resolves();
 
           next = await next(recordContext);

--- a/packages/cli/tests/unit/record/record.spec.ts
+++ b/packages/cli/tests/unit/record/record.spec.ts
@@ -1,0 +1,66 @@
+import 'jest-sinon';
+import sinon from 'sinon';
+import yargs from 'yargs';
+import { RemoteRecordingError } from '../../../src/cmds/record/makeRequest';
+import * as initial from '../../../src/cmds/record/state/initial';
+import * as openTicket from '../../../src/lib/ticket/openTicket';
+import recordCmd from '../../../src/cmds/record/record';
+import UI from '../../../src/cmds/userInteraction';
+
+describe('record', () => {
+  const parser = yargs.command(recordCmd);
+  const runCommand = async () => {
+    const cmdLine = `record remote`;
+    await new Promise((resolve, reject) => {
+      parser.parse(cmdLine, {}, (err, argv, output) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(output);
+        }
+      });
+    });
+  };
+
+  describe('handling tickets', () => {
+    let initialStateStub: sinon.SinonStub,
+      promptStub: sinon.SinonStub,
+      openTicketStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      initialStateStub = sinon.stub(initial, 'createState');
+      promptStub = sinon.stub(UI, 'prompt');
+      openTicketStub = sinon.stub(openTicket, 'default');
+      openTicketStub.resolves();
+    });
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("doesn't open a ticket when no exception is thrown", async () => {
+      // Terminate the state machine immediately.
+      initialStateStub.resolves(() => undefined);
+
+      await runCommand();
+
+      expect(openTicketStub).not.toBeCalled();
+    });
+
+    it('opens a ticket when a state throws a remote recording exception', async () => {
+      // Stub the initial state so it throws an exception when entered.
+      initialStateStub.resolves(() => {
+        throw new RemoteRecordingError('testing', 500, 'GET', '/', 'fail');
+      });
+
+      // Don't need to see the server response
+      promptStub
+        .withArgs(sinon.match({ name: 'showResponse', type: 'confirm' }))
+        .resolves({ showResponse: false });
+
+      await runCommand();
+
+      // The user should have been offered the chance to open a ticket
+      expect(openTicketStub).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/packages/cli/tests/unit/record/record.test.spec.ts
+++ b/packages/cli/tests/unit/record/record.test.spec.ts
@@ -16,7 +16,8 @@ import RecordContext, {
 import Configuration from '../../../src/cmds/record/configuration';
 
 describe('record test', () => {
-  let prompt: sinon.SinonStub,
+  let confirm: sinon.SinonStub,
+    prompt: sinon.SinonStub,
     cont: sinon.SinonStub,
     recordContext: RecordContext;
 
@@ -29,6 +30,7 @@ describe('record test', () => {
   });
 
   beforeEach(() => {
+    confirm = sinon.stub(UI, 'confirm');
     prompt = sinon.stub(UI, 'prompt');
     cont = sinon.stub(UI, 'continue');
   });
@@ -139,6 +141,7 @@ describe('record test', () => {
     });
     it('and some fail', async () => {
       const stubWait = sinon.stub(TestCaseRecording, 'waitFor').resolves();
+      confirm.resolves(false);
       sinon.stub(recordContext, 'results').value([{ exitCode: 1 }]);
       prompt.resolves({ openTicket: false });
 

--- a/packages/cli/tests/unit/record/testCasesComplete.spec.ts
+++ b/packages/cli/tests/unit/record/testCasesComplete.spec.ts
@@ -16,7 +16,7 @@ describe('testCasesComplete', () => {
     beforeEach(() => {
       rc = new RecordContext(new Configuration());
       sinon.stub(rc, 'output').value(['']);
-      openTicketStub = sinon.stub(openTicket, 'openTicket').resolves();
+      openTicketStub = sinon.stub(openTicket, 'default').resolves();
       return rc.initialize();
     });
 


### PR DESCRIPTION
asciinema of the current flow: https://asciinema.org/a/aBppjvZmhPPz1tQitrOOC7VKU . Note that the final big blob of text (after I enter the email address `ajp@example.com`) is debugging output, showing the details of the request that would have been submitted to Zendesk. The user won't see this, they'll just see the confirmation that the support request was created.

You are, of course, welcome to review these changes however you see fit. I found that turning off whitespace, and comparing them side by side, made it to understand them:
<img width="754" alt="image" src="https://user-images.githubusercontent.com/4212483/187553714-61f4915f-4fa0-4ce4-9814-b434743a3eee.png">


Fixes applandinc/board#130 .
Fixes #639 .