### PR TITLE
feat: Add elapsedInstrumentationTime, path, threadId, parentId in Event

### DIFF
--- a/packages/models/src/event.js
+++ b/packages/models/src/event.js
@@ -318,6 +318,10 @@ export default class Event {
     this.$hidden.parent = value;
   }
 
+  set id(value) {
+    this.$hidden.id = value;
+  }
+
   set path(value) {
     this.callEvent.$hidden.path = value;
   }
@@ -339,6 +343,10 @@ export default class Event {
 
   isReturn() {
     return this.event === 'return';
+  }
+
+  get id() {
+    return this.$hidden.id;
   }
 
   get threadId() {

--- a/packages/models/src/event.js
+++ b/packages/models/src/event.js
@@ -105,6 +105,10 @@ export default class Event {
     return this.returnEvent.elapsed;
   }
 
+  get elapsedInstrumentationTime() {
+    return this.returnEvent.elapsed_instrumentation;
+  }
+
   get linkedEvent() {
     return this.$hidden.linkedEvent;
   }
@@ -314,6 +318,10 @@ export default class Event {
     this.$hidden.parent = value;
   }
 
+  set path(value) {
+    this.callEvent.$hidden.path = value;
+  }
+
   link(event) {
     /* eslint-disable no-param-reassign */
     if (event.linkedEvent || this.linkedEvent) {
@@ -331,6 +339,18 @@ export default class Event {
 
   isReturn() {
     return this.event === 'return';
+  }
+
+  get threadId() {
+    return this.thread_id;
+  }
+
+  get parentId() {
+    return this.returnEvent.parent_id;
+  }
+
+  get path() {
+    return this.callEvent.$hidden.path;
   }
 
   get callEvent() {


### PR DESCRIPTION
Add fields needed to use the Event type properly when showing functions with highest AppMap overhead in https://github.com/applandinc/appmap-js/pull/721.

I think this change needs to be merged and deployed first so that importing `@appland/models` will provide these fields.

I attempted to add these fields directly in https://github.com/applandinc/appmap-js/pull/721 but importing from a local module with the following didn't work.
```
import buildAppMap from '../../../../models/src/appMapBuilder/index';
```
It gave an error that said to unmark `models` as a module, which is probably not what we want.  I applied this change locally so I can develop in the meantime.
```
--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "module": "dist/index.js",
   "main": "dist/index.cjs",
-  "type": "module",
   "publishConfig": {
     "access": "public"
   },
```

Addresses https://github.com/applandinc/board/issues/140