### PR TITLE
Check project dependencies before adding appmap

### DIFF
--- a/packages/cli/src/cmds/agentInstaller/agentInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentInstaller.ts
@@ -12,6 +12,7 @@ export default abstract class AgentInstaller {
   }
 
   abstract installAgent(): Promise<void>;
+  abstract checkCurrentConfig(): Promise<void>;
   abstract validateAgentCommand(): Promise<CommandStruct | undefined>;
   abstract initCommand(): Promise<CommandStruct>;
   abstract verifyCommand(): Promise<CommandStruct | undefined>;

--- a/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
+++ b/packages/cli/src/cmds/agentInstaller/agentInstallerProcedure.ts
@@ -1,10 +1,8 @@
 import chalk from 'chalk';
 import fs from 'fs';
-import { resolve } from 'path';
 import Yargs from 'yargs';
 
-import AgentInstaller from './agentInstaller';
-import { AbortError, ValidationError } from '../errors';
+import { AbortError } from '../errors';
 import { run } from './commandRunner';
 import UI from '../userInteraction';
 import AgentProcedure from './agentProcedure';
@@ -60,6 +58,7 @@ export default class AgentInstallerProcedure extends AgentProcedure {
 
     UI.status = 'Installing the AppMap agent...';
 
+    await this.installer.checkCurrentConfig();
     await this.installer.installAgent();
 
     await this.verifyProject();

--- a/packages/cli/src/cmds/agentInstaller/gradleInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/gradleInstaller.ts
@@ -11,9 +11,7 @@ import JavaBuildToolInstaller from './javaBuildToolInstaller';
 import { GradleParser, GradleParseResult } from './gradleParser';
 import EncodedFile from '../../encodedFile';
 
-export default class GradleInstaller
-  extends JavaBuildToolInstaller
-{
+export default class GradleInstaller extends JavaBuildToolInstaller {
   constructor(path: string) {
     super('Gradle', path);
   }
@@ -40,8 +38,12 @@ export default class GradleInstaller
    * If not, the installer will pick the build.gradle.
    */
   get identifyGradleFile(): string {
-    const buildGradleKtsExists: boolean = fs.existsSync(join(this.path, this.buildGradleKtsFileName));
-    return buildGradleKtsExists ? this.buildGradleKtsFileName : this.buildGradleFileName;
+    const buildGradleKtsExists: boolean = fs.existsSync(
+      join(this.path, this.buildGradleKtsFileName)
+    );
+    return buildGradleKtsExists
+      ? this.buildGradleKtsFileName
+      : this.buildGradleFileName;
   }
 
   async printJarPathCommand(): Promise<CommandStruct> {
@@ -171,7 +173,7 @@ ${whitespace.padLine(pluginSpec)}
     const updatedSrc = [
       buildFileSource.substring(0, parseResult.plugins.lbrace + 1),
       lines.map((l) => whitespace.padLine(l)).join(os.EOL),
-      '}'
+      '}',
     ].join(os.EOL);
     const offset = parseResult.plugins.rbrace + 1;
 
@@ -181,7 +183,9 @@ ${whitespace.padLine(pluginSpec)}
   private selectPluginSpec() {
     const pluginSpecKotlinSyntax = `id("com.appland.appmap") version "1.1.0"`;
     const pluginSpecGroovySyntax = `id 'com.appland.appmap' version '1.1.0'`;
-    return this.identifyGradleFile.endsWith('.gradle.kts') ? pluginSpecKotlinSyntax : pluginSpecGroovySyntax;
+    return this.identifyGradleFile.endsWith('.gradle.kts')
+      ? pluginSpecKotlinSyntax
+      : pluginSpecGroovySyntax;
   }
 
   /**
@@ -235,6 +239,9 @@ ${whitespace.padLine(mavenCentral)}
     offset = parseResult.repositories.rbrace - 1;
     return { updatedSrc, offset };
   }
+
+  // TODO: validate the user's project before adding AppMap
+  async checkCurrentConfig(): Promise<void> {}
 
   async installAgent(): Promise<void> {
     const encodedFile: EncodedFile = new EncodedFile(this.buildFilePath);

--- a/packages/cli/src/cmds/agentInstaller/install-agent.ts
+++ b/packages/cli/src/cmds/agentInstaller/install-agent.ts
@@ -5,6 +5,7 @@ import {
   ChildProcessError,
   InvalidPathError,
   ValidationError,
+  UserConfigError,
 } from '../errors';
 import { endTime, prefixLines, verbose } from '../../utils';
 import AgentInstallerProcedure from './agentInstallerProcedure';
@@ -84,6 +85,26 @@ class InstallerError {
       });
 
       UI.error(`${chalk.red('!')} ${this.error.message}`);
+      return true;
+    } else if (this.error instanceof UserConfigError) {
+      UI.error(
+        `${chalk.red('!')} Error in project configuration:\n\n${
+          this.error?.message
+        }`
+      );
+
+      Telemetry.sendEvent({
+        name: 'install-agent:user-config-error',
+        properties: {
+          installer: this.project?.selectedInstaller?.name,
+          installers_available: installersAvailable,
+          error: this.error?.message,
+          log: this.log,
+          directory: this.project?.path
+            ? await getDirectoryProperty(this.project.path)
+            : undefined,
+        },
+      });
       return true;
     } else {
       let exception: string | undefined;

--- a/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
+++ b/packages/cli/src/cmds/agentInstaller/mavenInstaller.ts
@@ -60,6 +60,9 @@ export default class MavenInstaller extends JavaBuildToolInstaller {
     );
   }
 
+  // TODO: validate the user's project before adding AppMap
+  async checkCurrentConfig(): Promise<void> {}
+
   async installAgent(): Promise<void> {
     const encodedFile: EncodedFile = new EncodedFile(this.buildFilePath);
     const buildFileSource = encodedFile.toString();

--- a/packages/cli/src/cmds/errors.ts
+++ b/packages/cli/src/cmds/errors.ts
@@ -9,6 +9,7 @@ export class InvalidPathError extends Error {
 
 export class AbortError extends Error {}
 export class ValidationError extends Error {}
+export class UserConfigError extends Error {}
 
 export interface HttpErrorResponse {
   status: number;

--- a/packages/cli/tests/unit/agentInstall/agentInstaller.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/agentInstaller.spec.ts
@@ -1,6 +1,6 @@
-import path from "path";
-import AgentInstaller from "../../../src/cmds/agentInstaller/agentInstaller";
-import commandStruct from "../../../src/cmds/agentInstaller/commandStruct";
+import path from 'path';
+import AgentInstaller from '../../../src/cmds/agentInstaller/agentInstaller';
+import commandStruct from '../../../src/cmds/agentInstaller/commandStruct';
 
 class FakeInstaller extends AgentInstaller {
   public buildFile: string = 'bf';
@@ -10,22 +10,25 @@ class FakeInstaller extends AgentInstaller {
   }
 
   installAgent(): Promise<void> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
+  }
+  checkCurrentConfig(): Promise<void> {
+    throw new Error('Method not implemented.');
   }
   validateAgentCommand(): Promise<commandStruct> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
   initCommand(): Promise<commandStruct> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
   verifyCommand(): Promise<commandStruct> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
   environment(): Promise<Record<string, string>> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
   available(): Promise<boolean> {
-    throw new Error("Method not implemented.");
+    throw new Error('Method not implemented.');
   }
 }
 

--- a/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
+++ b/packages/cli/tests/unit/agentInstall/installCommand.spec.ts
@@ -308,6 +308,14 @@ packages:
       sinon.stub(inquirer, 'prompt').resolves({ confirm: true });
     });
 
+    const checkCurrentConfig = (cmdStruct: CommandStruct) => {
+      expect(cmdStruct.program).toEqual('bundle');
+      const args = cmdStruct.args;
+      expect(args).toEqual(['check', '--dry-run']);
+      const ret = { stdout: '', stderr: '' };
+      return Promise.resolve(ret);
+    };
+
     const installAgent = (cmdStruct: CommandStruct) => {
       expect(cmdStruct.program).toEqual('bundle');
       const args = cmdStruct.args;
@@ -363,7 +371,8 @@ packages:
       installAgent: (command: CommandStruct) => Promise<CommandReturn>,
       initAgent: (command: CommandStruct) => Promise<CommandReturn>,
       validateAgent: (command: CommandStruct) => Promise<CommandReturn>,
-      evalResults: (err: Error | undefined, argv: any, output: string) => void
+      evalResults: (err: Error | undefined, argv: any, output: string) => void,
+      checkCurrentConfig: (command: CommandStruct) => Promise<CommandReturn>
     ) => {
       let callIdx = 0;
       sinon
@@ -372,6 +381,8 @@ packages:
         .callsFake(rubyVersion)
         .onCall(callIdx++)
         .callsFake(gemHome)
+        .onCall(callIdx++)
+        .callsFake(checkCurrentConfig)
         .onCall(callIdx++)
         .callsFake(installAgent)
         .onCall(callIdx++)
@@ -383,7 +394,7 @@ packages:
     };
 
     it('installs as expected', async () => {
-      expect.assertions(11);
+      expect.assertions(13);
       const evalResults = (err, argv, output) => {
         expect(err).toBeNull();
 
@@ -399,12 +410,13 @@ packages:
         installAgent,
         initAgent,
         validateAgent,
-        evalResults
+        evalResults,
+        checkCurrentConfig
       );
     });
 
     it('fails when validation fails', async () => {
-      expect.assertions(8);
+      expect.assertions(10);
       const msg = 'failValidate, validation failed';
       const failValidate = () => {
         return Promise.reject(new Error(msg));
@@ -419,7 +431,8 @@ packages:
         installAgent,
         initAgent,
         failValidate,
-        evalResults
+        evalResults,
+        checkCurrentConfig
       );
     });
 
@@ -439,18 +452,19 @@ packages:
           installAgent,
           initAgent,
           failValidate,
-          evalResults
+          evalResults,
+          checkCurrentConfig
         );
       };
 
       const errorArray = `[{"message": "${msg}"}]`;
       it('fails for old output format', async () => {
-        expect.assertions(8);
+        expect.assertions(10);
         await testValidation(errorArray);
       });
 
       it('fails for new output format', async () => {
-        expect.assertions(8);
+        expect.assertions(10);
         const errorObj = `{"errors": ${errorArray}}`;
         await testValidation(errorObj);
       });
@@ -463,7 +477,8 @@ packages:
       pythonPath: (command: CommandStruct) => Promise<CommandReturn>,
       installAgent: (command: CommandStruct) => Promise<CommandReturn>,
       initAgent: (command: CommandStruct) => Promise<CommandReturn>,
-      evalResults: (err: Error | undefined, argv: any, output: string) => void
+      evalResults: (err: Error | undefined, argv: any, output: string) => void,
+      checkCurrentConfig: (command: CommandStruct) => Promise<CommandReturn>
     ) => {
       let callIdx = 0;
       sinon
@@ -472,6 +487,8 @@ packages:
         .callsFake(pythonVersion)
         .onCall(callIdx++)
         .callsFake(pythonPath)
+        .onCall(callIdx++)
+        .callsFake(checkCurrentConfig)
         .onCall(callIdx++)
         .callsFake(installAgent)
         .onCall(callIdx++)
@@ -509,6 +526,19 @@ packages:
           .resolves({ result: 'pip', confirm: true });
       });
 
+      const checkCurrentConfig = (cmdStruct: CommandStruct) => {
+        expect(cmdStruct.program).toEqual('pip');
+        const args = cmdStruct.args;
+        expect(args).toEqual([
+          'install',
+          '-r',
+          'requirements.txt',
+          '--dry-run',
+        ]);
+        const ret = { stdout: '', stderr: '' };
+        return Promise.resolve(ret);
+      };
+
       const installAgent = (cmdStruct: CommandStruct) => {
         expect(cmdStruct.program).toEqual('pip');
         expect(cmdStruct.args).toEqual(['install', '-r', 'requirements.txt']);
@@ -530,7 +560,7 @@ packages:
       };
 
       it('installs as expected', async () => {
-        expect.assertions(10);
+        expect.assertions(12);
         const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
@@ -545,7 +575,8 @@ packages:
           pythonPath,
           installAgent,
           initAgent,
-          evalResults
+          evalResults,
+          checkCurrentConfig
         );
       });
     });
@@ -559,6 +590,14 @@ packages:
           .stub(inquirer, 'prompt')
           .resolves({ result: 'poetry', confirm: true });
       });
+
+      const checkCurrentConfig = (cmdStruct: CommandStruct) => {
+        expect(cmdStruct.program).toEqual('poetry');
+        const args = cmdStruct.args;
+        expect(args).toEqual(['install', '--dry-run']);
+        const ret = { stdout: '', stderr: '' };
+        return Promise.resolve(ret);
+      };
 
       const installAgent = (cmdStruct: CommandStruct) => {
         expect(cmdStruct.program).toEqual('poetry');
@@ -586,7 +625,7 @@ packages:
       };
 
       it('installs as expected', async () => {
-        expect.assertions(10);
+        expect.assertions(12);
         const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
@@ -601,7 +640,8 @@ packages:
           pythonPath,
           installAgent,
           initAgent,
-          evalResults
+          evalResults,
+          checkCurrentConfig
         );
       });
     });
@@ -613,13 +653,16 @@ packages:
       installAgent: (command: CommandStruct) => Promise<CommandReturn>,
       initAgent: (command: CommandStruct) => Promise<CommandReturn>,
       validateAgent: (command: CommandStruct) => Promise<CommandReturn>,
-      evalResults: (err: Error | undefined, argv: any, output: string) => void
+      evalResults: (err: Error | undefined, argv: any, output: string) => void,
+      checkCurrentConfig: (command: CommandStruct) => Promise<CommandReturn>
     ) => {
       let callIdx = 0;
       sinon
         .stub(commandRunner, 'run')
         .onCall(callIdx++)
         .callsFake(nodeVersion)
+        .onCall(callIdx++)
+        .callsFake(checkCurrentConfig)
         .onCall(callIdx++)
         .callsFake(installAgent)
         .onCall(callIdx++)
@@ -675,6 +718,14 @@ packages:
           .resolves({ result: 'npm', confirm: true });
       });
 
+      const checkCurrentConfig = (cmdStruct: CommandStruct) => {
+        expect(cmdStruct.program).toEqual('npm');
+        const args = cmdStruct.args;
+        expect(args).toEqual(['install', '--dry-run']);
+        const ret = { stdout: '', stderr: '' };
+        return Promise.resolve(ret);
+      };
+
       const installAgent = (cmdStruct: CommandStruct) => {
         expect(cmdStruct.program).toEqual('npm');
         expect(cmdStruct.args).toEqual([
@@ -687,7 +738,7 @@ packages:
       };
 
       it('installs as expected', async () => {
-        expect.assertions(10);
+        expect.assertions(12);
         const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
@@ -703,12 +754,13 @@ packages:
           installAgent,
           initAgent,
           validateAgent,
-          evalResults
+          evalResults,
+          checkCurrentConfig
         );
       });
 
       it('fails when validation fails', async () => {
-        expect.assertions(7);
+        expect.assertions(9);
         const msg = 'failValidate, validation failed';
         const failValidate = () => Promise.reject(new Error(msg));
         const evalResults = (err, argv, output) => {
@@ -719,7 +771,8 @@ packages:
           installAgent,
           initAgent,
           failValidate,
-          evalResults
+          evalResults,
+          checkCurrentConfig
         );
       });
     });
@@ -733,6 +786,14 @@ packages:
           .resolves({ result: 'yarn', confirm: true });
       });
 
+      const checkCurrentConfig = (cmdStruct: CommandStruct) => {
+        expect(cmdStruct.program).toEqual('yarn');
+        const args = cmdStruct.args;
+        expect(args).toEqual(['install', '--immutable']);
+        const ret = { stdout: '', stderr: '' };
+        return Promise.resolve(ret);
+      };
+
       const installAgent = (cmdStruct: CommandStruct) => {
         expect(cmdStruct.program).toEqual('yarn');
         expect(cmdStruct.args).toEqual([
@@ -745,7 +806,7 @@ packages:
       };
 
       it('installs as expected', async () => {
-        expect.assertions(10);
+        expect.assertions(12);
         const evalResults = (err, argv, output) => {
           expect(err).toBeNull();
 
@@ -761,12 +822,13 @@ packages:
           installAgent,
           initAgent,
           validateAgent,
-          evalResults
+          evalResults,
+          checkCurrentConfig
         );
       });
 
       it('fails when validation fails', async () => {
-        expect.assertions(7);
+        expect.assertions(9);
         const msg = 'failValidate, validation failed';
         const failValidate = () => Promise.reject(new Error(msg));
         const evalResults = (err, argv, output) => {
@@ -777,7 +839,8 @@ packages:
           installAgent,
           initAgent,
           failValidate,
-          evalResults
+          evalResults,
+          checkCurrentConfig
         );
       });
     });
@@ -885,6 +948,7 @@ packages:
         overwriteAppMapYml: 'Use existing',
       });
 
+      sinon.stub(BundleInstaller.prototype, 'checkCurrentConfig').resolves();
       sinon.stub(BundleInstaller.prototype, 'installAgent').resolves();
 
       sinon.stub(AgentInstallerProcedure.prototype, 'configExists').value(true);


### PR DESCRIPTION
Fixes applandinc/board#139

Check dependencies before adding AppMap. The check varies with the package manager:

* `npm install --dry-run`
* `yarn install --immutable`
* `bundle check --dry-run`
* `pip install -r requirements.txt --dry-run`
* `poetry install --dry-run`

Maven and Gradle are less straightforward, so those will be a separate batch.