### PR TITLE
fix: Skip bad files when running scanner on a directory

### DIFF
--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -49,6 +49,7 @@
     "prettier": "^2.3.2",
     "semantic-release": "^19.0.2",
     "sinon": "^13.0.1",
+    "tmp-promise": "^3.0.3",
     "ts-jest": "^27.1.4",
     "ts-json-schema-generator": "^0.97.0",
     "ts-node": "^10.2.1",

--- a/packages/scanner/src/cli/scan.ts
+++ b/packages/scanner/src/cli/scan.ts
@@ -8,6 +8,7 @@ import RuleChecker from '../ruleChecker';
 import { Finding } from '../types';
 
 import AppMapIndex from '../appMapIndex';
+import assert from 'node:assert';
 
 type Result = {
   appMapMetadata: Record<string, Metadata>;
@@ -17,13 +18,51 @@ type Result = {
 async function batch<T>(
   items: readonly T[],
   size: number,
-  process: (item: T) => PromiseLike<null | undefined>
+  process: (item: T) => PromiseLike<void>
 ) {
   const left = [...items];
   while (left.length) await Promise.all(left.splice(0, size).map(process));
 }
 
-export default async function scan(files: string[], checks: Check[]): Promise<Result> {
+class Progress {
+  constructor(private numFiles: number, private numChecks: number) {
+    if (process.stdout.isTTY)
+      this.bar = new cliProgress.SingleBar(
+        { format: `Scanning [{bar}] {percentage}% | {value}/{total}` },
+        cliProgress.Presets.shades_classic
+      );
+    else {
+      this.start = this.check = this.file = this.stop = () => {};
+    }
+  }
+
+  start() {
+    this.bar?.start(this.numFiles * this.numChecks, 0);
+  }
+
+  check() {
+    this.checks += 1;
+    this.bar?.increment();
+  }
+
+  file() {
+    this.bar?.increment(this.numChecks - this.checks);
+    this.checks = 0;
+  }
+
+  stop() {
+    this.bar?.stop();
+  }
+
+  bar?: cliProgress.SingleBar;
+  checks = 0;
+}
+
+export default async function scan(
+  files: string[],
+  checks: Check[],
+  skipErrors = true
+): Promise<Result> {
   // TODO: Improve this by respecting .gitignore, or similar.
   // For now, this addresses the main problem of encountering appmap-js and its appmap.json files
   // in a bundled node_modules.
@@ -33,43 +72,42 @@ export default async function scan(files: string[], checks: Check[]): Promise<Re
   const appMapMetadata: Record<string, Metadata> = {};
   const findings: Finding[] = [];
 
-  function newProgress() {
-    if (process.stdout.isTTY) {
-      return new cliProgress.SingleBar(
-        { format: `Scanning [{bar}] {percentage}% | {value}/{total}` },
-        cliProgress.Presets.shades_classic
-      );
-    }
+  const progress = new Progress(files.length, checks.length);
 
-    return {
-      increment: () => {},
-      start: () => {},
-      stop: () => {},
-    };
-  }
-
-  const progress = newProgress();
-  progress.start(files.length * checks.length, 0);
+  let lastError = null;
+  let anySuccess = false;
 
   await batch(files, 2, async (file: string) => {
-    const appMapData = await readFile(file, 'utf8');
-    const appMap = buildAppMap(appMapData).normalize().build();
-    const appMapIndex = new AppMapIndex(appMap);
-    appMapMetadata[file] = appMap.metadata;
+    try {
+      console.log(`scanning ${file}`);
+      const appMapData = await readFile(file, 'utf8');
+      const appMap = buildAppMap(appMapData).normalize().build();
+      const appMapIndex = new AppMapIndex(appMap);
+      appMapMetadata[file] = appMap.metadata;
 
-    await Promise.all(
-      checks.map(async (check) => {
-        const matchCount = findings.length;
-        await checker.check(file, appMapIndex, check, findings);
-        progress.increment();
-        const newMatches = findings.slice(matchCount, findings.length);
-        newMatches.forEach((match) => (match.appMapFile = file));
-      })
-    );
-    return null;
+      await Promise.all(
+        checks.map(async (check) => {
+          const matchCount = findings.length;
+          await checker.check(file, appMapIndex, check, findings);
+          progress.check();
+          const newMatches = findings.slice(matchCount, findings.length);
+          newMatches.forEach((match) => (match.appMapFile = file));
+        })
+      );
+
+      anySuccess = true;
+    } catch (error) {
+      assert(error instanceof Error);
+      lastError = new Error(`Error processing "${file}"`, { cause: error });
+      if (!skipErrors) throw lastError;
+      console.warn(lastError);
+    }
+    progress.file();
   });
 
   progress.stop();
+
+  if (!anySuccess && lastError) throw lastError;
 
   return { appMapMetadata, findings };
 }

--- a/packages/scanner/src/cli/scan/scanner.ts
+++ b/packages/scanner/src/cli/scan/scanner.ts
@@ -10,6 +10,7 @@ import { ScanResults } from '../../report/scanResults';
 
 export interface Scanner {
   scan(): Promise<ScanResults>;
+  scan(skipErrors: boolean): Promise<ScanResults>;
 
   fetchFindingStatus(appId?: string, appMapDir?: string): Promise<FindingStatusListItem[]>;
 }
@@ -30,9 +31,9 @@ export default async function scanner(
 abstract class ScannerBase {
   constructor(public configuration: Configuration, public files: string[]) {}
 
-  async scan(): Promise<ScanResults> {
+  async scan(skipErrors = false): Promise<ScanResults> {
     const checks = await loadConfig(this.configuration);
-    const { appMapMetadata, findings } = await scan(this.files, checks);
+    const { appMapMetadata, findings } = await scan(this.files, checks, skipErrors);
     return new ScanResults(this.configuration, appMapMetadata, findings, checks);
   }
 }

--- a/packages/scanner/src/cli/scan/singleScan.ts
+++ b/packages/scanner/src/cli/scan/singleScan.ts
@@ -26,6 +26,8 @@ export default async function singleScan(options: SingleScanOptions): Promise<vo
   const { appmapFile, appmapDir, configuration, reportAllFindings, appId, ide, reportFile } =
     options;
 
+  const skipErrors = appmapDir !== undefined;
+
   const files = await collectAppMapFiles(appmapFile, appmapDir);
   await Promise.all(files.map(async (file) => validateFile('file', file)));
 
@@ -38,7 +40,7 @@ export default async function singleScan(options: SingleScanOptions): Promise<vo
   const startTime = Date.now();
 
   const [rawScanResults, findingStatuses] = await Promise.all([
-    scanner.scan(),
+    scanner.scan(skipErrors),
     scanner.fetchFindingStatus(appId, appmapDir),
   ]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,6 +380,7 @@ __metadata:
     sinon: ^13.0.1
     supports-hyperlinks: ^2.2.0
     tar-stream: ^2.2.0
+    tmp-promise: ^3.0.3
     ts-jest: ^27.1.4
     ts-json-schema-generator: ^0.97.0
     ts-node: ^10.2.1
@@ -27924,6 +27925,15 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
+"tmp-promise@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "tmp-promise@npm:3.0.3"
+  dependencies:
+    tmp: ^0.2.0
+  checksum: f854f5307dcee6455927ec3da9398f139897faf715c5c6dcee6d9471ae85136983ea06662eba2edf2533bdcb0fca66d16648e79e14381e30c7fb20be9c1aa62c
+  languageName: node
+  linkType: hard
+
 "tmp@npm:^0.0.33":
   version: 0.0.33
   resolution: "tmp@npm:0.0.33"
@@ -27933,7 +27943,7 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.2.1, tmp@npm:~0.2.1":
+"tmp@npm:^0.2.0, tmp@npm:^0.2.1, tmp@npm:~0.2.1":
   version: 0.2.1
   resolution: "tmp@npm:0.2.1"
   dependencies:


### PR DESCRIPTION
When running scanner in a directory scan mode, an error processing
an appmap (eg. due to malformation or too large size) will no
longer crash the process preventing scanning other maps.
A warning will be printed instead and the process continues.

If all appmaps fail, the process still exits with an error status.
If at least one succeeds, the process exits with success.

Note this change doesn't affect the scenario where you explicitly
list files using --appmap-file argument. Any failure there will
still cause the process to fail.