### PR TITLE
Scan initial files in `scan --watch`

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jest": "^25.3.0",
-    "eslint-plugin-promise": "^5.2.0",
+    "eslint-plugin-promise": "^6.0.1",
     "eslint-plugin-unicorn": "^39.0.0",
     "jest": "^27.4.7",
     "nock": "^13.2.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,6 +56,7 @@
     "@vue/eslint-config-airbnb": "^5.0.2",
     "@vue/test-utils": "^1.0.3",
     "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.3",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.2",
     "chromatic": "^6.4.3",

--- a/packages/scanner/src/cli/scan/watchScan.ts
+++ b/packages/scanner/src/cli/scan/watchScan.ts
@@ -37,7 +37,7 @@ export class Watcher {
     // Chokidar struggles with relative paths. Make sure the watch pattern is absolute.
     const watchPattern = path.resolve(this.options.appmapDir, '**', 'mtime');
     this.appmapWatcher = chokidar.watch(watchPattern, {
-      ignoreInitial: true,
+      ignoreInitial: false,
     });
     this.appmapWatcher
       .on('add', (filePath) => this.scan(filePath))

--- a/packages/scanner/test/cli/scan.spec.ts
+++ b/packages/scanner/test/cli/scan.spec.ts
@@ -244,6 +244,15 @@ describe('scan', () => {
       fsextra.rm(tmpDir, { recursive: true });
     });
 
+    it('scans already indexed AppMaps on start', async () => {
+      await createIndex(secretInLogMap);
+      await createWatcher();
+      const findings = await expectScan(secretInLogMap);
+
+      expect(findings.findings.length).toEqual(1);
+      expect(findings.findings[0].ruleId).toEqual('secret-in-log');
+    });
+
     it('scans AppMaps when the mtime file is created or changed', async () => {
       await createWatcher();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -211,6 +211,7 @@ __metadata:
     "@vue/eslint-config-airbnb": ^5.0.2
     "@vue/test-utils": ^1.0.3
     babel-cli: ^6.26.0
+    babel-core: ^6.26.3
     babel-eslint: ^10.1.0
     babel-loader: ^8.2.2
     chromatic: ^6.4.3
@@ -8469,7 +8470,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-core@npm:^6.26.0":
+"babel-core@npm:^6.26.0, babel-core@npm:^6.26.3":
   version: 6.26.3
   resolution: "babel-core@npm:6.26.3"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -172,7 +172,7 @@ __metadata:
     eslint-plugin-eslint-comments: ^3.2.0
     eslint-plugin-import: ^2.25.3
     eslint-plugin-jest: ^25.3.0
-    eslint-plugin-promise: ^5.2.0
+    eslint-plugin-promise: ^6.0.1
     eslint-plugin-unicorn: ^39.0.0
     jest: ^27.4.7
     js-yaml: ^4.1.0
@@ -13100,12 +13100,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-promise@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "eslint-plugin-promise@npm:5.2.0"
+"eslint-plugin-promise@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "eslint-plugin-promise@npm:6.0.1"
   peerDependencies:
-    eslint: ^7.0.0
-  checksum: 5d6b2d28408c5afde6386942862427af3d83c9a130eb2555bb54b26a1761914e2c7326aca1be26dd3fee6405e65a2ee9432a4526147e5962545060ea0ef64058
+    eslint: ^7.0.0 || ^8.0.0
+  checksum: c1bb3c2e591787e97133dcaf764f908420a3a1959a3132e199db8f14d70dfa79fc9caf991ca60a4b60ae5f1f9823bc96c2e52304828a4278ef2f3964fe121de9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #727 

Note: the pull request contains some unrelated drive-by warning fixes, plus a refactoring. Every change is in a separate commit.

If accepted, the reviewer is welcome to go ahead and do a rebase merge.