### PR TITLE
feat: Index in watch mode guarantees all AppMap indexes are up to date

### DIFF
--- a/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.js
+++ b/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.js
@@ -39,4 +39,33 @@ describe(FingerprintWatchCommand, () => {
       expect(fs.existsSync(path.join(appMapDir, 'index.pid'))).toBeFalsy();
     });
   });
+
+  describe('indexing', () => {
+    beforeEach(() => {
+      fs.copyFileSync(
+        path.join(__dirname, '../fixtures/ruby/revoke_api_key.appmap.json'),
+        path.join(appMapDir, 'revoke_api_key.appmap.json')
+      );
+    });
+
+    it('occurs on existing un-indexed appmaps', async () => {
+      cmd = new FingerprintWatchCommand(appMapDir);
+      await cmd.execute();
+
+      const maxRetries = 10;
+      function verifyFileExists(filePath, retryCount = 0) {
+        if (fs.existsSync(filePath)) return;
+
+        if (retryCount < maxRetries) {
+          setTimeout(() => verifyFileExists(filePath, retryCount + 1), 1000);
+        } else {
+          throw new Error(
+            `File ${filePath} does not exist after ${retryCount} retries`
+          );
+        }
+      }
+
+      verifyFileExists(path.join(appMapDir, 'revoke_api_key', 'mtime'));
+    }, 11000);
+  });
 });

--- a/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.js
+++ b/packages/cli/tests/unit/fingerprint/fingerprintWatchCommand.spec.js
@@ -7,30 +7,34 @@ const { verbose } = require('../../../src/utils');
 
 const appMapDir = tmp.dirSync().name;
 
-// Because if you use arrow functions, there's no this:
-/* eslint-disable prefer-arrow-callback */
-describe(FingerprintWatchCommand, function () {
-  beforeEach(function () {
+describe(FingerprintWatchCommand, () => {
+  let cmd;
+
+  beforeEach(() => {
     verbose(process.env.DEBUG === 'true');
   });
-  afterEach(async function () {
-    await this.cmd.close();
+
+  afterEach(async () => {
+    if (cmd) {
+      cmd.close();
+      cmd = null;
+    }
     sinon.restore();
   });
 
-  describe('a pid file', function () {
-    it('is created when env var is set', async function () {
+  describe('a pid file', () => {
+    it('is created when env var is set', async () => {
       sinon.stub(process, 'env').value({ APPMAP_WRITE_PIDFILE: 'true' });
-      this.cmd = new FingerprintWatchCommand(appMapDir);
+      cmd = new FingerprintWatchCommand(appMapDir);
 
-      await this.cmd.execute();
+      await cmd.execute();
 
       expect(fs.existsSync(path.join(appMapDir, 'index.pid'))).toBeTruthy();
     });
 
-    it('is not created when env var is unset', async function () {
-      this.cmd = new FingerprintWatchCommand(appMapDir);
-      await this.cmd.execute();
+    it('is not created when env var is unset', async () => {
+      cmd = new FingerprintWatchCommand(appMapDir);
+      await cmd.execute();
 
       expect(fs.existsSync(path.join(appMapDir, 'index.pid'))).toBeFalsy();
     });


### PR DESCRIPTION
When running `index --watch`, all existing AppMaps will be considered for indexing. This differs from the previous behavior in which only AppMaps modified/created while the watcher was running would be indexed.