### PR TITLE
Recording configuration is no longer a global singleton

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "build-native": "yarn build && ./bin/build-native"
   },
   "lint-staged": {
-    "*.{js,md,json}": [
+    "*.{js,md,json,ts}": [
       "prettier --write"
     ]
   },

--- a/packages/cli/src/cmds/record/action/cancelRecording.ts
+++ b/packages/cli/src/cmds/record/action/cancelRecording.ts
@@ -1,8 +1,11 @@
+import { RequestOptions } from 'http';
 import UI from '../../userInteraction';
-import { requestOptions } from '../configuration';
+import RecordContext from '../recordContext';
 import RemoteRecording from '../remoteRecording';
 
-export default async function cancelRecording(): Promise<void> {
-  await new RemoteRecording(await requestOptions()).stop();
+export default async function cancelRecording({
+  configuration: { requestOptions },
+}: RecordContext): Promise<void> {
+  await new RemoteRecording(requestOptions()).stop();
   UI.success('The recording has been cancelled.');
 }

--- a/packages/cli/src/cmds/record/action/configureHostAndPort.ts
+++ b/packages/cli/src/cmds/record/action/configureHostAndPort.ts
@@ -1,8 +1,10 @@
 import UI from '../../userInteraction';
-import { readSetting, writeSetting } from '../configuration';
+import RecordContext from '../recordContext';
 
-export default async function configureHostAndPort() {
-  const defaultHostname = await readSetting(
+export default async function configureHostAndPort({
+  configuration,
+}: RecordContext) {
+  const defaultHostname = configuration.setting(
     'remote_recording.host',
     'localhost'
   );
@@ -14,11 +16,11 @@ export default async function configureHostAndPort() {
   });
 
   if (hostname !== defaultHostname) {
-    await writeSetting('remote_recording.host', hostname);
+    configuration.setSetting('remote_recording.host', hostname);
   }
 
   let port: number | undefined;
-  const defaultPort = await readSetting('remote_recording.port', 3000);
+  const defaultPort = configuration.setting('remote_recording.port', 3000);
   while (!port) {
     const { portNumber: answer } = await UI.prompt({
       type: 'input',
@@ -28,7 +30,9 @@ export default async function configureHostAndPort() {
     });
     port = parseInt(answer);
     if (port !== NaN && port !== defaultPort) {
-      await writeSetting('remote_recording.port', port);
+      configuration.setSetting('remote_recording.port', port);
     }
   }
+
+  await configuration.write();
 }

--- a/packages/cli/src/cmds/record/action/configureRemainingRequestOptions.ts
+++ b/packages/cli/src/cmds/record/action/configureRemainingRequestOptions.ts
@@ -1,14 +1,10 @@
 import UI from '../../userInteraction';
-import {
-  readConfigOption,
-  readSetting,
-  requestOptions,
-  writeConfigOption,
-  writeSetting,
-} from '../configuration';
+import RecordContext from '../recordContext';
 
-export default async function configureRemainingRequestOptions() {
-  const defaultPath = await readConfigOption('remote_recording.path', '/');
+export default async function configureRemainingRequestOptions({
+  configuration,
+}: RecordContext) {
+  const defaultPath = configuration.configOption('remote_recording.path', '/');
   const { baseURL: path } = await UI.prompt({
     type: 'input',
     name: 'baseURL',
@@ -21,10 +17,10 @@ export default async function configureRemainingRequestOptions() {
     if (!basePath.endsWith('/')) basePath = [basePath, '/'].join('');
     if (!basePath.startsWith('/')) basePath = ['/', basePath].join('');
 
-    await writeConfigOption('remote_recording.path', basePath);
+    configuration.setConfigOption('remote_recording.path', basePath);
   }
 
-  const defaultProtocol = await readConfigOption(
+  const defaultProtocol = configuration.configOption(
     'remote_recording.protocol',
     'http:'
   );
@@ -38,10 +34,11 @@ export default async function configureRemainingRequestOptions() {
 
   const protocol = useSSL ? 'https:' : 'http:';
   if (protocol !== defaultProtocol) {
-    await writeConfigOption('remote_recording.protocol', protocol);
+    configuration.setConfigOption('remote_recording.protocol', protocol);
   }
+  await configuration.write();
 
-  const ro = await requestOptions();
+  const ro = configuration.requestOptions();
   UI.progress(
     `Here's the URL I will use to try and connect to the AppMap agent:\n`
   );

--- a/packages/cli/src/cmds/record/action/detectProcessCharacteristics.ts
+++ b/packages/cli/src/cmds/record/action/detectProcessCharacteristics.ts
@@ -1,10 +1,12 @@
 import UI from '../../userInteraction';
 import portPid from 'port-pid';
 import ps from 'ps-node';
-import { requestOptions } from '../configuration';
+import RecordContext from '../recordContext';
 
-export default async function detectProcessCharacteristics(): Promise<boolean> {
-  const ro = await requestOptions();
+export default async function detectProcessCharacteristics({
+  configuration,
+}: RecordContext): Promise<boolean> {
+  const ro = configuration.requestOptions();
   if (ro.hostname !== 'localhost') {
     return false;
   }

--- a/packages/cli/src/cmds/record/action/guessTestCommands.ts
+++ b/packages/cli/src/cmds/record/action/guessTestCommands.ts
@@ -1,6 +1,6 @@
 import { cwd } from 'process';
 import { exists, verbose } from '../../../utils';
-import { readConfigOption, TestCommand } from '../configuration';
+import { TestCommand } from '../configuration';
 
 const RubyEnv = { APPMAP: 'true', DISABLE_SPRING: 'true' };
 

--- a/packages/cli/src/cmds/record/action/saveAppMap.ts
+++ b/packages/cli/src/cmds/record/action/saveAppMap.ts
@@ -2,14 +2,18 @@ import { mkdirp } from 'fs-extra';
 import { writeFile } from 'fs/promises';
 import { join } from 'path';
 import UI from '../../userInteraction';
-import { readConfigOption } from '../configuration';
+import RecordContext from '../recordContext';
 
-export default async function saveAppMap(jsonData: any, appMapName: string) {
+export default async function saveAppMap(
+  { configuration }: RecordContext,
+  jsonData: any,
+  appMapName: string
+) {
   const data = JSON.stringify(jsonData);
 
   const fileName = `${appMapName}.appmap.json`;
   const outputDir = join(
-    (await readConfigOption('appmap_dir', 'tmp/appmap')) as string,
+    configuration.configOption('appmap_dir', 'tmp/appmap') as string,
     'remote'
   );
   await mkdirp(outputDir);

--- a/packages/cli/src/cmds/record/action/saveRecording.ts
+++ b/packages/cli/src/cmds/record/action/saveRecording.ts
@@ -1,5 +1,4 @@
 import UI from '../../userInteraction';
-import { requestOptions } from '../configuration';
 import RecordContext from '../recordContext';
 import RemoteRecording from '../remoteRecording';
 import nameAppMap from './nameAppMap';
@@ -8,7 +7,7 @@ import saveAppMap from './saveAppMap';
 export default async function saveRecording(
   recordContext: RecordContext
 ): Promise<string | undefined> {
-  const rr = new RemoteRecording(await requestOptions());
+  const rr = new RemoteRecording(recordContext.configuration.requestOptions());
   let data = await rr.stop();
 
   if (data) {
@@ -27,5 +26,5 @@ export default async function saveRecording(
   }
 
   const appMapName = await nameAppMap(jsonData);
-  return saveAppMap(jsonData, appMapName);
+  return saveAppMap(recordContext, jsonData, appMapName);
 }

--- a/packages/cli/src/cmds/record/action/startRecording.ts
+++ b/packages/cli/src/cmds/record/action/startRecording.ts
@@ -1,9 +1,9 @@
 import UI from '../../userInteraction';
-import { requestOptions } from '../configuration';
+import RecordContext from '../recordContext';
 import RemoteRecording from '../remoteRecording';
 
-export default async function startRecording() {
-  const ro = await requestOptions();
+export default async function startRecording({ configuration }: RecordContext) {
+  const ro = configuration.requestOptions();
 
   UI.progress('');
   await UI.continue('Press enter to start recording');

--- a/packages/cli/src/cmds/record/action/startTestCases.ts
+++ b/packages/cli/src/cmds/record/action/startTestCases.ts
@@ -1,10 +1,11 @@
 import TestCaseRecording from '../testCaseRecording';
 import UI from '../../userInteraction';
-import { readSetting, writeSetting } from '../configuration';
+import RecordContext from '../recordContext';
 
-export default async function startTestCases() {
+export default async function startTestCases(context: RecordContext) {
+  const { configuration } = context;
   if (Boolean(process.stdout.isTTY)) {
-    const defaultMaxTime = await readSetting('test_recording.max_time', 30);
+    const defaultMaxTime = configuration.setting('test_recording.max_time', 30);
     let maxTime: number | undefined;
     do {
       maxTime = (
@@ -19,8 +20,9 @@ export default async function startTestCases() {
       maxTime = Number(maxTime);
     } while (Number.isNaN(maxTime));
     if (maxTime !== defaultMaxTime)
-      await writeSetting('test_recording.max_time', maxTime);
+      configuration.setSetting('test_recording.max_time', maxTime);
+    await configuration.write();
   }
 
-  await TestCaseRecording.start();
+  await TestCaseRecording.start(context);
 }

--- a/packages/cli/src/cmds/record/configuration.ts
+++ b/packages/cli/src/cmds/record/configuration.ts
@@ -1,12 +1,10 @@
+import assert from 'assert';
 import { existsSync } from 'fs';
 import { readFile, writeFile } from 'fs/promises';
 import { RequestOptions } from 'http';
 import { dump, load } from 'js-yaml';
 import { isAbsolute, join } from 'path';
 import TestCaseRecording from './testCaseRecording';
-
-let AppMapConfigFilePath = 'appmap.yml';
-let AppMapSettingsFilePath = join(process.env.HOME || '', '.appmaprc');
 
 export type RemoteRecordingConfig = {
   path?: string;
@@ -35,31 +33,110 @@ export type AppMapConfig = {
   remote_recording?: RemoteRecordingConfig;
 };
 
+interface Setting {
+  [key: string]: string | number | TestCommand | Setting;
+}
+
 export type AppMapSettings = {
   max_time?: number;
+} & {
+  [key: string]: Setting;
 };
 
-// Returns the previous config file path.
-export function setAppMapConfigFilePath(appMapFile: string): string {
-  const oldPath = AppMapConfigFilePath;
-  AppMapConfigFilePath = appMapFile;
-  if (!existsSync(appMapFile)) {
-    console.log(`Warning: AppMap config file ${appMapFile} does not exist.`);
+export default class Configuration {
+  constructor(appMapFile?: string, settingsFile?: string) {
+    this.appMapFile = appMapFile || 'appmap.yml';
+    this.settingsFile =
+      settingsFile || join(process.env.HOME || '', '.appmaprc');
   }
-  return oldPath;
+
+  async read(): Promise<void> {
+    this.config = (await readConfig(this.appMapFile)) || {};
+    this.settings =
+      (await readAllSettings(this.settingsFile))[this.settingsKey()] || {};
+  }
+
+  async write(): Promise<void> {
+    if (this.configDirty) {
+      await writeFile(this.appMapFile, dump(this.config));
+      this.configDirty = false;
+    }
+
+    if (this.settingsDirty) {
+      const all = await readAllSettings(this.settingsFile);
+      assert(this.settings);
+      all[this.settingsKey()] = this.settings;
+      await writeFile(this.settingsFile, dump(all));
+      this.settingsDirty = false;
+    }
+  }
+  configOption(
+    path: string,
+    defaultValue: string | number | TestCommand[]
+  ): string | number | TestCommand[] {
+    return findOption(this.config, path, defaultValue);
+  }
+
+  setConfigOption(path: string, value: string | number | TestCommand[]) {
+    mergeConfigData(this.config, path, value);
+    this.configDirty = true;
+  }
+
+  setting(
+    path: string,
+    defaultValue: string | number | TestCommand[]
+  ): string | number | TestCommand[] {
+    return findOption(this.settings, path, defaultValue);
+  }
+
+  setSetting(path: string, value: string | number | TestCommand[]) {
+    mergeConfigData(this.settings, path, value);
+    this.settingsDirty = true;
+  }
+
+  requestOptions(): RequestOptions {
+    const requestOptions = {} as RequestOptions;
+
+    requestOptions.hostname = this.setting(
+      'remote_recording.host',
+      'localhost'
+    ).toString();
+    requestOptions.port = this.setting('remote_recording.port', 3000) as number;
+    requestOptions.path = this.configOption(
+      'remote_recording.path',
+      '/'
+    ).toString();
+    requestOptions.protocol = this.configOption(
+      'remote_recording.protocol',
+      'http:'
+    ).toString();
+
+    return requestOptions;
+  }
+
+  locationString(): string {
+    const ro = this.requestOptions();
+    return `${ro.protocol}//${ro.hostname}:${ro.port}${ro.path}`;
+  }
+
+  private settingsKey() {
+    return isAbsolute(this.appMapFile)
+      ? this.appMapFile
+      : join(process.cwd(), this.appMapFile);
+  }
+
+  protected appMapFile: string;
+  protected settingsFile: string;
+  private config?: Partial<AppMapConfig>;
+  private settings?: Setting;
+  private configDirty = false;
+  private settingsDirty = false;
 }
 
-// Returns the previous settings file path.
-export function setAppMapSettingsFilePath(appMapFile: string): string {
-  const oldPath = AppMapSettingsFilePath;
-  AppMapSettingsFilePath = appMapFile;
-  return oldPath;
-}
-
-export async function readConfig(): Promise<AppMapConfig | undefined> {
+async function readConfig(path: string): Promise<AppMapConfig | undefined> {
   let fileContents: Buffer | undefined;
   try {
-    fileContents = await readFile(AppMapConfigFilePath);
+    fileContents = await readFile(path);
   } catch {
     return {} as AppMapConfig;
   }
@@ -67,87 +144,23 @@ export async function readConfig(): Promise<AppMapConfig | undefined> {
   try {
     config = load(fileContents.toString()) as AppMapConfig;
   } catch (err) {
-    console.warn(
-      `Error parsing AppMap config file ${AppMapConfigFilePath}: ${err}`
-    );
+    console.warn(`Error parsing AppMap config file ${path}: ${err}`);
     config = {} as AppMapConfig;
   }
   return config;
 }
 
-function settingsKey(): string {
-  return isAbsolute(AppMapConfigFilePath)
-    ? AppMapConfigFilePath
-    : join(process.cwd(), AppMapConfigFilePath);
-}
-
-export async function readAllSettings(): Promise<AppMapSettings> {
+async function readAllSettings(path: string): Promise<AppMapSettings> {
   let settings: any;
   try {
-    const fileContents = await readFile(AppMapSettingsFilePath);
+    const fileContents = await readFile(path);
     settings = load(fileContents.toString()) as any;
     // Make sure settings is an object.
-    settings[settingsKey()];
+    settings['test'];
   } catch {
     settings = {};
   }
-  if (!settings[settingsKey()]) {
-    settings[settingsKey()] = {};
-  }
   return settings;
-}
-
-async function readSettings(): Promise<any> {
-  return (await readAllSettings())[settingsKey()];
-}
-
-async function writeConfig(config: any) {
-  await writeFile(AppMapConfigFilePath, dump(config));
-}
-
-async function writeSettings(settings: any) {
-  await writeFile(AppMapSettingsFilePath, dump(settings));
-}
-
-export async function requestOptions(): Promise<RequestOptions> {
-  const requestOptions = {} as RequestOptions;
-
-  requestOptions.hostname = (
-    await readSetting('remote_recording.host', 'localhost')
-  ).toString();
-  requestOptions.port = (await readSetting(
-    'remote_recording.port',
-    3000
-  )) as number;
-  requestOptions.path = (
-    await readConfigOption('remote_recording.path', '/')
-  ).toString();
-  requestOptions.protocol = (
-    await readConfigOption('remote_recording.protocol', 'http:')
-  ).toString();
-
-  return requestOptions;
-}
-
-export async function locationString(): Promise<string> {
-  const ro = await requestOptions();
-  return `${ro.protocol}//${ro.hostname}:${ro.port}${ro.path}`;
-}
-
-export async function readSetting(
-  path: string,
-  defaultValue: string | number | TestCommand[]
-): Promise<string | number | TestCommand[]> {
-  const settings = await readSettings();
-  return findOption(settings, path, defaultValue);
-}
-
-export async function readConfigOption(
-  path: string,
-  defaultValue: string | number | TestCommand[]
-): Promise<string | number | TestCommand[]> {
-  const config = await readConfig();
-  return findOption(config, path, defaultValue);
 }
 
 function findOption(
@@ -165,27 +178,6 @@ function findOption(
   }
 
   return entry || defaultValue;
-}
-
-export async function writeSetting(
-  path: string,
-  value: string | number | TestCommand[]
-) {
-  const allSettings = await readAllSettings();
-  const settings = allSettings[settingsKey()];
-  mergeConfigData(settings, path, value);
-  await writeSettings(allSettings);
-}
-
-export async function writeConfigOption(
-  path: string,
-  value: string | number | TestCommand[]
-) {
-  const config = await readConfig();
-  if (!config) return;
-
-  mergeConfigData(config, path, value);
-  await writeConfig(config);
 }
 
 function mergeConfigData(

--- a/packages/cli/src/cmds/record/prompt/continueWithRequestOptionConfiguration.ts
+++ b/packages/cli/src/cmds/record/prompt/continueWithRequestOptionConfiguration.ts
@@ -1,15 +1,16 @@
 import UI from '../../userInteraction';
-import { requestOptions } from '../configuration';
-
+import RecordContext from '../recordContext';
 export enum ConfigurationAction {
   HostAndPort = 'Reconfigure host and port',
   RequestOptions = 'Keep the host and port, and configure additional connection options',
 }
 
-export default async function continueWithRequestOptionConfiguration(): Promise<ConfigurationAction> {
+export default async function continueWithRequestOptionConfiguration({
+  configuration,
+}: RecordContext): Promise<ConfigurationAction> {
   UI.progress(
     `I can't find your AppMap server process on port ${
-      (await requestOptions()).port
+      configuration.requestOptions().port
     }.`
   );
   UI.progress('');

--- a/packages/cli/src/cmds/record/prompt/obtainTestCommands.ts
+++ b/packages/cli/src/cmds/record/prompt/obtainTestCommands.ts
@@ -1,9 +1,12 @@
 import UI from '../../userInteraction';
-import { TestCommand, writeConfigOption } from '../configuration';
+import { TestCommand } from '../configuration';
 import guessTestCommands from '../action/guessTestCommands';
 import TestCaseRecording from '../testCaseRecording';
+import RecordContext from '../recordContext';
 
-export default async function obtainTestCommands(): Promise<void> {
+export default async function obtainTestCommands({
+  configuration,
+}: RecordContext): Promise<void> {
   UI.progress(``);
   UI.progress(
     `In order to record test cases, you need to provide a command that I can use to run the tests. ` +
@@ -21,7 +24,10 @@ export default async function obtainTestCommands(): Promise<void> {
     UI.progress(TestCommand.toString(testCommand));
     UI.progress(``);
     if (await UI.confirm('Use this suggested test command?')) {
-      await writeConfigOption('test_recording.test_commands', [testCommand]);
+      configuration.setConfigOption('test_recording.test_commands', [
+        testCommand,
+      ]);
+      await configuration.write();
 
       UI.progress(``);
       UI.progress(
@@ -75,9 +81,10 @@ export default async function obtainTestCommands(): Promise<void> {
 
     confirmed = await UI.confirm(`Continue with this command?`);
     if (confirmed) {
-      await writeConfigOption('test_recording.test_commands', [
+      configuration.setConfigOption('test_recording.test_commands', [
         { env, command: testCommand },
       ]);
+      await configuration.write();
     }
   }
 }

--- a/packages/cli/src/cmds/record/record.ts
+++ b/packages/cli/src/cmds/record/record.ts
@@ -9,7 +9,7 @@ import { chdir } from 'process';
 import initial from './state/initial';
 import Telemetry from '../../telemetry';
 import RecordContext from './recordContext';
-import { readConfigOption, setAppMapConfigFilePath } from './configuration';
+import Configuration from './configuration';
 
 export const command = 'record [mode]';
 export const describe =
@@ -46,11 +46,8 @@ export async function handler(argv: any) {
       chdir(directory);
     }
 
-    if (appmapConfig) setAppMapConfigFilePath(appmapConfig);
-
-    const appmapDir = (await readConfigOption('appmap_dir', '.')) as string;
-
-    const recordContext = new RecordContext(appmapDir);
+    const configuration = new Configuration(appmapConfig);
+    const recordContext = new RecordContext(configuration);
     await recordContext.initialize();
 
     const { mode } = argv;

--- a/packages/cli/src/cmds/record/state/agentAvailableAndReady.ts
+++ b/packages/cli/src/cmds/record/state/agentAvailableAndReady.ts
@@ -1,9 +1,12 @@
 import startRecording from '../action/startRecording';
 import recordingInProgress from './recordingInProgress';
 import { State } from '../types/state';
+import RecordContext from '../recordContext';
 
 // The AppMap agent has been confirmed
-export default async function agentAvailableAndReady(): Promise<State> {
-  await startRecording();
+export default async function agentAvailableAndReady(
+  recordContext: RecordContext
+): Promise<State> {
+  await startRecording(recordContext);
   return recordingInProgress;
 }

--- a/packages/cli/src/cmds/record/state/agentIsRecording.ts
+++ b/packages/cli/src/cmds/record/state/agentIsRecording.ts
@@ -14,7 +14,7 @@ export default async function agentIsRecording(
   const recordingAction = await promptRecordingInProgress();
 
   if (recordingAction === RecordingAction.Cancel) {
-    await cancelRecording();
+    await cancelRecording(recordContext);
     return serverAvailableAndReady;
   } else if (recordingAction === RecordingAction.Save) {
     await saveRecording(recordContext);

--- a/packages/cli/src/cmds/record/state/agentNotAvailable.ts
+++ b/packages/cli/src/cmds/record/state/agentNotAvailable.ts
@@ -1,5 +1,4 @@
 import UI from '../../userInteraction';
-import configureHostAndPort from '../action/configureHostAndPort';
 import configureRemainingRequestOptions from '../action/configureRemainingRequestOptions';
 import detectProcessCharacteristics from '../action/detectProcessCharacteristics';
 import continueWithRequestOptionConfiguration, {
@@ -19,9 +18,9 @@ import initial from './record_remote';
 export default async function agentNotAvailable(
   recordContext: RecordContext
 ): Promise<State> {
-  if (!(await detectProcessCharacteristics())) {
+  if (!(await detectProcessCharacteristics(recordContext))) {
     if (
-      (await continueWithRequestOptionConfiguration()) ===
+      (await continueWithRequestOptionConfiguration(recordContext)) ===
       ConfigurationAction.HostAndPort
     )
       return agentProcessNotRunning;
@@ -43,9 +42,9 @@ For case (3), you can configure the application URL path and protocol.
 `
   );
 
-  await configureRemainingRequestOptions();
+  await configureRemainingRequestOptions(recordContext);
 
-  await recordContext.populateURL();
+  recordContext.populateURL();
 
   return initial;
 }

--- a/packages/cli/src/cmds/record/state/agentProcessNotRunning.ts
+++ b/packages/cli/src/cmds/record/state/agentProcessNotRunning.ts
@@ -1,11 +1,14 @@
 import UI from '../../userInteraction';
 import configureHostAndPort from '../action/configureHostAndPort';
+import RecordContext from '../recordContext';
 import { State } from '../types/state';
 import initial from './record_remote';
 
 // No process could be contact on the configured host and port.
 // Prompt the user to start the agent process, and then start over.
-export default async function agentProcessNotRunning(): Promise<State> {
+export default async function agentProcessNotRunning(
+  context: RecordContext
+): Promise<State> {
   UI.progress(
     `It looks like you need to start your app (make sure you have the AppMap agent enabled).`
   );
@@ -28,7 +31,7 @@ export default async function agentProcessNotRunning(): Promise<State> {
   JavaScript: https://appland.com/docs/reference/appmap-agent-js.html#remote-recording
   `);
 
-  await configureHostAndPort();
+  await configureHostAndPort(context);
 
   return initial;
 }

--- a/packages/cli/src/cmds/record/state/record_remote.ts
+++ b/packages/cli/src/cmds/record/state/record_remote.ts
@@ -11,9 +11,9 @@ import RecordContext from '../recordContext';
 export default async function remote(
   recordContext: RecordContext
 ): Promise<State> {
-  await recordContext.populateURL();
-  if (await isAgentAvailable()) {
-    if (!(await isRecordingInProgress())) {
+  recordContext.populateURL();
+  if (await isAgentAvailable(recordContext)) {
+    if (!(await isRecordingInProgress(recordContext))) {
       return agentAvailableAndReady;
     } else {
       return agentIsRecording;

--- a/packages/cli/src/cmds/record/state/record_test.ts
+++ b/packages/cli/src/cmds/record/state/record_test.ts
@@ -9,8 +9,8 @@ import RecordContext from '../recordContext';
 export default async function test(
   recordContext: RecordContext
 ): Promise<State> {
-  if (await areTestCommandsConfigured()) {
-    await recordContext.populateTestCommands();
+  if (await areTestCommandsConfigured(recordContext)) {
+    recordContext.populateTestCommands();
 
     return testCommandsAvailable;
   } else {

--- a/packages/cli/src/cmds/record/state/testCasesComplete.ts
+++ b/packages/cli/src/cmds/record/state/testCasesComplete.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import chalk from 'chalk';
 import { openTicket } from '../../../lib/ticket/openTicket';
 import UI from '../../userInteraction';
@@ -23,6 +24,7 @@ Test command failed with no output`,
     return;
   }
 
+  assert(recordContext.appMapDir);
   await printAppMapCount(recordContext.appMapDir);
 
   return;

--- a/packages/cli/src/cmds/record/state/testCommandsAvailable.ts
+++ b/packages/cli/src/cmds/record/state/testCommandsAvailable.ts
@@ -7,7 +7,7 @@ import RecordContext from '../recordContext';
 export default async function testCommandsAvailable(
   recordContext: RecordContext
 ): Promise<State> {
-  await startTestCases();
+  await startTestCases(recordContext);
 
   await recordContext.populateMaxTime();
 

--- a/packages/cli/src/cmds/record/state/testCommandsNeeded.ts
+++ b/packages/cli/src/cmds/record/state/testCommandsNeeded.ts
@@ -6,9 +6,9 @@ import testCommandsAvailable from './testCommandsAvailable';
 export default async function testCommandsNeeded(
   recordContext: RecordContext
 ): Promise<State> {
-  await obtainTestCommands();
+  await obtainTestCommands(recordContext);
 
-  await recordContext.populateTestCommands();
+  recordContext.populateTestCommands();
 
   return testCommandsAvailable;
 }

--- a/packages/cli/src/cmds/record/test/areTestCommandsConfigured.ts
+++ b/packages/cli/src/cmds/record/test/areTestCommandsConfigured.ts
@@ -1,16 +1,15 @@
 import UI from '../../userInteraction';
-import {
-  readConfigOption,
-  TestCommand,
-  writeConfigOption,
-} from '../configuration';
+import { TestCommand } from '../configuration';
+import RecordContext from '../recordContext';
 import TestCaseRecording from '../testCaseRecording';
 
-export default async function areTestCasesConfigured(): Promise<boolean> {
-  let testCommands: TestCommand[] | undefined = (await readConfigOption(
+export default async function areTestCasesConfigured({
+  configuration,
+}: RecordContext): Promise<boolean> {
+  let testCommands: TestCommand[] | undefined = configuration.configOption(
     'test_recording.test_commands',
     []
-  )) as TestCommand[];
+  ) as TestCommand[];
 
   if (testCommands && testCommands.length > 0) {
     UI.progress(
@@ -32,7 +31,8 @@ export default async function areTestCasesConfigured(): Promise<boolean> {
     });
 
     if (!useTestCommands) {
-      await writeConfigOption('test_recording.test_commands', []);
+      configuration.setConfigOption('test_recording.test_commands', []);
+      await configuration.write();
     }
 
     return useTestCommands;

--- a/packages/cli/src/cmds/record/test/isAgentAvailable.ts
+++ b/packages/cli/src/cmds/record/test/isAgentAvailable.ts
@@ -1,15 +1,17 @@
 import UI from '../../userInteraction';
-import { locationString, requestOptions } from '../configuration';
+import RecordContext from '../recordContext';
 import RemoteRecording from '../remoteRecording';
 
-export default async function isAgentAvailable(): Promise<boolean> {
-  const ro = await requestOptions();
-  const location = await locationString();
+export default async function isAgentAvailable({
+  configuration,
+}: RecordContext): Promise<boolean> {
+  const ro = configuration.requestOptions();
+  const location = configuration.locationString();
   UI.status = `Checking if the AppMap agent is available at ${location}`;
   try {
     await new RemoteRecording(ro).status();
     UI.success(`AppMap agent is available at ${location}`);
-     return true;
+    return true;
   } catch (e: any) {
     UI.error(`AppMap agent is not avaliable at ${location}: ${e.toString()}`);
     return false;

--- a/packages/cli/src/cmds/record/test/isRecordingInProgress.ts
+++ b/packages/cli/src/cmds/record/test/isRecordingInProgress.ts
@@ -1,8 +1,11 @@
-import { requestOptions } from '../configuration';
+import RecordContext from '../recordContext';
 import RemoteRecording from '../remoteRecording';
 
-export default async function isRecordingInProgress(
-): Promise<boolean> {
-  const status = await new RemoteRecording(await requestOptions()).status();
+export default async function isRecordingInProgress({
+  configuration,
+}: RecordContext): Promise<boolean> {
+  const status = await new RemoteRecording(
+    configuration.requestOptions()
+  ).status();
   return status.enabled === true;
 }

--- a/packages/cli/src/cmds/record/testCaseRecording.ts
+++ b/packages/cli/src/cmds/record/testCaseRecording.ts
@@ -2,12 +2,7 @@ import { ChildProcess, exec, spawn } from 'child_process';
 import { exitCode, kill } from 'process';
 import { exists, verbose } from '../../utils';
 import UI from '../userInteraction';
-import {
-  readConfig,
-  readConfigOption,
-  readSetting,
-  TestCommand,
-} from './configuration';
+import { TestCommand } from './configuration';
 import RecordContext, { RecordProcessResult } from './recordContext';
 
 let TestCommands: TestCommand[] = [];
@@ -19,17 +14,17 @@ const DiagnosticCommands: Record<string, string[]> = {
 };
 
 export default class TestCaseRecording {
-  static async start() {
+  static async start({ configuration }: RecordContext) {
     TestCaseProcesses.forEach((process) => {
       if (process.pid) kill(process.pid);
     });
     TestCommands = [];
     TestCaseProcesses = [];
 
-    let testCommands = (await readConfigOption(
+    let testCommands = configuration.configOption(
       'test_recording.test_commands',
       []
-    )) as TestCommand[];
+    ) as TestCommand[];
 
     if (testCommands.length === 0)
       throw new Error(`No test commands are configured`);
@@ -62,10 +57,10 @@ export default class TestCaseRecording {
   }
 
   static async waitFor(ctx: RecordContext): Promise<void> {
-    let maxTime: number | undefined = (await readSetting(
+    let maxTime: number | undefined = ctx.configuration.setting(
       'test_recording.max_time',
       -1
-    )) as number;
+    ) as number;
 
     if (maxTime === -1) maxTime = undefined;
 

--- a/packages/cli/tests/unit/record/action/configureHostAndPort.spec.ts
+++ b/packages/cli/tests/unit/record/action/configureHostAndPort.spec.ts
@@ -4,25 +4,31 @@ import * as configuration from '../../../../src/cmds/record/configuration';
 import UI from '../../../../src/cmds/userInteraction';
 import configureHostAndPort from '../../../../src/cmds/record/action/configureHostAndPort';
 import TempConfig from '../tempConfig';
+import RecordContext from '../../../../src/cmds/record/recordContext';
 
 describe('record.action.configureHostAndPort', () => {
   let config: TempConfig;
   let prompt: sinon.SinonStub;
+  let context: RecordContext;
 
-  beforeEach(() => (config = new TempConfig()));
-  beforeEach(() => config.initialize());
+  beforeEach(() => {
+    config = new TempConfig();
+    config.initialize();
+    context = new RecordContext(config);
+    return context.initialize();
+  });
+
   beforeEach(() => (prompt = sinon.stub(UI, 'prompt')));
 
-  afterEach(() => config.cleanup());
   afterEach(() => sinon.restore());
 
   it('accepts and saves host and port', async () => {
     prompt.onCall(0).resolves({ hostname: 'myhost' });
     prompt.onCall(1).resolves({ portNumber: '3000' });
 
-    await configureHostAndPort();
+    await configureHostAndPort(context);
 
-    const ro = await configuration.requestOptions();
+    const ro = config.requestOptions();
 
     expect(ro.hostname).toEqual('myhost');
     expect(ro.port).toEqual(3000);
@@ -33,9 +39,9 @@ describe('record.action.configureHostAndPort', () => {
     prompt.onCall(1).resolves({ portNumber: 'blarg' });
     prompt.onCall(2).resolves({ portNumber: '3000' });
 
-    await configureHostAndPort();
+    await configureHostAndPort(context);
 
-    const ro = await configuration.requestOptions();
+    const ro = config.requestOptions();
     expect(ro.hostname).toEqual('myhost');
     expect(ro.port).toEqual(3000);
   });

--- a/packages/cli/tests/unit/record/action/configureRemainingRequestOptions.spec.ts
+++ b/packages/cli/tests/unit/record/action/configureRemainingRequestOptions.spec.ts
@@ -4,25 +4,31 @@ import * as configuration from '../../../../src/cmds/record/configuration';
 import UI from '../../../../src/cmds/userInteraction';
 import configureRemainingRequestOptions from '../../../../src/cmds/record/action/configureRemainingRequestOptions';
 import TempConfig from '../tempConfig';
+import RecordContext from '../../../../src/cmds/record/recordContext';
 
 describe('record.action.configureRemainingRequestOptions', () => {
   let config: TempConfig;
   let prompt: sinon.SinonStub;
+  let context: RecordContext;
 
-  beforeEach(() => (config = new TempConfig()));
-  beforeEach(() => config.initialize());
+  beforeEach(() => {
+    config = new TempConfig();
+    config.initialize();
+    context = new RecordContext(config);
+    return context.initialize();
+  });
+
   beforeEach(() => (prompt = sinon.stub(UI, 'prompt')));
 
-  afterEach(() => config.cleanup());
   afterEach(() => sinon.restore());
 
   it('accepts and saves agent path and protocol', async () => {
     prompt.onCall(0).resolves({ baseURL: '/myapp/' });
     prompt.onCall(1).resolves({ useSSL: true });
 
-    await configureRemainingRequestOptions();
+    await configureRemainingRequestOptions(context);
 
-    const ro = await configuration.requestOptions();
+    const ro = config.requestOptions();
 
     expect(ro.hostname).toEqual('localhost');
     expect(ro.port).toEqual(3000);

--- a/packages/cli/tests/unit/record/action/guessTestCommands.spec.ts
+++ b/packages/cli/tests/unit/record/action/guessTestCommands.spec.ts
@@ -8,13 +8,6 @@ describe('record.action.guessTestCommands', () => {
   afterEach(() => sinon.restore());
 
   describe('ruby', () => {
-    beforeEach(() => {
-      sinon
-        .stub(configuration, 'readConfigOption')
-        .withArgs('language', 'undefined')
-        .resolves('ruby');
-    });
-
     describe('when test path exists', () => {
       it('provides test command', async () => {
         const stubAccess = sinon.stub(fsp, 'access');

--- a/packages/cli/tests/unit/record/configuration.spec.ts
+++ b/packages/cli/tests/unit/record/configuration.spec.ts
@@ -1,17 +1,13 @@
-import * as configuration from '../../../src/cmds/record/configuration';
 import TempConfig from './tempConfig';
 
 describe('configuration', () => {
-  let config: TempConfig;
+  let config = new TempConfig();
 
-  beforeEach(() => (config = new TempConfig()));
-  beforeEach(() => config.initialize());
-
-  afterEach(() => config.cleanup());
+  beforeEach(() => (config = new TempConfig()).initialize());
 
   describe('requestOptions', () => {
     it('returns default config', async () => {
-      const options = await configuration.requestOptions();
+      const options = config.requestOptions();
       expect(options).toEqual({
         hostname: 'localhost',
         path: '/',
@@ -21,11 +17,10 @@ describe('configuration', () => {
     });
     describe('with non-default config', () => {
       it('returns modified request options', async () => {
-        await configuration.writeConfigOption(
-          'remote_recording.path',
-          '/myapp'
-        );
-        const options = await configuration.requestOptions();
+        config.setConfigOption('remote_recording.path', '/myapp');
+        await config.write();
+        await config.read();
+        const options = config.requestOptions();
         expect(options).toEqual({
           hostname: 'localhost',
           path: '/myapp',
@@ -36,8 +31,10 @@ describe('configuration', () => {
     });
     describe('with non-default setting', () => {
       it('returns modified request options', async () => {
-        await configuration.writeSetting('remote_recording.host', 'myhost');
-        const options = await configuration.requestOptions();
+        config.setSetting('remote_recording.host', 'myhost');
+        await config.write();
+        await config.read();
+        const options = config.requestOptions();
         expect(options).toEqual({
           hostname: 'myhost',
           path: '/',

--- a/packages/cli/tests/unit/record/record.remote.spec.ts
+++ b/packages/cli/tests/unit/record/record.remote.spec.ts
@@ -1,6 +1,4 @@
-import { RequestOptions } from 'http';
 import sinon from 'sinon';
-import { inspect } from 'util';
 import * as configureHostAndPort from '../../../src/cmds/record/action/configureHostAndPort';
 import * as configureRemainingRequestOptions from '../../../src/cmds/record/action/configureRemainingRequestOptions';
 import * as detectProcessCharacteristics from '../../../src/cmds/record/action/detectProcessCharacteristics';
@@ -15,19 +13,12 @@ import * as agentAvailableAndReady from '../../../src/cmds/record/state/agentAva
 import * as agentIsRecording from '../../../src/cmds/record/state/agentIsRecording';
 import * as agentNotAvailable from '../../../src/cmds/record/state/agentNotAvailable';
 import * as agentProcessNotRunning from '../../../src/cmds/record/state/agentProcessNotRunning';
+import * as remote from '../../../src/cmds/record/state/record_remote';
 import * as isAgentAvailable from '../../../src/cmds/record/test/isAgentAvailable';
 import * as isRecordingInProgress from '../../../src/cmds/record/test/isRecordingInProgress';
 import { State } from '../../../src/cmds/record/types/state';
 import UI from '../../../src/cmds/userInteraction';
-import proxyquire from 'proxyquire';
 
-import type * as RemoteModule from '../../../src/cmds/record/state/record_remote';
-const remote: typeof RemoteModule = proxyquire(
-  '../../../src/cmds/record/state/record_remote.ts',
-  {
-    requestOptions: 'foo',
-  }
-);
 
 function checkContext(
   context: RecordContext,

--- a/packages/cli/tests/unit/record/record.test.spec.ts
+++ b/packages/cli/tests/unit/record/record.test.spec.ts
@@ -10,16 +10,23 @@ import * as testCasesComplete from '../../../src/cmds/record/state/testCasesComp
 import * as areTestCommandsConfigured from '../../../src/cmds/record/test/areTestCommandsConfigured';
 import * as obtainTestCommands from '../../../src/cmds/record/prompt/obtainTestCommands';
 import TestCaseRecording from '../../../src/cmds/record/testCaseRecording';
-import RecordContext from '../../../src/cmds/record/recordContext';
-import { inspect } from 'util';
+import RecordContext, {
+  RecordProcessResult,
+} from '../../../src/cmds/record/recordContext';
+import Configuration from '../../../src/cmds/record/configuration';
 
 describe('record test', () => {
   let prompt: sinon.SinonStub,
     cont: sinon.SinonStub,
-    recordContext: RecordContext,
-    appMapDir = '.';
+    recordContext: RecordContext;
 
-  beforeEach(() => (recordContext = new RecordContext(appMapDir)));
+  beforeEach(() => {
+    const config = new Configuration();
+    sinon.stub(config, 'read');
+    sinon.stub(config, 'write');
+    recordContext = new RecordContext(config);
+    return recordContext.initialize();
+  });
 
   beforeEach(() => {
     prompt = sinon.stub(UI, 'prompt');
@@ -39,9 +46,10 @@ describe('record test', () => {
       recordContext.recordMethod = 'test';
 
       const next = await test.default(recordContext);
-      expect(inspect(recordContext)).toEqual(
-        `RecordContext { appMapDir: '.', recordMethod: 'test' }`
-      );
+      expect(recordContext).toMatchObject<Partial<RecordContext>>({
+        appMapDir: '.',
+        recordMethod: 'test',
+      });
       expect(next).toEqual(testCommandsNeeded.default);
     });
   });
@@ -51,9 +59,10 @@ describe('record test', () => {
       const stubObtain = sinon.stub(obtainTestCommands, 'default').resolves();
 
       const next = await testCommandsNeeded.default(recordContext);
-      expect(inspect(recordContext)).toEqual(
-        `RecordContext { appMapDir: '.', testCommands: [] }`
-      );
+      expect(recordContext).toMatchObject<Partial<RecordContext>>({
+        appMapDir: '.',
+        testCommands: [],
+      });
       expect(next).toEqual(testCommandsAvailable.default);
 
       expect(stubObtain.calledOnce).toBeTruthy();
@@ -67,9 +76,10 @@ describe('record test', () => {
 
     it('is ready to run test cases', async () => {
       const next = await test.default(recordContext);
-      expect(inspect(recordContext)).toEqual(
-        `RecordContext { appMapDir: '.', testCommands: [] }`
-      );
+      expect(recordContext).toMatchObject<Partial<RecordContext>>({
+        appMapDir: '.',
+        testCommands: [],
+      });
       expect(next).toEqual(testCommandsAvailable.default);
     });
   });
@@ -79,9 +89,10 @@ describe('record test', () => {
       const stubStart = sinon.stub(startTestCases, 'default').resolves();
 
       const next = await testCommandsAvailable.default(recordContext);
-      expect(inspect(recordContext)).toEqual(
-        `RecordContext { appMapDir: '.', maxTime: 30 }`
-      );
+      expect(recordContext).toMatchObject<Partial<RecordContext>>({
+        appMapDir: '.',
+        maxTime: 30,
+      });
       expect(next).toEqual(testCasesRunning.default);
 
       expect(stubStart.calledOnce).toBeTruthy();
@@ -110,15 +121,12 @@ describe('record test', () => {
 
       await next(recordContext);
 
-      expect(inspect(recordContext)).toEqual(
-        // eslint-disable-next-line prettier/prettier
-        `RecordContext {
-  appMapDir: '.',
-  initialAppMapCount: 0,
-  results: [ { exitCode: 0 } ],
-  appMapCount: 10
-}`
-      );
+      expect(recordContext).toMatchObject<Partial<RecordContext>>({
+        appMapDir: '.',
+        initialAppMapCount: 0,
+        results: [{ exitCode: 0 } as RecordProcessResult],
+        appMapCount: 10,
+      });
       expect(recordContext.properties()).toEqual({
         exitCodes: '0',
         // eslint-disable-next-line prettier/prettier
@@ -142,15 +150,12 @@ describe('record test', () => {
       await next(recordContext);
       cont.resolves();
 
-      expect(inspect(recordContext)).toEqual(
-        // eslint-disable-next-line prettier/prettier
-        `RecordContext {
-  appMapDir: '.',
-  initialAppMapCount: 0,
-  results: [ { exitCode: 1 } ],
-  appMapCount: 10
-}`
-      );
+      expect(recordContext).toMatchObject<Partial<RecordContext>>({
+        appMapDir: '.',
+        initialAppMapCount: 0,
+        results: [{ exitCode: 1 } as RecordProcessResult],
+        appMapCount: 10,
+      });
       expect(recordContext.properties()).toEqual({
         exitCodes: '1',
         // eslint-disable-next-line prettier/prettier

--- a/packages/cli/tests/unit/record/recordContext.spec.ts
+++ b/packages/cli/tests/unit/record/recordContext.spec.ts
@@ -3,6 +3,7 @@ import RecordContext, {
 } from '../../../src/cmds/record/recordContext';
 import * as countAppMaps from '../../../src/cmds/record/action/countAppMaps';
 import sinon from 'sinon';
+import TempConfig from './tempConfig';
 
 describe('RecordContext', () => {
   let resultsStub: sinon.SinonStub;
@@ -59,7 +60,7 @@ describe('RecordContext', () => {
     ].forEach((e) => {
       const { codes, expectation } = e;
       (e['fn'] || it)(`has exit codes ${JSON.stringify(codes)}`, () => {
-        const ctx = new RecordContext('.');
+        const ctx = new RecordContext(new TempConfig());
         sinon.stub(ctx, 'exitCodes').value(codes);
         expect(ctx.failures).toEqual(expectation);
       });

--- a/packages/cli/tests/unit/record/tempConfig.ts
+++ b/packages/cli/tests/unit/record/tempConfig.ts
@@ -1,35 +1,19 @@
 import tmp from 'tmp';
 import { unlink, writeFile } from 'fs/promises';
-import { promisify } from 'util';
-import {
-  setAppMapConfigFilePath,
-  setAppMapSettingsFilePath,
-} from '../../../src/cmds/record/configuration';
-import { dump } from 'js-yaml';
+import Configuration from '../../../src/cmds/record/configuration';
 
-export default class TempConfig {
-  configFile?: string;
-  settingsFile?: string;
-  originalConfigFile?: string;
-  originalSettingsFile?: string;
-
-  constructor() {}
+export default class TempConfig extends Configuration {
+  constructor() {
+    super(tmp.fileSync().name, tmp.fileSync().name);
+  }
 
   async initialize() {
-    this.configFile = await promisify(tmp.file)();
-    this.settingsFile = await promisify(tmp.file)();
     // Initially this will not exist until we create it. Better simulates a user environment.
     await unlink(this.settingsFile);
 
-    this.originalConfigFile = setAppMapConfigFilePath(this.configFile);
-    this.originalSettingsFile = setAppMapSettingsFilePath(this.settingsFile);
-
-    await writeFile(this.configFile, dump({}));
+    await writeFile(this.appMapFile, '{}');
     // Settings file does not have to exist
-  }
 
-  cleanup() {
-    setAppMapConfigFilePath(this.originalConfigFile!);
-    setAppMapSettingsFilePath(this.originalSettingsFile!);
+    await this.read();
   }
 }

--- a/packages/cli/tests/unit/record/test/areTestCommandsConfigured.spec.ts
+++ b/packages/cli/tests/unit/record/test/areTestCommandsConfigured.spec.ts
@@ -1,38 +1,45 @@
 import sinon from 'sinon';
 
-import * as configuration from '../../../../src/cmds/record/configuration';
 import UI from '../../../../src/cmds/userInteraction';
 import areTestCasesConfigured from '../../../../src/cmds/record/test/areTestCommandsConfigured';
+import TempConfig from '../tempConfig';
+import RecordContext from '../../../../src/cmds/record/recordContext';
+import { TestCommand } from '../../../../src/cmds/record/configuration';
 
 describe('record.test.areTestCommandsConfigured', () => {
+  let config: TempConfig;
   let prompt: sinon.SinonStub;
+  let context: RecordContext;
+
+  beforeEach(() => {
+    config = new TempConfig();
+    config.initialize();
+    context = new RecordContext(config);
+    return context.initialize();
+  });
 
   beforeEach(() => (prompt = sinon.stub(UI, 'prompt')));
 
   afterEach(() => sinon.restore());
 
   describe('when config contains test commands', () => {
-    beforeEach(() => {
-      sinon
-        .stub(configuration, 'readConfigOption')
-        .withArgs('test_recording.test_commands', [])
-        .resolves([
-          {
-            command: 'bundle exec rails test',
-          } as configuration.TestCommand,
-        ]);
-    });
     it('prompts the user to accept and use those commands', async () => {
+      config.setConfigOption('test_recording.test_commands', [
+        {
+          command: 'bundle exec rails test',
+        } as TestCommand,
+      ]);
+
       prompt.onCall(0).resolves({ useTestCommands: true });
 
-      const result = await areTestCasesConfigured();
+      const result = await areTestCasesConfigured(context);
       expect(result).toBeTruthy();
     });
   });
 
   describe('when config does not contain test commands', () => {
     it('returns false', async () => {
-      const result = await areTestCasesConfigured();
+      const result = await areTestCasesConfigured(context);
       expect(result).toBeFalsy();
     });
   });

--- a/packages/cli/tests/unit/record/test/recordContext.spec.ts
+++ b/packages/cli/tests/unit/record/test/recordContext.spec.ts
@@ -2,6 +2,7 @@ import * as sinon from 'sinon';
 import { inspect } from 'util';
 import * as countAppMaps from '../../../../src/cmds/record/action/countAppMaps';
 import RecordContext from '../../../../src/cmds/record/recordContext';
+import TempConfig from '../tempConfig';
 
 describe('RecordContext', function () {
   afterEach(sinon.restore);
@@ -15,7 +16,7 @@ describe('RecordContext', function () {
         .onCall(1)
         .resolves(0);
 
-      const rc = new RecordContext('.');
+      const rc = new RecordContext(new TempConfig());
       await rc.initialize();
       await rc.populateAppMapCount();
       rc.appMapEventCount = 0;

--- a/packages/cli/tests/unit/record/testCaseRecording.spec.ts
+++ b/packages/cli/tests/unit/record/testCaseRecording.spec.ts
@@ -1,30 +1,36 @@
 import sinon from 'sinon';
 
-import * as configuration from '../../../src/cmds/record/configuration';
+import { TestCommand } from '../../../src/cmds/record/configuration';
 import RecordContext from '../../../src/cmds/record/recordContext';
 import TestCaseRecording from '../../../src/cmds/record/testCaseRecording';
 import UI from '../../../src/cmds/userInteraction';
+import TempConfig from './tempConfig';
+
+let config: TempConfig;
+let context: RecordContext;
+
+beforeEach(() => {
+  config = new TempConfig();
+  config.initialize();
+  context = new RecordContext(config);
+  return context.initialize();
+});
 
 describe('record.testCaseRecording', () => {
   afterEach(() => sinon.restore());
 
   describe('with a quick test command', () => {
-    beforeEach(() =>
-      sinon
-        .stub(configuration, 'readConfigOption')
-        .withArgs('test_recording.test_commands', [])
-        .resolves([
-          {
-            command: 'sleep 0.01',
-          } as configuration.TestCommand,
-        ])
-    );
-
     it('starts and waits for the command', async () => {
+      config.setConfigOption('test_recording.test_commands', [
+        {
+          command: 'sleep 0.01',
+        } as TestCommand,
+      ]);
+
       const stubUI = sinon.stub(UI, 'progress');
 
-      await TestCaseRecording.start();
-      await TestCaseRecording.waitFor(new RecordContext('.'));
+      await TestCaseRecording.start(context);
+      await TestCaseRecording.waitFor(context);
 
       expect(stubUI.getCalls().map((c) => c.firstArg)).toEqual([
         'Running test command: sleep 0.01',
@@ -33,28 +39,18 @@ describe('record.testCaseRecording', () => {
   });
 
   describe('with a slow test command', () => {
-    beforeEach(() =>
-      sinon
-        .stub(configuration, 'readConfigOption')
-        .withArgs('test_recording.test_commands', [])
-        .resolves([
-          {
-            command: 'sleep 1',
-          } as configuration.TestCommand,
-        ])
-    );
-    beforeEach(() =>
-      sinon
-        .stub(configuration, 'readSetting')
-        .withArgs('test_recording.max_time', -1)
-        .resolves(0.01)
-    );
-
     it('starts and kills the command', async () => {
+      config.setConfigOption('test_recording.test_commands', [
+        {
+          command: 'sleep 1',
+        } as TestCommand,
+      ]);
+      config.setSetting('test_recording.max_time', 0.01);
+
       const stubUI = sinon.stub(UI, 'progress');
 
-      await TestCaseRecording.start();
-      await TestCaseRecording.waitFor(new RecordContext('.'));
+      await TestCaseRecording.start(context);
+      await TestCaseRecording.waitFor(context);
 
       expect(stubUI.getCalls().map((c) => c.firstArg)).toEqual([
         'Running tests for up to 0.01 seconds',
@@ -65,22 +61,17 @@ describe('record.testCaseRecording', () => {
   });
 
   describe('with an invalid test command', () => {
-    beforeEach(() =>
-      sinon
-        .stub(configuration, 'readConfigOption')
-        .withArgs('test_recording.test_commands', [])
-        .resolves([
-          {
-            command: 'foobar',
-          } as configuration.TestCommand,
-        ])
-    );
-
     it('starts the command and reports the error', async () => {
+      config.setConfigOption('test_recording.test_commands', [
+        {
+          command: 'foobar',
+        } as TestCommand,
+      ]);
+
       const stubUI = sinon.stub(UI, 'progress');
 
-      await TestCaseRecording.start();
-      await TestCaseRecording.waitFor(new RecordContext('.'));
+      await TestCaseRecording.start(context);
+      await TestCaseRecording.waitFor(context);
 
       expect(stubUI.getCalls().map((c) => c.firstArg)).toEqual([
         'Running test command: foobar',

--- a/packages/cli/tests/unit/record/testCasesComplete.spec.ts
+++ b/packages/cli/tests/unit/record/testCasesComplete.spec.ts
@@ -3,6 +3,7 @@ import 'jest-sinon';
 import RecordContext from '../../../src/cmds/record/recordContext';
 import testCasesComplete from '../../../src/cmds/record/state/testCasesComplete';
 import * as openTicket from '../../../src/lib/ticket/openTicket';
+import Configuration from '../../../src/cmds/record/configuration';
 
 describe('testCasesComplete', () => {
   afterEach(() => {
@@ -13,9 +14,10 @@ describe('testCasesComplete', () => {
     let rc: RecordContext, openTicketStub: sinon.SinonStub;
 
     beforeEach(() => {
-      rc = new RecordContext('.');
+      rc = new RecordContext(new Configuration());
       sinon.stub(rc, 'output').value(['']);
       openTicketStub = sinon.stub(openTicket, 'openTicket').resolves();
+      return rc.initialize();
     });
 
     it('opens a ticket when test commands fail', async () => {


### PR DESCRIPTION
This simplifies reasoning about and testing the code.
The configuration is carried in the context which is now used
explicitly by all the state transitions that need it.

Fixes https://github.com/applandinc/board/issues/144